### PR TITLE
feat(iframe): host signing iframe inside a parent-controlled modal

### DIFF
--- a/examples/parent-sample/index.html
+++ b/examples/parent-sample/index.html
@@ -8,6 +8,15 @@
   </head>
   <body>
     <div id="app"></div>
+    <div id="iframe-modal" class="iframe-modal" aria-hidden="true">
+      <div class="iframe-modal__backdrop"></div>
+      <div
+        class="iframe-modal__card"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Nosskey signing"
+      ></div>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/examples/parent-sample/src/main.ts
+++ b/examples/parent-sample/src/main.ts
@@ -22,6 +22,37 @@ if (!app) {
   throw new Error('#app element missing from index.html');
 }
 
+const modal = document.querySelector<HTMLDivElement>('#iframe-modal');
+const modalCard = modal?.querySelector<HTMLDivElement>('.iframe-modal__card') ?? null;
+if (!modal || !modalCard) {
+  throw new Error('#iframe-modal markup missing from index.html');
+}
+
+function setModalVisible(visible: boolean): void {
+  modal?.setAttribute('aria-hidden', visible ? 'false' : 'true');
+}
+
+function withEmbeddedParam(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl, window.location.href);
+    url.searchParams.set('embedded', '1');
+    return url.toString();
+  } catch {
+    return rawUrl;
+  }
+}
+
+window.addEventListener('message', (event) => {
+  const data = event.data as unknown;
+  if (
+    data &&
+    typeof data === 'object' &&
+    (data as { type?: unknown }).type === 'nosskey:visibility'
+  ) {
+    setModalVisible(Boolean((data as { visible?: unknown }).visible));
+  }
+});
+
 app.innerHTML = `
   <h1>Nosskey iframe parent sample</h1>
   <p class="subtitle">
@@ -122,10 +153,12 @@ async function connect(): Promise<void> {
     return;
   }
   setStatus('connecting…');
-  log(`Mounting iframe: ${iframeUrl}`);
+  const embeddedUrl = withEmbeddedParam(iframeUrl);
+  log(`Mounting iframe: ${embeddedUrl}`);
   try {
-    const next = new NosskeyIframeClient({ iframeUrl });
+    const next = new NosskeyIframeClient({ iframeUrl: embeddedUrl });
     client = next;
+    modalCard.appendChild(next.iframe);
     await next.ready();
     window.nostr = {
       getPublicKey: () => next.getPublicKey(),
@@ -141,6 +174,7 @@ async function connect(): Promise<void> {
     client = null;
     window.nostr = undefined;
     setConnectedUI(false);
+    setModalVisible(false);
   }
 }
 
@@ -150,6 +184,7 @@ function disconnect(): void {
   client = null;
   window.nostr = undefined;
   setConnectedUI(false);
+  setModalVisible(false);
   setStatus('disconnected');
   log('Iframe destroyed; window.nostr removed.');
 }

--- a/examples/parent-sample/src/style.css
+++ b/examples/parent-sample/src/style.css
@@ -130,3 +130,47 @@ button.secondary {
 .status.err {
   color: #e03131;
 }
+
+.iframe-modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  z-index: 2000;
+}
+
+.iframe-modal[aria-hidden="false"] {
+  display: block;
+}
+
+.iframe-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+}
+
+.iframe-modal__card {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(560px, 95vw);
+  height: min(640px, 90vh);
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+}
+
+.iframe-modal__card > iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+  background: transparent;
+}
+
+@media (prefers-color-scheme: dark) {
+  .iframe-modal__card {
+    background: #1d2025;
+  }
+}

--- a/examples/svelte-app/src/App.svelte
+++ b/examples/svelte-app/src/App.svelte
@@ -303,4 +303,10 @@ onMount(() => {
       color 0.3s ease,
       background-color 0.3s ease;
   }
+
+  /* Embedded mode: the iframe is mounted inside a parent-provided modal card,
+     so the body must be transparent to blend with the parent card surface. */
+  :global(body.nosskey-embedded) {
+    background: transparent;
+  }
 </style>

--- a/examples/svelte-app/src/components/ConsentDialog.svelte
+++ b/examples/svelte-app/src/components/ConsentDialog.svelte
@@ -134,4 +134,21 @@ function truncate(value: string, limit = CONTENT_PREVIEW_LIMIT): string {
   .consent-actions :global(.btn) {
     width: auto;
   }
+
+  /* Embedded mode: parent modal already provides the backdrop and card frame,
+     so suppress this component's own dim overlay and let the card fill the
+     iframe viewport seamlessly. */
+  :global(body.nosskey-embedded) .consent-backdrop {
+    background: transparent;
+    padding: 0;
+  }
+
+  :global(body.nosskey-embedded) .consent-card {
+    max-width: none;
+    max-height: none;
+    height: 100%;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+  }
 </style>

--- a/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
+++ b/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
 import { i18n } from '../../i18n/i18n-store.js';
-import { startIframeHost } from '../../iframe-mode.js';
+import { isEmbeddedIframeMode, startIframeHost } from '../../iframe-mode.js';
 import { getNosskeyManager } from '../../services/nosskey-manager.service.js';
 import ConsentDialog from '../ConsentDialog.svelte';
 
@@ -108,11 +108,15 @@ async function requestAccess(): Promise<void> {
 }
 
 onMount(() => {
+  if (isEmbeddedIframeMode()) {
+    document.body.classList.add('nosskey-embedded');
+  }
   stopHost = startIframeHost();
   detectInitialState();
 });
 
 onDestroy(() => {
+  document.body.classList.remove('nosskey-embedded');
   stopHost?.();
   stopHost = null;
 });

--- a/examples/svelte-app/src/iframe-mode.ts
+++ b/examples/svelte-app/src/iframe-mode.ts
@@ -29,6 +29,12 @@ export function rejectConsent(): void {
   });
 }
 
+export function isEmbeddedIframeMode(): boolean {
+  if (typeof window === 'undefined') return false;
+  const params = new URLSearchParams(window.location.search);
+  return params.get('embedded') === '1';
+}
+
 export function startIframeHost(overrides: Partial<NosskeyIframeHostOptions> = {}): () => void {
   const host = new NosskeyIframeHost({
     manager: getNosskeyManager(),


### PR DESCRIPTION
Parent sample now mounts the Nosskey iframe inside its own modal
(backdrop + centered card) and toggles the modal on nosskey:visibility,
so the signing UI is presented with consistent framing while the
consent content keeps rendering inside the iframe (trust boundary
preserved). The svelte-app gains an `embedded=1` URL flag that drops
its own backdrop/body background so the two layers don't stack.

https://claude.ai/code/session_01EXDjgKuEUpkh1bZJaS9X3b