### PR TITLE
chore(deps): replace deprecated rx-nostr-crypto with @rx-nostr/crypto

### DIFF
--- a/examples/svelte-app/README.md
+++ b/examples/svelte-app/README.md
@@ -10,7 +10,7 @@ PRF拡張の出力値を直接Nostrのシークレットキーとして使用す
 - **フレームワーク**: Svelte v5
 - **言語**: TypeScript
 - **ビルドツール**: Vite
-- **Nostr関連**: rx-nostr、rx-nostr-crypto
+- **Nostr関連**: rx-nostr、@rx-nostr/crypto
 - **鍵管理**: Nosskey SDK
 
 ## 主な機能

--- a/examples/svelte-app/package-lock.json
+++ b/examples/svelte-app/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "bech32": "^2.0.0",
         "rx-nostr": "^3.6.1",
-        "rx-nostr-crypto": "^3.1.3"
+        "@rx-nostr/crypto": "^3.1.5"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
@@ -1346,16 +1346,17 @@
         "rxjs": "^7.8.0"
       }
     },
-    "node_modules/rx-nostr-crypto": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/rx-nostr-crypto/-/rx-nostr-crypto-3.1.3.tgz",
-      "integrity": "sha512-8WiXCBBMbiFlXs7twmYyPl4+LmwhCI3BeSRtM5jeqvL9BDta/xt825M7iZjih7ChRw9MZWbQZcpFRplM9iIChg==",
+    "node_modules/@rx-nostr/crypto": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@rx-nostr/crypto/-/crypto-3.1.5.tgz",
+      "integrity": "sha512-d0JPOfIaks+JA47S/4gDo+LJ9M4w1/PA5KtPW7WLSdqowNYEv8dtQyUnhb2bP/rS0lkRAGixNg7ibz1RDI/6zg==",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "^1.0.0",
-        "@noble/hashes": "^1.3.0",
-        "@scure/base": "^1.1.1",
-        "nostr-typedef": "^0.9.0"
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "@scure/base": "^2.0.0",
+        "@types/node": "^25.6.0",
+        "nostr-typedef": "^0.13.0"
       },
       "peerDependencies": {
         "rx-nostr": "~3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -821,33 +821,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1209,14 +1182,83 @@
         "win32"
       ]
     },
-    "node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+    "node_modules/@rx-nostr/crypto": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@rx-nostr/crypto/-/crypto-3.1.5.tgz",
+      "integrity": "sha512-d0JPOfIaks+JA47S/4gDo+LJ9M4w1/PA5KtPW7WLSdqowNYEv8dtQyUnhb2bP/rS0lkRAGixNg7ibz1RDI/6zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "@scure/base": "^2.0.0",
+        "@types/node": "^25.6.0",
+        "nostr-typedef": "^0.13.0"
+      },
+      "peerDependencies": {
+        "rx-nostr": "~3"
+      },
+      "peerDependenciesMeta": {
+        "rx-nostr": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rx-nostr/crypto/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@rx-nostr/crypto/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@rx-nostr/crypto/node_modules/@scure/base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
+      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@rx-nostr/crypto/node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@rx-nostr/crypto/node_modules/nostr-typedef": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/nostr-typedef/-/nostr-typedef-0.13.0.tgz",
+      "integrity": "sha512-CwEC8m83FYKip4ED0nkQa+/tJQpJAKwzc7JgPsunuv26ZpwYqNfc+KvEaKCyM/q5IuKzWuSzsLFtXDfTIm2lkQ==",
+      "license": "MIT"
+    },
+    "node_modules/@rx-nostr/crypto/node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
     },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.9",
@@ -2631,27 +2673,6 @@
         "rxjs": "^7.8.0"
       }
     },
-    "node_modules/rx-nostr-crypto": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/rx-nostr-crypto/-/rx-nostr-crypto-3.1.3.tgz",
-      "integrity": "sha512-8WiXCBBMbiFlXs7twmYyPl4+LmwhCI3BeSRtM5jeqvL9BDta/xt825M7iZjih7ChRw9MZWbQZcpFRplM9iIChg==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "^1.0.0",
-        "@noble/hashes": "^1.3.0",
-        "@scure/base": "^1.1.1",
-        "nostr-typedef": "^0.9.0"
-      },
-      "peerDependencies": {
-        "rx-nostr": "~3"
-      },
-      "peerDependenciesMeta": {
-        "rx-nostr": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -4045,8 +4066,8 @@
       "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
-        "rx-nostr": "^3.6.1",
-        "rx-nostr-crypto": "^3.1.3"
+        "@rx-nostr/crypto": "^3.1.5",
+        "rx-nostr": "^3.6.1"
       },
       "engines": {
         "node": ">=22"

--- a/packages/nosskey-sdk/package.json
+++ b/packages/nosskey-sdk/package.json
@@ -42,6 +42,6 @@
   },
   "dependencies": {
     "rx-nostr": "^3.6.1",
-    "rx-nostr-crypto": "^3.1.3"
+    "@rx-nostr/crypto": "^3.1.5"
   }
 }

--- a/packages/nosskey-sdk/src/nosskey.spec.ts
+++ b/packages/nosskey-sdk/src/nosskey.spec.ts
@@ -1,4 +1,4 @@
-import { seckeySigner } from 'rx-nostr-crypto';
+import { seckeySigner } from '@rx-nostr/crypto';
 /**
  * Nosskey SDK テスト
  * @packageDocumentation
@@ -8,8 +8,8 @@ import { NosskeyManager } from './nosskey.js';
 import type { NostrEvent, NostrKeyInfo } from './types.js';
 import { bytesToHex } from './utils.js';
 
-// rx-nostr-crypto のモック
-vi.mock('rx-nostr-crypto', () => {
+// @rx-nostr/crypto のモック
+vi.mock('@rx-nostr/crypto', () => {
   return {
     seckeySigner: vi.fn(() => ({
       signEvent: vi.fn(async (event) => ({

--- a/packages/nosskey-sdk/src/nosskey.ts
+++ b/packages/nosskey-sdk/src/nosskey.ts
@@ -1,4 +1,4 @@
-import { seckeySigner } from 'rx-nostr-crypto';
+import { seckeySigner } from '@rx-nostr/crypto';
 import { KeyCache } from './key-cache.js';
 import { createPasskey, getPrfSecret, isPrfSupported } from './prf-handler.js';
 import type {
@@ -287,7 +287,7 @@ export class NosskeyManager implements NosskeyManagerLike {
     // 秘密鍵HEX文字列を取得
     const skHex = bytesToHex(sk);
 
-    // rx-nostr-cryptoを使用して公開鍵を取得
+    // @rx-nostr/cryptoを使用して公開鍵を取得
     const signer = seckeySigner(skHex);
     const publicKey = await signer.getPublicKey();
 
@@ -344,7 +344,7 @@ export class NosskeyManager implements NosskeyManagerLike {
     // 秘密鍵HEX文字列を取得
     const skHex = bytesToHex(sk);
 
-    // rx-nostr-crypto seckeySigner を使用して署名
+    // @rx-nostr/crypto seckeySigner を使用して署名
     const signer = seckeySigner(skHex, { tags });
     const signedEvent = await signer.signEvent(event);
 


### PR DESCRIPTION
`rx-nostr-crypto` has been deprecated on npm ("Package no longer
supported"). Migrate every reference to the maintained scoped package
`@rx-nostr/crypto` (3.1.5). The `seckeySigner` API is unchanged, so this
is a drop-in rename.