### PR TITLE
feat(examples): add parent-sample demonstrating NosskeyIframeClient

### DIFF
--- a/examples/parent-sample/README.md
+++ b/examples/parent-sample/README.md
@@ -1,0 +1,59 @@
+# parent-sample
+
+Minimal Vanilla TS + Vite example of a **parent page** that embeds the Nosskey
+signing iframe via [`nosskey-iframe`](../../packages/nosskey-iframe) and exposes
+a NIP-07 compatible `window.nostr`.
+
+Runs on port **5174** by default so it lives on a different origin than the
+host example (`svelte-app` on port 5173), exercising the cross-origin
+`postMessage` path that production deployments actually use.
+
+## What it demonstrates
+
+1. Mount `NosskeyIframeClient` against a host URL (default
+   `http://localhost:5173/#/iframe`).
+2. Wait for the `nosskey:ready` handshake.
+3. Install a NIP-07 compatible `window.nostr = { getPublicKey, signEvent }`.
+4. Call `getPublicKey()`.
+5. Build a kind:1 event, sign it through the iframe (consent dialog is shown
+   inside the iframe/host page), and publish it via raw WebSocket to a public
+   relay (default `wss://relay.damus.io`).
+6. Surface `NosskeyIframeError.code` values such as `NO_KEY`,
+   `USER_REJECTED`, `NOT_AUTHORIZED` in the log.
+
+## Run locally
+
+From the monorepo root:
+
+```sh
+npm install
+
+# Terminal 1 — host (svelte-app) on http://localhost:5173
+npm run dev -w svelte-app
+# Visit http://localhost:5173/#/settings once to create a passkey and store
+# an encrypted secret key. The iframe route is http://localhost:5173/#/iframe.
+
+# Terminal 2 — parent sample on http://localhost:5174
+npm run dev -w parent-sample
+```
+
+Open <http://localhost:5174/> in Chrome and click **Connect**, then
+**Get public key**, then **Sign & publish**.
+
+## Browser support
+
+- **Chrome 118+** — fully supported (WebAuthn PRF + iframe).
+- **Firefox (latest)** — partial; PRF support is limited.
+- **Safari / iOS** — not supported at this time. See
+  [`docs/iframe-plan.md`](../../docs/iframe-plan.md) for the rationale.
+
+## Notes
+
+- The `allow="publickey-credentials-get; publickey-credentials-create"`
+  attribute required for WebAuthn inside the iframe is added by
+  `NosskeyIframeClient` itself — nothing to wire up on the parent side.
+- The production host must serve a
+  `Permissions-Policy: publickey-credentials-get=*, publickey-credentials-create=*`
+  header. The bundled svelte-app dev server is only used for local testing.
+- The WebSocket publish path is deliberately minimal (no `nostr-tools`): it
+  sends `["EVENT", signedEvent]` and logs the first `OK` / `NOTICE` frame.

--- a/examples/parent-sample/index.html
+++ b/examples/parent-sample/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nosskey iframe parent sample</title>
+    <link rel="stylesheet" href="/src/style.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/parent-sample/package.json
+++ b/examples/parent-sample/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "parent-sample",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "cd ../.. && biome check ./examples/parent-sample/src",
+    "format": "cd ../.. && biome check --write ./examples/parent-sample/src",
+    "format:check": "cd ../.. && biome check ./examples/parent-sample/src"
+  },
+  "dependencies": {
+    "nosskey-iframe": "*",
+    "nosskey-sdk": "*"
+  },
+  "devDependencies": {
+    "typescript": "~5.8.3",
+    "vite": "^6.4.2"
+  }
+}

--- a/examples/parent-sample/src/main.ts
+++ b/examples/parent-sample/src/main.ts
@@ -1,0 +1,271 @@
+import { NosskeyIframeClient, NosskeyIframeError } from 'nosskey-iframe';
+import type { NostrEvent } from 'nosskey-sdk';
+
+interface NostrProvider {
+  getPublicKey(): Promise<string>;
+  signEvent(event: NostrEvent): Promise<NostrEvent>;
+}
+
+declare global {
+  interface Window {
+    nostr?: NostrProvider;
+  }
+}
+
+const DEFAULT_IFRAME_URL = 'http://localhost:5173/#/iframe';
+const DEFAULT_RELAY_URL = 'wss://relay.damus.io';
+const DEFAULT_NOTE = 'Hello from Nosskey iframe parent sample!';
+const PUBLISH_ACK_TIMEOUT_MS = 8000;
+
+const app = document.querySelector<HTMLDivElement>('#app');
+if (!app) {
+  throw new Error('#app element missing from index.html');
+}
+
+app.innerHTML = `
+  <h1>Nosskey iframe parent sample</h1>
+  <p class="subtitle">
+    Mounts the Nosskey signing iframe, exposes a NIP-07 compatible
+    <code>window.nostr</code>, and publishes a signed kind:1 note to a relay.
+  </p>
+
+  <section>
+    <h2>1. Connect to iframe</h2>
+    <label for="iframe-url">Iframe URL</label>
+    <input id="iframe-url" type="url" value="${DEFAULT_IFRAME_URL}" />
+    <div class="row">
+      <button id="connect">Connect</button>
+      <button id="disconnect" class="secondary" disabled>Disconnect</button>
+      <span id="status" class="status">disconnected</span>
+    </div>
+  </section>
+
+  <section>
+    <h2>2. Get public key</h2>
+    <div class="row">
+      <button id="get-pubkey" disabled>Call window.nostr.getPublicKey()</button>
+    </div>
+  </section>
+
+  <section>
+    <h2>3. Sign &amp; publish kind:1 note</h2>
+    <label for="note">Note content</label>
+    <textarea id="note">${DEFAULT_NOTE}</textarea>
+    <label for="relay-url" style="margin-top:12px;">Relay URL</label>
+    <input id="relay-url" type="url" value="${DEFAULT_RELAY_URL}" />
+    <div class="row">
+      <button id="sign-publish" disabled>Sign &amp; publish</button>
+    </div>
+  </section>
+
+  <section>
+    <h2>Log</h2>
+    <pre id="log"></pre>
+  </section>
+`;
+
+function requireEl<T extends Element>(selector: string): T {
+  const el = app.querySelector<T>(selector);
+  if (!el) {
+    throw new Error(`UI element missing: ${selector}`);
+  }
+  return el;
+}
+
+const ui = {
+  iframeUrl: requireEl<HTMLInputElement>('#iframe-url'),
+  relayUrl: requireEl<HTMLInputElement>('#relay-url'),
+  note: requireEl<HTMLTextAreaElement>('#note'),
+  connect: requireEl<HTMLButtonElement>('#connect'),
+  disconnect: requireEl<HTMLButtonElement>('#disconnect'),
+  getPubkey: requireEl<HTMLButtonElement>('#get-pubkey'),
+  signPublish: requireEl<HTMLButtonElement>('#sign-publish'),
+  status: requireEl<HTMLSpanElement>('#status'),
+  log: requireEl<HTMLPreElement>('#log'),
+};
+
+let client: NosskeyIframeClient | null = null;
+
+function log(line: string): void {
+  const ts = new Date().toISOString().slice(11, 23);
+  ui.log.textContent += `[${ts}] ${line}\n`;
+  ui.log.scrollTop = ui.log.scrollHeight;
+}
+
+function setStatus(text: string, variant: '' | 'ok' | 'err' = ''): void {
+  ui.status.textContent = text;
+  ui.status.className = variant ? `status ${variant}` : 'status';
+}
+
+function setConnectedUI(connected: boolean): void {
+  ui.connect.disabled = connected;
+  ui.iframeUrl.disabled = connected;
+  ui.disconnect.disabled = !connected;
+  ui.getPubkey.disabled = !connected;
+  ui.signPublish.disabled = !connected;
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof NosskeyIframeError) {
+    return `NosskeyIframeError[${err.code}]: ${err.message}`;
+  }
+  if (err instanceof Error) {
+    return `${err.name}: ${err.message}`;
+  }
+  return String(err);
+}
+
+async function connect(): Promise<void> {
+  const iframeUrl = ui.iframeUrl.value.trim();
+  if (!iframeUrl) {
+    log('Connect aborted: iframe URL is empty.');
+    return;
+  }
+  setStatus('connecting…');
+  log(`Mounting iframe: ${iframeUrl}`);
+  try {
+    const next = new NosskeyIframeClient({ iframeUrl });
+    client = next;
+    await next.ready();
+    window.nostr = {
+      getPublicKey: () => next.getPublicKey(),
+      signEvent: (event) => next.signEvent(event),
+    };
+    setConnectedUI(true);
+    setStatus('connected', 'ok');
+    log('Received nosskey:ready. window.nostr is now available.');
+  } catch (err) {
+    log(`Connect failed: ${formatError(err)}`);
+    setStatus('connect failed', 'err');
+    client?.destroy();
+    client = null;
+    window.nostr = undefined;
+    setConnectedUI(false);
+  }
+}
+
+function disconnect(): void {
+  if (!client) return;
+  client.destroy();
+  client = null;
+  window.nostr = undefined;
+  setConnectedUI(false);
+  setStatus('disconnected');
+  log('Iframe destroyed; window.nostr removed.');
+}
+
+async function getPubkey(): Promise<void> {
+  if (!window.nostr) return;
+  log('Requesting window.nostr.getPublicKey()…');
+  try {
+    const pubkey = await window.nostr.getPublicKey();
+    log(`pubkey: ${pubkey}`);
+  } catch (err) {
+    log(`getPublicKey failed: ${formatError(err)}`);
+  }
+}
+
+function publishEvent(relayUrl: string, event: NostrEvent): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(relayUrl);
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      log(`Relay ${relayUrl}: no OK/NOTICE within ${PUBLISH_ACK_TIMEOUT_MS}ms, closing.`);
+      ws.close();
+      resolve();
+    }, PUBLISH_ACK_TIMEOUT_MS);
+
+    ws.addEventListener('open', () => {
+      log(`Relay ${relayUrl}: connection open, sending EVENT.`);
+      ws.send(JSON.stringify(['EVENT', event]));
+    });
+
+    ws.addEventListener('message', (msg) => {
+      const data = typeof msg.data === 'string' ? msg.data : '<binary>';
+      log(`Relay ${relayUrl}: ${data}`);
+      if (data === '<binary>') return;
+      try {
+        const parsed: unknown = JSON.parse(data);
+        if (Array.isArray(parsed) && (parsed[0] === 'OK' || parsed[0] === 'NOTICE') && !settled) {
+          settled = true;
+          clearTimeout(timer);
+          ws.close();
+          resolve();
+        }
+      } catch {
+        // Non-JSON payload — ignore and wait for timer.
+      }
+    });
+
+    ws.addEventListener('error', () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new Error(`WebSocket error for ${relayUrl}`));
+    });
+
+    ws.addEventListener('close', () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+async function signAndPublish(): Promise<void> {
+  if (!window.nostr) return;
+  const content = ui.note.value;
+  const relayUrl = ui.relayUrl.value.trim();
+  if (!relayUrl) {
+    log('Sign aborted: relay URL is empty.');
+    return;
+  }
+
+  const draft: NostrEvent = {
+    kind: 1,
+    content,
+    tags: [],
+    created_at: Math.floor(Date.now() / 1000),
+  };
+
+  log('Requesting window.nostr.signEvent() for kind:1 note…');
+  let signed: NostrEvent;
+  try {
+    signed = await window.nostr.signEvent(draft);
+  } catch (err) {
+    log(`signEvent failed: ${formatError(err)}`);
+    return;
+  }
+  log(`Signed event: ${JSON.stringify(signed, null, 2)}`);
+
+  try {
+    await publishEvent(relayUrl, signed);
+  } catch (err) {
+    log(`Publish failed: ${formatError(err)}`);
+  }
+}
+
+ui.connect.addEventListener('click', () => {
+  void connect();
+});
+ui.disconnect.addEventListener('click', disconnect);
+ui.getPubkey.addEventListener('click', () => {
+  void getPubkey();
+});
+ui.signPublish.addEventListener('click', () => {
+  void signAndPublish();
+});
+
+log(
+  'Ready. Open the host app (default http://localhost:5173/#/settings) to create a passkey first.'
+);

--- a/examples/parent-sample/src/style.css
+++ b/examples/parent-sample/src/style.css
@@ -1,0 +1,132 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  line-height: 1.5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 24px;
+  background: #f6f7f9;
+  color: #1b1e24;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #121418;
+    color: #e7e9ee;
+  }
+}
+
+#app {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+h1 {
+  margin: 0 0 8px;
+  font-size: 1.6rem;
+}
+
+.subtitle {
+  margin: 0 0 24px;
+  opacity: 0.75;
+  font-size: 0.95rem;
+}
+
+section {
+  background: rgba(127, 127, 127, 0.08);
+  border: 1px solid rgba(127, 127, 127, 0.2);
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+section h2 {
+  margin: 0 0 12px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+label {
+  display: block;
+  font-size: 0.85rem;
+  margin-bottom: 6px;
+  opacity: 0.8;
+}
+
+input[type="text"],
+input[type="url"],
+textarea {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid rgba(127, 127, 127, 0.35);
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+}
+
+textarea {
+  min-height: 80px;
+  resize: vertical;
+}
+
+.row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 12px;
+}
+
+button {
+  padding: 8px 14px;
+  border: 1px solid rgba(127, 127, 127, 0.35);
+  border-radius: 6px;
+  background: #4c6ef5;
+  color: white;
+  font: inherit;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button.secondary {
+  background: transparent;
+  color: inherit;
+}
+
+#log {
+  margin: 0;
+  padding: 12px;
+  background: #0b0d10;
+  color: #d4d8e0;
+  border-radius: 6px;
+  max-height: 320px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 0.82rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.status {
+  font-size: 0.85rem;
+  opacity: 0.8;
+}
+
+.status.ok {
+  color: #2f9e44;
+}
+
+.status.err {
+  color: #e03131;
+}

--- a/examples/parent-sample/tsconfig.json
+++ b/examples/parent-sample/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "useDefineForClassFields": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/examples/parent-sample/vite.config.ts
+++ b/examples/parent-sample/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    port: 5174,
+    strictPort: true,
+  },
+  preview: {
+    port: 5174,
+    strictPort: true,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,17 @@
         "node": ">=22"
       }
     },
+    "examples/parent-sample": {
+      "version": "0.0.0",
+      "dependencies": {
+        "nosskey-iframe": "*",
+        "nosskey-sdk": "*"
+      },
+      "devDependencies": {
+        "typescript": "~5.8.3",
+        "vite": "^6.4.2"
+      }
+    },
     "examples/svelte-app": {
       "version": "0.0.0",
       "dependencies": {
@@ -2378,6 +2389,10 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-sample": {
+      "resolved": "examples/parent-sample",
+      "link": true
     },
     "node_modules/path-key": {
       "version": "3.1.1",


### PR DESCRIPTION
Vanilla TS + Vite example on port 5174 that mounts the Nosskey signing
iframe (default http://localhost:5173/#/iframe), exposes a NIP-07
compatible window.nostr, and publishes a signed kind:1 note to a public
relay via raw WebSocket. Fills the gap in the E2E verification flow
described in docs/iframe-plan.md where a parent-side example on a
different origin was required.

https://claude.ai/code/session_01JLNCN5yfB2gJ76Ax6nSVVz