### PR TITLE
fix(svelte-app): initialize screen from hash before store subscribe

### DIFF
--- a/examples/svelte-app/src/App.svelte
+++ b/examples/svelte-app/src/App.svelte
@@ -35,13 +35,15 @@ function updateHash(value: string) {
   screen = value;
 }
 
-// 初期化とイベントリスナー設定
+// subscribe の初回同期コールバックで URL ハッシュが上書きされないよう、
+// 購読前にハッシュからストアを初期化しておく。
+if (typeof window !== 'undefined') {
+  initializeFromHash();
+}
+
+// ハッシュ変更のイベントリスナーを設定
 $effect(() => {
   if (typeof window !== 'undefined') {
-    // ページ読み込み時に初期化
-    initializeFromHash();
-
-    // ハッシュの変更を監視
     window.addEventListener('hashchange', handleHashChange);
 
     // コンポーネント破棄時にイベントリスナーを削除


### PR DESCRIPTION
currentScreen defaults to 'account', so the synchronous initial emit from
`currentScreen.subscribe(updateHash)` rewrote `window.location.hash` from
`#/iframe` to `#/account` before `$effect` could read the original hash.
As a result, `IframeHostScreen` never mounted when the iframe was loaded
at `https://nosskey.app/#/iframe`, `nosskey:ready` was never posted, and
the parent stayed stuck on "connecting".

Read the hash synchronously before subscribing so the initial emit matches
the URL.