### PR TITLE
fix(iframe): recover from partitioned localStorage via Storage Access API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# CLAUDE.md
+
+## Pre-commit verification
+
+Run these from the repository root before committing. They mirror the CI
+workflow (`.github/workflows/ci.yml`) — if any of them fails locally, CI
+will too.
+
+```sh
+# 1. Format & lint (matches CI: SDK - Test, Lint, Build)
+npm run format:check
+
+# 2. Build all workspaces (SDK, iframe, sample app)
+npm run build
+
+# 3. SDK + iframe unit tests with coverage (matches CI test:coverage)
+npm run test:coverage
+
+# 4. Sample app type-check (matches CI: Sample App - Check, Build)
+npm run check -w svelte-app
+```
+
+`npm run build` already builds `nosskey-sdk` → `nosskey-iframe` → `svelte-app`
+in dependency order, so the dedicated `Build SDK / Build iframe package` CI
+steps are covered by step 2.
+
+If `format:check` reports issues, run `npm run fix` to auto-format.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,26 +2,9 @@
 
 ## Pre-commit verification
 
-Run these from the repository root before committing. They mirror the CI
-workflow (`.github/workflows/ci.yml`) — if any of them fails locally, CI
-will too.
-
 ```sh
-# 1. Format & lint (matches CI: SDK - Test, Lint, Build)
 npm run format:check
-
-# 2. Build all workspaces (SDK, iframe, sample app)
 npm run build
-
-# 3. SDK + iframe unit tests with coverage (matches CI test:coverage)
 npm run test:coverage
-
-# 4. Sample app type-check (matches CI: Sample App - Check, Build)
 npm run check -w svelte-app
 ```
-
-`npm run build` already builds `nosskey-sdk` → `nosskey-iframe` → `svelte-app`
-in dependency order, so the dedicated `Build SDK / Build iframe package` CI
-steps are covered by step 2.
-
-If `format:check` reports issues, run `npm run fix` to auto-format.

--- a/README.ja.md
+++ b/README.ja.md
@@ -168,6 +168,20 @@ window.nostr = {
 
 参照実装は [`examples/svelte-app`](examples/svelte-app) (ルート `#/iframe`) にあります。ホスト側アーキテクチャの詳細は [docs/ja/iframe-host.ja.md](docs/ja/iframe-host.ja.md) を参照してください。
 
+#### Storage Partitioning への対応
+
+Chrome 115+ や Firefox の Total Cookie Protection では、**サードパーティ iframe の
+`localStorage` が top-level 親オリジンごとに分離 (partition)** されます。
+`nosskey.app` をトップレベルで開いて保存したキー情報は、別ドメインの親ページに
+埋め込まれた iframe からは参照できず、最初の呼び出しで `NO_KEY` が返ります。
+
+参照ホスト (`#/iframe`) はこれをユーザージェスチャで
+`document.requestStorageAccess({ all: true })` を呼ぶことでリカバーします。
+また `nosskey:visibility` postMessage で自身の表示/非表示を親に要求し、
+`NosskeyIframeClient` が自動で iframe の表示を切り替えます。詳細は
+[`docs/iframe-plan.md`](docs/iframe-plan.md#storage-partitioning-%E5%AF%BE%E5%BF%9C)
+を参照してください。独自ホストを実装する場合は同じフローを実装してください。
+
 ## サポート環境
 
 Nosskey SDKはWebAuthnとPRF拡張をサポートするブラウザ環境で動作します。また、パスキーの生成と認証には対応するOS・デバイスの認証器が必要です。主な対応状況は以下の通りです：

--- a/README.md
+++ b/README.md
@@ -168,6 +168,20 @@ server must also return
 
 See [`examples/svelte-app`](examples/svelte-app) (route `#/iframe`) for a reference host implementation. The host architecture is documented in detail at [docs/en/iframe-host.en.md](docs/en/iframe-host.en.md).
 
+#### Storage partitioning
+
+Chrome 115+ and Firefox's Total Cookie Protection **partition third-party
+iframe `localStorage` per top-level origin**. A passkey info record saved at
+`nosskey.app` (first-party) is not visible to the iframe embedded in a
+different parent origin, so the first call returns `NO_KEY`.
+
+The reference host (`#/iframe`) recovers by calling
+`document.requestStorageAccess({ all: true })` on a user gesture and
+auto-toggles the iframe's visibility via a `nosskey:visibility` postMessage
+(handled inside `NosskeyIframeClient`). See
+[`docs/iframe-plan.md`](docs/iframe-plan.md#storage-partitioning-%E5%AF%BE%E5%BF%9C)
+for details. If you build a custom host, implement the same flow.
+
 ## Supported Environments
 
 Nosskey SDK works in browser environments that support WebAuthn and the PRF extension. Passkey generation and authentication also require authenticators from compatible OS/devices. The main compatibility status is as follows:

--- a/docs/iframe-plan.md
+++ b/docs/iframe-plan.md
@@ -315,6 +315,49 @@ examples/svelte-app/src/services/test-rxnostr.ts
 
 ---
 
+## Storage Partitioning 対応
+
+### 問題
+
+Chrome 115+ (および Firefox の総合的保護機能) は、**サードパーティ iframe の `localStorage` を top-level 親オリジンごとに分離 (partition)** する。
+
+- ユーザーが `https://nosskey.app/#/settings` を直接開いて作成したキー情報 (`localStorage['nosskey_pwk']`) はファーストパーティ領域 (パーティション無し) に保存される
+- 別ドメインの親ページ (例: `https://parent.example`) に `https://nosskey.app/#/iframe` を埋め込むと、iframe 内の `localStorage` は **`(parent.example, nosskey.app)` のパーティション領域** を参照する
+- 結果: パーティション領域には鍵情報が無いので `hasKeyInfo()` が false を返し、`getPublicKey` / `signEvent` は `NO_KEY` エラーを返す
+
+**補足**: WebAuthn credential 自体はブラウザの passkey store に保存されパーティションされない。問題は Nosskey が `credentialId / pubkey / salt` を保持する localStorage JSON だけ。
+
+### 解決策: Storage Access API
+
+`IframeHostScreen.svelte` で以下のフローを実装:
+
+1. マウント時に `hasKeyInfo()` が false、かつ `document.hasStorageAccess()` も false ならパーティション状態と判定
+2. `nosskey:visibility { visible: true }` メッセージを `window.parent.postMessage` で通知 → `NosskeyIframeClient` が iframe を自動的に可視化
+3. iframe 内に「ストレージアクセスを許可」ボタンを表示
+4. ボタン押下 (ユーザージェスチャ) で `document.requestStorageAccess({ all: true })` を呼ぶ
+5. 成功時、`hasKeyInfo()` を再実行すると `#currentKeyInfo` は null のままなので localStorage (今度は unpartitioned) から再読込され、鍵が取得される
+6. `nosskey:visibility { visible: false }` で iframe を非表示に戻す
+7. 親はユーザー操作後に `getPublicKey` / `signEvent` をリトライして成功する
+
+### 新プロトコルメッセージ
+
+```ts
+export interface NosskeyVisibility {
+  type: 'nosskey:visibility';
+  visible: boolean;
+}
+```
+
+Host 側 (iframe) が発行、Client 側 (parent) が受信して `iframe.style.display` と `aria-hidden` を切り替える。メッセージ内容は非機密 (bool のみ) なので targetOrigin は `'*'`。
+
+### 非サポート時の挙動
+
+- `document.requestStorageAccess` 未実装 → `'unsupported'` 状態。ユーザーには `nosskey.app` を別タブで開くよう誘導
+- `{ all: true }` 引数を拒否するブラウザ → `TypeError` を捕捉して引数なしにフォールバック
+- ユーザーが拒否 → `'denied'` 状態でリトライボタンを表示
+
+---
+
 ## 検証
 
 ### 単体テスト

--- a/examples/parent-sample/README.md
+++ b/examples/parent-sample/README.md
@@ -47,6 +47,30 @@ Open <http://localhost:5174/> in Chrome and click **Connect**, then
 - **Safari / iOS** — not supported at this time. See
   [`docs/iframe-plan.md`](../../docs/iframe-plan.md) for the rationale.
 
+## First-run: storage partitioning
+
+Modern browsers (Chrome 115+, Firefox) **partition third-party iframe storage
+per top-level origin**. When the parent page lives on a different origin than
+the Nosskey iframe host (e.g. `parent.example` embedding `nosskey.app`), the
+iframe's `localStorage` is isolated from the first-party `nosskey.app` storage
+where the passkey info was saved. The iframe cannot see the key and responds
+with `NO_KEY`.
+
+The host page handles this automatically via the Storage Access API:
+
+1. `getPublicKey()` returns `NO_KEY`.
+2. The iframe detects the partitioned state and requests the parent to show
+   it (a `nosskey:visibility` message handled inside `NosskeyIframeClient`).
+3. The user clicks **Grant storage access** inside the now-visible iframe.
+4. The browser prompts for permission. On approval, the iframe reloads the
+   key from unpartitioned storage and signals the parent to hide itself.
+5. The parent retries `getPublicKey()` / `signEvent()` and they succeed.
+
+If the user denies storage access, or uses a browser without the Storage
+Access API, the fallback is to open the host origin directly
+(`https://nosskey.app/#/settings`) in a separate tab and create a key there;
+the parent iframe will still need storage access to read that key.
+
 ## Notes
 
 - The `allow="publickey-credentials-get; publickey-credentials-create"`

--- a/examples/parent-sample/src/main.ts
+++ b/examples/parent-sample/src/main.ts
@@ -162,6 +162,14 @@ async function getPubkey(): Promise<void> {
     log(`pubkey: ${pubkey}`);
   } catch (err) {
     log(`getPublicKey failed: ${formatError(err)}`);
+    if (err instanceof NosskeyIframeError && err.code === 'NO_KEY') {
+      log(
+        'Hint: browser storage may be partitioned for this cross-origin iframe. ' +
+          'If the iframe became visible above, click "Grant storage access" in it, ' +
+          'then retry Get public key. Otherwise, open the host URL directly in a ' +
+          'tab, create a passkey, and try again.'
+      );
+    }
   }
 }
 

--- a/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
+++ b/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
@@ -7,13 +7,13 @@ import ConsentDialog from '../ConsentDialog.svelte';
 
 type UiState = 'running' | 'partitioned' | 'denied' | 'granted' | 'noKeyExists' | 'unsupported';
 
-interface StorageAccessDocument extends Document {
-  requestStorageAccess?: (options?: { all?: boolean }) => Promise<void>;
-  hasStorageAccess?: () => Promise<boolean>;
-}
+// Newer Storage Access API options (`{ all: true }`) are not in the default
+// lib.dom yet. Define the call signature locally rather than augmenting
+// Document, which would conflict with the existing zero-arg declaration.
+type RequestStorageAccessFn = (options?: { all?: boolean }) => Promise<void>;
 
 let stopHost: (() => void) | null = null;
-let state = $state<UiState>('running');
+let uiState: UiState = $state('running');
 let errorMessage = $state('');
 let working = $state(false);
 
@@ -26,31 +26,31 @@ function postVisibility(visible: boolean): void {
 async function detectInitialState(): Promise<void> {
   const manager = getNosskeyManager();
   if (manager.hasKeyInfo()) {
-    state = 'running';
+    uiState = 'running';
     return;
   }
-  const doc = document as StorageAccessDocument;
-  if (typeof doc.requestStorageAccess !== 'function') {
-    state = 'unsupported';
+  if (typeof document.requestStorageAccess !== 'function') {
+    uiState = 'unsupported';
     postVisibility(true);
     return;
   }
   try {
-    const hasSA = typeof doc.hasStorageAccess === 'function' ? await doc.hasStorageAccess() : false;
+    const hasSA =
+      typeof document.hasStorageAccess === 'function' ? await document.hasStorageAccess() : false;
     if (hasSA) {
-      state = 'noKeyExists';
+      uiState = 'noKeyExists';
       postVisibility(true);
       return;
     }
   } catch {
     // Treat hasStorageAccess failures as "not granted" and proceed to request.
   }
-  state = 'partitioned';
+  uiState = 'partitioned';
   postVisibility(true);
 }
 
-async function callRequestStorageAccess(doc: StorageAccessDocument): Promise<void> {
-  const fn = doc.requestStorageAccess;
+async function callRequestStorageAccess(): Promise<void> {
+  const fn = document.requestStorageAccess as RequestStorageAccessFn | undefined;
   if (typeof fn !== 'function') {
     throw new Error('Storage Access API is not available.');
   }
@@ -69,20 +69,19 @@ async function callRequestStorageAccess(doc: StorageAccessDocument): Promise<voi
 }
 
 async function requestAccess(): Promise<void> {
-  const doc = document as StorageAccessDocument;
   working = true;
   errorMessage = '';
   try {
-    await callRequestStorageAccess(doc);
+    await callRequestStorageAccess();
     const manager = getNosskeyManager();
     if (manager.hasKeyInfo()) {
-      state = 'granted';
+      uiState = 'granted';
       postVisibility(false);
     } else {
-      state = 'noKeyExists';
+      uiState = 'noKeyExists';
     }
   } catch (err) {
-    state = 'denied';
+    uiState = 'denied';
     errorMessage = err instanceof Error ? err.message : String(err);
   } finally {
     working = false;
@@ -102,12 +101,12 @@ onDestroy(() => {
 
 <div class="iframe-host">
   <p class="status">{$i18n.t.iframeHost.running}</p>
-  {#if state === 'partitioned'}
+  {#if uiState === 'partitioned'}
     <p class="warning">{$i18n.t.iframeHost.partitionedWarning}</p>
     <button type="button" onclick={requestAccess} disabled={working}>
       {$i18n.t.iframeHost.grantStorageAccess}
     </button>
-  {:else if state === 'denied'}
+  {:else if uiState === 'denied'}
     <p class="warning">{$i18n.t.iframeHost.storageAccessDenied}</p>
     {#if errorMessage}
       <p class="error-detail">{errorMessage}</p>
@@ -115,11 +114,11 @@ onDestroy(() => {
     <button type="button" onclick={requestAccess} disabled={working}>
       {$i18n.t.iframeHost.retry}
     </button>
-  {:else if state === 'granted'}
+  {:else if uiState === 'granted'}
     <p class="success">{$i18n.t.iframeHost.storageAccessGranted}</p>
-  {:else if state === 'noKeyExists'}
+  {:else if uiState === 'noKeyExists'}
     <p class="warning">{$i18n.t.iframeHost.noKey}</p>
-  {:else if state === 'unsupported'}
+  {:else if uiState === 'unsupported'}
     <p class="warning">{$i18n.t.iframeHost.storageAccessUnsupported}</p>
     <p class="warning">{$i18n.t.iframeHost.noKey}</p>
   {/if}

--- a/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
+++ b/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
@@ -5,12 +5,93 @@ import { startIframeHost } from '../../iframe-mode.js';
 import { getNosskeyManager } from '../../services/nosskey-manager.service.js';
 import ConsentDialog from '../ConsentDialog.svelte';
 
+type UiState = 'running' | 'partitioned' | 'denied' | 'granted' | 'noKeyExists' | 'unsupported';
+
+interface StorageAccessDocument extends Document {
+  requestStorageAccess?: (options?: { all?: boolean }) => Promise<void>;
+  hasStorageAccess?: () => Promise<boolean>;
+}
+
 let stopHost: (() => void) | null = null;
-let hasKey = $state(false);
+let state = $state<UiState>('running');
+let errorMessage = $state('');
+let working = $state(false);
+
+function postVisibility(visible: boolean): void {
+  if (window.parent && window.parent !== window) {
+    window.parent.postMessage({ type: 'nosskey:visibility', visible }, '*');
+  }
+}
+
+async function detectInitialState(): Promise<void> {
+  const manager = getNosskeyManager();
+  if (manager.hasKeyInfo()) {
+    state = 'running';
+    return;
+  }
+  const doc = document as StorageAccessDocument;
+  if (typeof doc.requestStorageAccess !== 'function') {
+    state = 'unsupported';
+    postVisibility(true);
+    return;
+  }
+  try {
+    const hasSA = typeof doc.hasStorageAccess === 'function' ? await doc.hasStorageAccess() : false;
+    if (hasSA) {
+      state = 'noKeyExists';
+      postVisibility(true);
+      return;
+    }
+  } catch {
+    // Treat hasStorageAccess failures as "not granted" and proceed to request.
+  }
+  state = 'partitioned';
+  postVisibility(true);
+}
+
+async function callRequestStorageAccess(doc: StorageAccessDocument): Promise<void> {
+  const fn = doc.requestStorageAccess;
+  if (typeof fn !== 'function') {
+    throw new Error('Storage Access API is not available.');
+  }
+  try {
+    await fn.call(document, { all: true });
+  } catch (err) {
+    // Older implementations reject the `{ all: true }` argument with a
+    // TypeError. Fall back to the zero-arg form which at least grants cookie
+    // access; Firefox's zero-arg form also unpartitions localStorage.
+    if (err instanceof TypeError) {
+      await fn.call(document);
+      return;
+    }
+    throw err;
+  }
+}
+
+async function requestAccess(): Promise<void> {
+  const doc = document as StorageAccessDocument;
+  working = true;
+  errorMessage = '';
+  try {
+    await callRequestStorageAccess(doc);
+    const manager = getNosskeyManager();
+    if (manager.hasKeyInfo()) {
+      state = 'granted';
+      postVisibility(false);
+    } else {
+      state = 'noKeyExists';
+    }
+  } catch (err) {
+    state = 'denied';
+    errorMessage = err instanceof Error ? err.message : String(err);
+  } finally {
+    working = false;
+  }
+}
 
 onMount(() => {
-  hasKey = getNosskeyManager().hasKeyInfo();
   stopHost = startIframeHost();
+  void detectInitialState();
 });
 
 onDestroy(() => {
@@ -21,7 +102,25 @@ onDestroy(() => {
 
 <div class="iframe-host">
   <p class="status">{$i18n.t.iframeHost.running}</p>
-  {#if !hasKey}
+  {#if state === 'partitioned'}
+    <p class="warning">{$i18n.t.iframeHost.partitionedWarning}</p>
+    <button type="button" onclick={requestAccess} disabled={working}>
+      {$i18n.t.iframeHost.grantStorageAccess}
+    </button>
+  {:else if state === 'denied'}
+    <p class="warning">{$i18n.t.iframeHost.storageAccessDenied}</p>
+    {#if errorMessage}
+      <p class="error-detail">{errorMessage}</p>
+    {/if}
+    <button type="button" onclick={requestAccess} disabled={working}>
+      {$i18n.t.iframeHost.retry}
+    </button>
+  {:else if state === 'granted'}
+    <p class="success">{$i18n.t.iframeHost.storageAccessGranted}</p>
+  {:else if state === 'noKeyExists'}
+    <p class="warning">{$i18n.t.iframeHost.noKey}</p>
+  {:else if state === 'unsupported'}
+    <p class="warning">{$i18n.t.iframeHost.storageAccessUnsupported}</p>
     <p class="warning">{$i18n.t.iframeHost.noKey}</p>
   {/if}
 </div>
@@ -43,5 +142,35 @@ onDestroy(() => {
   .warning {
     color: var(--color-warning);
     font-weight: 600;
+    margin: 8px 0;
+  }
+
+  .success {
+    color: var(--color-success);
+    font-weight: 600;
+    margin: 8px 0;
+  }
+
+  .error-detail {
+    color: var(--color-text-secondary);
+    font-size: 0.8rem;
+    margin: 4px 0;
+    word-break: break-word;
+  }
+
+  button {
+    margin-top: 8px;
+    padding: 8px 16px;
+    border: 1px solid var(--color-warning);
+    background-color: transparent;
+    color: var(--color-warning);
+    font-weight: 600;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 </style>

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -174,6 +174,12 @@ export interface TranslationData {
   iframeHost: {
     running: string;
     noKey: string;
+    partitionedWarning: string;
+    grantStorageAccess: string;
+    storageAccessGranted: string;
+    storageAccessDenied: string;
+    storageAccessUnsupported: string;
+    retry: string;
   };
 }
 
@@ -362,6 +368,14 @@ export const ja: TranslationData = {
   iframeHost: {
     running: 'Nosskey iframe が起動中です。親アプリからの署名リクエストを待機します。',
     noKey: '鍵が設定されていません。別タブで設定画面を開き、パスキーでログインしてください。',
+    partitionedWarning:
+      'このサイトは別ドメインから埋め込まれています。鍵にアクセスするには、下のボタンを押してストレージアクセスを許可してください。',
+    grantStorageAccess: 'ストレージアクセスを許可',
+    storageAccessGranted: 'アクセスが許可されました。鍵を読み込みました。',
+    storageAccessDenied:
+      'ストレージアクセスが拒否されました。もう一度試すか、別タブで nosskey.app を開いてください。',
+    storageAccessUnsupported: 'このブラウザは Storage Access API をサポートしていません。',
+    retry: '再試行',
   },
 };
 
@@ -550,6 +564,14 @@ export const en: TranslationData = {
   iframeHost: {
     running: 'Nosskey iframe is running and waiting for signing requests from the parent app.',
     noKey: 'No key configured. Open the settings page in another tab and sign in with a passkey.',
+    partitionedWarning:
+      'This page is embedded from a different domain. Grant storage access with the button below to reach your key.',
+    grantStorageAccess: 'Grant storage access',
+    storageAccessGranted: 'Access granted. Key loaded.',
+    storageAccessDenied:
+      'Storage access was denied. Retry, or open nosskey.app in another tab to create or unlock your key.',
+    storageAccessUnsupported: 'This browser does not support the Storage Access API.',
+    retry: 'Retry',
   },
 };
 

--- a/packages/nosskey-iframe/src/client.spec.ts
+++ b/packages/nosskey-iframe/src/client.spec.ts
@@ -15,6 +15,7 @@ interface FakeIframe {
   parentNode: FakeElement | null;
   setAttribute(name: string, value: string): void;
   getAttribute(name: string): string | null;
+  removeAttribute(name: string): void;
 }
 
 interface FakeElement {
@@ -51,6 +52,9 @@ function createHarness(iframeOrigin = 'https://nosskey.example'): Harness {
       },
       getAttribute(name) {
         return iframe.attributes[name] ?? null;
+      },
+      removeAttribute(name) {
+        delete iframe.attributes[name];
       },
     };
     iframes.push(iframe);
@@ -312,6 +316,44 @@ describe('NosskeyIframeClient', () => {
     // Post-destroy: further messages must not resolve anything.
     harness.dispatchAsIframe({ type: 'nosskey:response', id: 'test-id-1', result: 'late' });
     // No assertion needed — absence of unhandled rejections is the check.
+  });
+
+  it('toggles iframe visibility when a nosskey:visibility message arrives', () => {
+    const client = new NosskeyIframeClient({
+      iframeUrl: 'https://nosskey.example/iframe',
+      window: harness.window,
+      document: harness.document,
+      container: harness.container as unknown as HTMLElement,
+    });
+    const iframe = harness.iframes[0];
+    expect(iframe.style.display).toBe('none');
+    expect(iframe.getAttribute('aria-hidden')).toBe('true');
+
+    harness.dispatchAsIframe({ type: 'nosskey:visibility', visible: true });
+    expect(iframe.style.display).toBe('block');
+    expect(iframe.getAttribute('aria-hidden')).toBeNull();
+
+    harness.dispatchAsIframe({ type: 'nosskey:visibility', visible: false });
+    expect(iframe.style.display).toBe('none');
+    expect(iframe.getAttribute('aria-hidden')).toBe('true');
+
+    client.destroy();
+  });
+
+  it('ignores nosskey:visibility messages from unrelated sources', () => {
+    const client = new NosskeyIframeClient({
+      iframeUrl: 'https://nosskey.example/iframe',
+      window: harness.window,
+      document: harness.document,
+      container: harness.container as unknown as HTMLElement,
+    });
+    const iframe = harness.iframes[0];
+
+    harness.dispatch({ type: 'nosskey:visibility', visible: true }, 'https://nosskey.example', {
+      unrelated: true,
+    });
+    expect(iframe.style.display).toBe('none');
+    client.destroy();
   });
 
   it('request rejects when the iframe has no contentWindow', async () => {

--- a/packages/nosskey-iframe/src/client.ts
+++ b/packages/nosskey-iframe/src/client.ts
@@ -10,6 +10,7 @@ import {
   type NosskeyResponse,
   isNosskeyReady,
   isNosskeyResponse,
+  isNosskeyVisibility,
 } from './protocol.js';
 
 /** WebAuthn permission policy required for the iframe to use passkeys. */
@@ -210,8 +211,21 @@ export class NosskeyIframeClient {
       }
       return;
     }
+    if (isNosskeyVisibility(event.data)) {
+      this.#applyVisibility(event.data.visible);
+      return;
+    }
     if (isNosskeyResponse(event.data)) {
       this.#resolveResponse(event.data);
+    }
+  }
+
+  #applyVisibility(visible: boolean): void {
+    this.#iframe.style.display = visible ? 'block' : 'none';
+    if (visible) {
+      this.#iframe.removeAttribute('aria-hidden');
+    } else {
+      this.#iframe.setAttribute('aria-hidden', 'true');
     }
   }
 

--- a/packages/nosskey-iframe/src/index.ts
+++ b/packages/nosskey-iframe/src/index.ts
@@ -12,6 +12,7 @@ export {
   isNosskeyReady,
   isNosskeyRequest,
   isNosskeyResponse,
+  isNosskeyVisibility,
 } from './protocol.js';
 export type {
   NosskeyErrorCode,
@@ -21,4 +22,5 @@ export type {
   NosskeyRequest,
   NosskeyRequestParams,
   NosskeyResponse,
+  NosskeyVisibility,
 } from './protocol.js';

--- a/packages/nosskey-iframe/src/protocol.spec.ts
+++ b/packages/nosskey-iframe/src/protocol.spec.ts
@@ -5,6 +5,7 @@ import {
   isNosskeyReady,
   isNosskeyRequest,
   isNosskeyResponse,
+  isNosskeyVisibility,
 } from './protocol.js';
 
 describe('protocol: isNosskeyRequest', () => {
@@ -140,6 +141,32 @@ describe('protocol: isNosskeyReady', () => {
 
   it.each([null, undefined, 'nosskey:ready', 42, []])('rejects %s', (value) => {
     expect(isNosskeyReady(value)).toBe(false);
+  });
+});
+
+describe('protocol: isNosskeyVisibility', () => {
+  it('accepts visible=true', () => {
+    expect(isNosskeyVisibility({ type: 'nosskey:visibility', visible: true })).toBe(true);
+  });
+
+  it('accepts visible=false', () => {
+    expect(isNosskeyVisibility({ type: 'nosskey:visibility', visible: false })).toBe(true);
+  });
+
+  it('rejects wrong type tag', () => {
+    expect(isNosskeyVisibility({ type: 'nosskey:ready', visible: true })).toBe(false);
+  });
+
+  it('rejects missing visible flag', () => {
+    expect(isNosskeyVisibility({ type: 'nosskey:visibility' })).toBe(false);
+  });
+
+  it('rejects non-boolean visible flag', () => {
+    expect(isNosskeyVisibility({ type: 'nosskey:visibility', visible: 'yes' })).toBe(false);
+  });
+
+  it.each([null, undefined, 'nosskey:visibility', 0, []])('rejects %s', (value) => {
+    expect(isNosskeyVisibility(value)).toBe(false);
   });
 });
 

--- a/packages/nosskey-iframe/src/protocol.ts
+++ b/packages/nosskey-iframe/src/protocol.ts
@@ -59,8 +59,18 @@ export interface NosskeyReady {
   type: 'nosskey:ready';
 }
 
+/**
+ * Visibility request from iframe → parent, asking the parent to show or hide
+ * the iframe element. Used when the iframe needs a user gesture (e.g. the
+ * Storage Access API prompt for partitioned storage recovery).
+ */
+export interface NosskeyVisibility {
+  type: 'nosskey:visibility';
+  visible: boolean;
+}
+
 /** Any message defined by this protocol. */
-export type NosskeyMessage = NosskeyRequest | NosskeyResponse | NosskeyReady;
+export type NosskeyMessage = NosskeyRequest | NosskeyResponse | NosskeyReady | NosskeyVisibility;
 
 function isPlainObject(x: unknown): x is Record<string, unknown> {
   return typeof x === 'object' && x !== null && !Array.isArray(x);
@@ -103,4 +113,11 @@ export function isNosskeyResponse(value: unknown): value is NosskeyResponse {
 /** Type guard: does the value look like a {@link NosskeyReady}? */
 export function isNosskeyReady(value: unknown): value is NosskeyReady {
   return isPlainObject(value) && value.type === 'nosskey:ready';
+}
+
+/** Type guard: does the value look like a {@link NosskeyVisibility}? */
+export function isNosskeyVisibility(value: unknown): value is NosskeyVisibility {
+  if (!isPlainObject(value)) return false;
+  if (value.type !== 'nosskey:visibility') return false;
+  return typeof value.visible === 'boolean';
 }


### PR DESCRIPTION
Chrome 115+ and Firefox's Total Cookie Protection partition third-party
iframe localStorage per top-level origin, so the passkey info saved at
nosskey.app first-party is invisible to the iframe embedded in a
different parent, causing getPublicKey/signEvent to return NO_KEY on
first call.

The reference host (#/iframe) now detects the partitioned state on
mount and requests parent to show the iframe via a new
nosskey:visibility protocol message. The user clicks "Grant storage
access" in the visible iframe, which calls
document.requestStorageAccess({ all: true }); on success the host
re-reads localStorage and signals the parent to hide itself.

NosskeyIframeClient handles the visibility message automatically,
toggling iframe.style.display and aria-hidden.

https://claude.ai/code/session_01TSFzm3zJ5AEPk6aYbUCRnn