### PR TITLE
feat(iframe): add NIP-07 getRelays() support

### DIFF
--- a/docs/iframe-expansion-plan.md
+++ b/docs/iframe-expansion-plan.md
@@ -19,7 +19,7 @@
 | `signEvent(event)` | ✅ 実装済み（同意ダイアログあり） |
 | `nosskey:visibility` | ✅ 実装済み（Storage Access API 対応） |
 | `nosskey:ready` | ✅ 実装済み |
-| `getRelays()` | ❌ 未実装 |
+| `getRelays()` | ✅ 実装済み（同意不要・iframe アプリで保管） |
 | `nip44.encrypt / decrypt` | ❌ 未実装 |
 | `nip04.encrypt / decrypt` | ❌ 未実装 |
 | オリジン別の許可記憶 | ❌ 未実装 |
@@ -53,7 +53,7 @@
 
 **目的**: 主要 Nostr クライアント（Snort, Iris, Nostrium 等）が要求する全 NIP-07 メソッドを揃える。
 
-### 1-A: `getRelays()` の追加
+### 1-A: `getRelays()` の追加（✅ 実装済み）
 
 **概要**: ユーザーの優先リレーリストを返す。ユーザー同意不要の読み取り専用操作。
 
@@ -62,20 +62,23 @@
 type RelayMap = Record<string, { read: boolean; write: boolean }>;
 ```
 
+**設計方針**: SDK には実装しない。リレー設定は「アプリのユーザー設定」であり SDK の責務外（`docs/todo.md` でも「リレーへのパブリッシュは SDK 責務外」と明記）。`onConsent` と同パターンで `NosskeyIframeHost` に `onGetRelays` コールバックを追加し、iframe を提供するアプリ側（svelte-app）が localStorage で保管する。書き込み（`setRelays`）はプロトコルに載せず、iframe 内アプリの UI が直接 localStorage を編集する（NIP-07 標準にも `setRelays` は無い）。
+
 **変更ファイル:**
 
 | ファイル | 変更内容 |
 |----------|---------|
-| `packages/nosskey-sdk/src/types.ts` | `NosskeyManagerLike` に `getRelays(): Promise<RelayMap>` / `setRelays(relays: RelayMap): void` 追加 |
-| `packages/nosskey-sdk/src/nosskey.ts` | `getRelays()` / `setRelays()` 実装。localStorage に `nosskey_relays` キーで JSON 保存 |
-| `packages/nosskey-iframe/src/protocol.ts` | `NosskeyMethod` に `'getRelays'` 追加 |
-| `packages/nosskey-iframe/src/host.ts` | `#dispatch()` に `getRelays` ケース追加 |
+| `packages/nosskey-iframe/src/protocol.ts` | `NosskeyMethod` に `'getRelays'` 追加、`isSupportedMethod` 更新 |
+| `packages/nosskey-iframe/src/host.ts` | `NosskeyIframeHostOptions` に `onGetRelays` コールバック追加。`#dispatch()` に `getRelays` ケース追加（同意不要、未指定時は `{}` を返す） |
 | `packages/nosskey-iframe/src/client.ts` | `getRelays(): Promise<RelayMap>` 追加 |
-| `examples/svelte-app/src/screens/SettingsScreen.svelte` | リレー設定 UI（追加・削除・read/write フラグ切り替え）を追加 |
+| `examples/svelte-app/src/services/relays-store.ts` | localStorage の load/save ヘルパー（新規） |
+| `examples/svelte-app/src/iframe-mode.ts` | Host 生成時に `onGetRelays: async () => loadRelays()` を渡す |
+| `examples/svelte-app/src/components/settings/RelaySettings.svelte` | リレー設定 UI（追加・削除・read/write フラグ切り替え、新規） |
+| `examples/svelte-app/src/components/screens/SettingsScreen.svelte` | `<RelaySettings />` 挿入 |
+| `examples/svelte-app/src/i18n/translations.ts` | `settings.relays.*` 翻訳追加 |
 
 **テスト追加:**
-- `packages/nosskey-sdk/src/nosskey.spec.ts` — `getRelays` / `setRelays` の正常系・空リスト
-- `packages/nosskey-iframe/src/host.spec.ts` — `getRelays` リクエスト処理
+- `packages/nosskey-iframe/src/host.spec.ts` — `getRelays` リクエストが `onGetRelays` を呼ぶこと、未指定時に `{}` を返すこと
 - `packages/nosskey-iframe/src/client.spec.ts` — `getRelays` レスポンス受信
 
 ---

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -13,7 +13,7 @@
 ### iframe機能拡充（詳細: `docs/iframe-expansion-plan.md`）
 
 #### Phase 1: NIP-07 完全対応
-- [ ] `getRelays()` の追加 — リレー設定の取得・保存 (SDK + iframe + Svelte UI)
+- [x] `getRelays()` の追加 — リレー設定の取得 (iframe `onGetRelays` コールバック + Svelte UI、SDK 非変更方針)
 - [ ] `nip44.encrypt / decrypt` の追加 — NIP-44 暗号化/復号 (SDK + iframe + 同意ダイアログ)
 - [ ] `nip04.encrypt / decrypt` の追加 — NIP-04 暗号化/復号 (SDK + iframe + 同意ダイアログ)
 

--- a/examples/parent-sample/src/main.ts
+++ b/examples/parent-sample/src/main.ts
@@ -4,6 +4,7 @@ import type { NostrEvent } from 'nosskey-sdk';
 interface NostrProvider {
   getPublicKey(): Promise<string>;
   signEvent(event: NostrEvent): Promise<NostrEvent>;
+  getRelays(): Promise<Record<string, { read: boolean; write: boolean }>>;
 }
 
 declare global {
@@ -79,7 +80,15 @@ app.innerHTML = `
   </section>
 
   <section>
-    <h2>3. Sign &amp; publish kind:1 note</h2>
+    <h2>3. Get relays</h2>
+    <div class="row">
+      <button id="get-relays" disabled>Call window.nostr.getRelays()</button>
+    </div>
+    <pre id="relays-output">No relays fetched yet.</pre>
+  </section>
+
+  <section>
+    <h2>4. Sign &amp; publish kind:1 note</h2>
     <label for="note">Note content</label>
     <textarea id="note">${DEFAULT_NOTE}</textarea>
     <label for="relay-url" style="margin-top:12px;">Relay URL</label>
@@ -110,6 +119,8 @@ const ui = {
   connect: requireEl<HTMLButtonElement>('#connect'),
   disconnect: requireEl<HTMLButtonElement>('#disconnect'),
   getPubkey: requireEl<HTMLButtonElement>('#get-pubkey'),
+  getRelays: requireEl<HTMLButtonElement>('#get-relays'),
+  relaysOutput: requireEl<HTMLPreElement>('#relays-output'),
   signPublish: requireEl<HTMLButtonElement>('#sign-publish'),
   status: requireEl<HTMLSpanElement>('#status'),
   log: requireEl<HTMLPreElement>('#log'),
@@ -133,6 +144,7 @@ function setConnectedUI(connected: boolean): void {
   ui.iframeUrl.disabled = connected;
   ui.disconnect.disabled = !connected;
   ui.getPubkey.disabled = !connected;
+  ui.getRelays.disabled = !connected;
   ui.signPublish.disabled = !connected;
 }
 
@@ -163,6 +175,7 @@ async function connect(): Promise<void> {
     window.nostr = {
       getPublicKey: () => next.getPublicKey(),
       signEvent: (event) => next.signEvent(event),
+      getRelays: () => next.getRelays(),
     };
     setConnectedUI(true);
     setStatus('connected', 'ok');
@@ -205,6 +218,22 @@ async function getPubkey(): Promise<void> {
           'tab, create a passkey, and try again.'
       );
     }
+  }
+}
+
+async function getRelays(): Promise<void> {
+  if (!window.nostr) return;
+  log('Requesting window.nostr.getRelays()…');
+  try {
+    const relays = await window.nostr.getRelays();
+    const count = Object.keys(relays).length;
+    const formatted = count === 0 ? '{}' : JSON.stringify(relays, null, 2);
+    ui.relaysOutput.textContent = formatted;
+    log(`getRelays: ${count} relay(s) returned`);
+  } catch (err) {
+    const message = formatError(err);
+    log(`getRelays failed: ${message}`);
+    ui.relaysOutput.textContent = `Error: ${message}`;
   }
 }
 
@@ -304,6 +333,9 @@ ui.connect.addEventListener('click', () => {
 ui.disconnect.addEventListener('click', disconnect);
 ui.getPubkey.addEventListener('click', () => {
   void getPubkey();
+});
+ui.getRelays.addEventListener('click', () => {
+  void getRelays();
 });
 ui.signPublish.addEventListener('click', () => {
   void signAndPublish();

--- a/examples/parent-sample/src/style.css
+++ b/examples/parent-sample/src/style.css
@@ -104,7 +104,8 @@ button.secondary {
   color: inherit;
 }
 
-#log {
+#log,
+#relays-output {
   margin: 0;
   padding: 12px;
   background: #0b0d10;
@@ -116,6 +117,10 @@ button.secondary {
   word-break: break-word;
   font-size: 0.82rem;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+#relays-output {
+  margin-top: 12px;
 }
 
 .status {

--- a/examples/svelte-app/src/components/screens/SettingsScreen.svelte
+++ b/examples/svelte-app/src/components/screens/SettingsScreen.svelte
@@ -3,6 +3,7 @@ import { i18n } from '../../i18n/i18n-store.js';
 import AppInfo from '../settings/AppInfo.svelte';
 import LanguageSettings from '../settings/LanguageSettings.svelte';
 import LocalStorageSection from '../settings/LocalStorageSection.svelte';
+import RelaySettings from '../settings/RelaySettings.svelte';
 import ThemeSettings from '../settings/theme-settings.svelte';
 </script>
 
@@ -11,6 +12,7 @@ import ThemeSettings from '../settings/theme-settings.svelte';
 
   <LanguageSettings />
   <ThemeSettings />
+  <RelaySettings />
   <AppInfo />
 </div>
 

--- a/examples/svelte-app/src/components/settings/RelaySettings.svelte
+++ b/examples/svelte-app/src/components/settings/RelaySettings.svelte
@@ -1,0 +1,192 @@
+<script lang="ts">
+import type { RelayMap } from 'nosskey-iframe';
+import { i18n } from '../../i18n/i18n-store.js';
+import { loadRelays, saveRelays } from '../../services/relays-store.js';
+import CardSection from '../ui/CardSection.svelte';
+import Button from '../ui/button/Button.svelte';
+
+let relays = $state<RelayMap>(loadRelays());
+let newRelayUrl = $state('');
+let errorMessage = $state('');
+
+function persist() {
+  saveRelays(relays);
+}
+
+function isValidRelayUrl(url: string): boolean {
+  return /^wss?:\/\/.+/i.test(url.trim());
+}
+
+function addRelay() {
+  const url = newRelayUrl.trim();
+  if (!isValidRelayUrl(url)) {
+    errorMessage = $i18n.t.settings.relays.invalidUrl;
+    return;
+  }
+  if (relays[url]) {
+    errorMessage = '';
+    newRelayUrl = '';
+    return;
+  }
+  relays = { ...relays, [url]: { read: true, write: true } };
+  newRelayUrl = '';
+  errorMessage = '';
+  persist();
+}
+
+function removeRelay(url: string) {
+  const next = { ...relays };
+  delete next[url];
+  relays = next;
+  persist();
+}
+
+function toggleRead(url: string) {
+  const entry = relays[url];
+  if (!entry) return;
+  relays = { ...relays, [url]: { ...entry, read: !entry.read } };
+  persist();
+}
+
+function toggleWrite(url: string) {
+  const entry = relays[url];
+  if (!entry) return;
+  relays = { ...relays, [url]: { ...entry, write: !entry.write } };
+  persist();
+}
+
+function relayEntries(map: RelayMap): Array<[string, { read: boolean; write: boolean }]> {
+  return Object.entries(map);
+}
+</script>
+
+<CardSection title={$i18n.t.settings.relays.title}>
+  <p class="description">{$i18n.t.settings.relays.description}</p>
+
+  {#if relayEntries(relays).length === 0}
+    <p class="empty">{$i18n.t.settings.relays.empty}</p>
+  {:else}
+    <ul class="relay-list">
+      {#each relayEntries(relays) as [url, flags] (url)}
+        <li class="relay-item">
+          <div class="relay-url" title={url}>{url}</div>
+          <label class="flag">
+            <input
+              type="checkbox"
+              checked={flags.read}
+              onchange={() => toggleRead(url)}
+            />
+            {$i18n.t.settings.relays.readLabel}
+          </label>
+          <label class="flag">
+            <input
+              type="checkbox"
+              checked={flags.write}
+              onchange={() => toggleWrite(url)}
+            />
+            {$i18n.t.settings.relays.writeLabel}
+          </label>
+          <Button
+            variant="danger"
+            size="small"
+            onclick={() => removeRelay(url)}
+          >
+            {$i18n.t.settings.relays.removeButton}
+          </Button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+
+  <div class="add-row">
+    <input
+      type="url"
+      class="add-input"
+      placeholder={$i18n.t.settings.relays.addPlaceholder}
+      bind:value={newRelayUrl}
+    />
+    <Button variant="primary" onclick={addRelay}>
+      {$i18n.t.settings.relays.addButton}
+    </Button>
+  </div>
+
+  {#if errorMessage}
+    <div class="error-message">{errorMessage}</div>
+  {/if}
+</CardSection>
+
+<style>
+  .description {
+    margin-bottom: 15px;
+    color: var(--color-text-secondary);
+    transition: color 0.3s ease;
+  }
+
+  .empty {
+    margin: 10px 0;
+    color: var(--color-text-secondary);
+    font-style: italic;
+  }
+
+  .relay-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 15px 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .relay-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 12px;
+    background-color: var(--color-tertiary);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    flex-wrap: wrap;
+  }
+
+  .relay-url {
+    flex: 1 1 240px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: monospace;
+    color: var(--color-text);
+  }
+
+  .flag {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--color-text-secondary);
+  }
+
+  .add-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    margin-top: 10px;
+  }
+
+  .add-input {
+    flex: 1;
+    padding: 8px 12px;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background-color: var(--color-card);
+    color: var(--color-text);
+    font-family: monospace;
+  }
+
+  .error-message {
+    margin-top: 10px;
+    padding: 8px 12px;
+    background-color: var(--color-danger-bg, #fee);
+    border: 1px solid var(--color-danger-border, #f88);
+    border-radius: 8px;
+    color: var(--color-danger, #c00);
+  }
+</style>

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -155,6 +155,17 @@ export interface TranslationData {
       auto: string;
       changed: string;
     };
+    relays: {
+      title: string;
+      description: string;
+      addPlaceholder: string;
+      addButton: string;
+      readLabel: string;
+      writeLabel: string;
+      removeButton: string;
+      invalidUrl: string;
+      empty: string;
+    };
   };
   navigation: {
     account: string;
@@ -332,6 +343,18 @@ export const ja: TranslationData = {
       dark: 'ダークモード',
       auto: 'システム設定に従う',
       changed: 'テーマを変更しました',
+    },
+    relays: {
+      title: 'リレー設定',
+      description:
+        '親アプリから getRelays() で参照されるリレー一覧です。Nosskey 自身はリレーへ送信しません。',
+      addPlaceholder: 'wss://relay.example',
+      addButton: '追加',
+      readLabel: '読み取り',
+      writeLabel: '書き込み',
+      removeButton: '削除',
+      invalidUrl: 'wss:// または ws:// で始まる URL を入力してください。',
+      empty: 'リレーが登録されていません。',
     },
     exportKeyInfo: {
       title: '鍵情報のエクスポート',
@@ -528,6 +551,18 @@ export const en: TranslationData = {
       dark: 'Dark Mode',
       auto: 'Follow System Setting',
       changed: 'Theme changed',
+    },
+    relays: {
+      title: 'Relay Settings',
+      description:
+        'Relays returned to parent apps via getRelays(). Nosskey itself does not publish to relays.',
+      addPlaceholder: 'wss://relay.example',
+      addButton: 'Add',
+      readLabel: 'Read',
+      writeLabel: 'Write',
+      removeButton: 'Remove',
+      invalidUrl: 'Please enter a URL starting with wss:// or ws://.',
+      empty: 'No relays configured.',
     },
     exportKeyInfo: {
       title: 'Export KeyInfo',

--- a/examples/svelte-app/src/iframe-mode.ts
+++ b/examples/svelte-app/src/iframe-mode.ts
@@ -2,6 +2,7 @@ import type { ConsentRequest, NosskeyIframeHostOptions } from 'nosskey-iframe';
 import { NosskeyIframeHost } from 'nosskey-iframe';
 import { writable } from 'svelte/store';
 import { getNosskeyManager } from './services/nosskey-manager.service.js';
+import { loadRelays } from './services/relays-store.js';
 
 export interface PendingConsent extends ConsentRequest {
   resolve: (approved: boolean) => void;
@@ -41,6 +42,7 @@ export function startIframeHost(overrides: Partial<NosskeyIframeHostOptions> = {
     allowedOrigins: '*',
     requireUserConsent: true,
     onConsent,
+    onGetRelays: async () => loadRelays(),
     ...overrides,
   });
   host.start();

--- a/examples/svelte-app/src/services/relays-store.ts
+++ b/examples/svelte-app/src/services/relays-store.ts
@@ -1,0 +1,30 @@
+import type { RelayMap } from 'nosskey-iframe';
+
+/** localStorage key used to persist relay configuration. */
+export const RELAYS_STORAGE_KEY = 'nosskey_relays';
+
+function getStorage(): Storage | null {
+  return typeof localStorage !== 'undefined' ? localStorage : null;
+}
+
+/** Load the persisted relay map. Returns `{}` when missing or malformed. */
+export function loadRelays(): RelayMap {
+  const storage = getStorage();
+  if (!storage) return {};
+  const raw = storage.getItem(RELAYS_STORAGE_KEY);
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return parsed as RelayMap;
+  } catch {
+    return {};
+  }
+}
+
+/** Persist the relay map. */
+export function saveRelays(relays: RelayMap): void {
+  const storage = getStorage();
+  if (!storage) return;
+  storage.setItem(RELAYS_STORAGE_KEY, JSON.stringify(relays));
+}

--- a/packages/nosskey-iframe/src/client.spec.ts
+++ b/packages/nosskey-iframe/src/client.spec.ts
@@ -188,6 +188,37 @@ describe('NosskeyIframeClient', () => {
     client.destroy();
   });
 
+  it('getRelays() posts a request and resolves with the relay map', async () => {
+    const client = new NosskeyIframeClient({
+      iframeUrl: 'https://nosskey.example/iframe',
+      window: harness.window,
+      document: harness.document,
+      container: harness.container as unknown as HTMLElement,
+    });
+    const iframe = harness.iframes[0];
+    const relays = {
+      'wss://relay.example': { read: true, write: true },
+      'wss://relay.read.example': { read: true, write: false },
+    };
+
+    const pending = client.getRelays();
+    expect(iframe.contentWindow.postMessage).toHaveBeenCalledOnce();
+    const [request, targetOrigin] = iframe.contentWindow.postMessage.mock.calls[0];
+    expect(targetOrigin).toBe('https://nosskey.example');
+    expect(request).toMatchObject({
+      type: 'nosskey:request',
+      method: 'getRelays',
+    });
+
+    harness.dispatchAsIframe({
+      type: 'nosskey:response',
+      id: (request as { id: string }).id,
+      result: relays,
+    });
+    await expect(pending).resolves.toEqual(relays);
+    client.destroy();
+  });
+
   it('signEvent() posts the event and resolves with the signed event', async () => {
     const client = new NosskeyIframeClient({
       iframeUrl: 'https://nosskey.example/iframe',

--- a/packages/nosskey-iframe/src/client.ts
+++ b/packages/nosskey-iframe/src/client.ts
@@ -8,6 +8,7 @@ import type { NostrEvent } from 'nosskey-sdk';
 import {
   type NosskeyRequest,
   type NosskeyResponse,
+  type RelayMap,
   isNosskeyReady,
   isNosskeyResponse,
   isNosskeyVisibility,
@@ -136,6 +137,15 @@ export class NosskeyIframeClient {
       throw new Error('getPublicKey: expected string result from iframe.');
     }
     return result;
+  }
+
+  /** Send a `getRelays` request and await the relay map. */
+  async getRelays(): Promise<RelayMap> {
+    const result = await this.#request({ method: 'getRelays' });
+    if (!result || typeof result !== 'object') {
+      throw new Error('getRelays: expected object result from iframe.');
+    }
+    return result as RelayMap;
   }
 
   /** Send a `signEvent` request and await the signed event. */

--- a/packages/nosskey-iframe/src/host.spec.ts
+++ b/packages/nosskey-iframe/src/host.spec.ts
@@ -157,6 +157,54 @@ describe('NosskeyIframeHost', () => {
     host.stop();
   });
 
+  it('routes getRelays via the onGetRelays callback', async () => {
+    const win = createFakeWindow() as DispatchableWindow;
+    const relays = {
+      'wss://relay.example': { read: true, write: true },
+      'wss://relay.read.example': { read: true, write: false },
+    };
+    const onGetRelays = vi.fn(async () => relays);
+    const host = new NosskeyIframeHost({
+      manager: makeManager(),
+      allowedOrigins: ['https://parent.example'],
+      onGetRelays,
+      window: win as unknown as Window,
+    });
+    host.start();
+
+    await win.dispatchMessage(
+      { type: 'nosskey:request', id: 'rg1', method: 'getRelays' },
+      'https://parent.example'
+    );
+
+    expect(onGetRelays).toHaveBeenCalledOnce();
+    expect(win.sent).toHaveLength(1);
+    const msg = win.sent[0];
+    expect(isNosskeyResponse(msg.data)).toBe(true);
+    expect((msg.data as { result: unknown }).result).toEqual(relays);
+    expect(msg.targetOrigin).toBe('https://parent.example');
+    host.stop();
+  });
+
+  it('returns an empty map for getRelays when onGetRelays is not provided', async () => {
+    const win = createFakeWindow() as DispatchableWindow;
+    const host = new NosskeyIframeHost({
+      manager: makeManager(),
+      allowedOrigins: ['https://parent.example'],
+      window: win as unknown as Window,
+    });
+    host.start();
+
+    await win.dispatchMessage(
+      { type: 'nosskey:request', id: 'rg2', method: 'getRelays' },
+      'https://parent.example'
+    );
+
+    expect(win.sent).toHaveLength(1);
+    expect((win.sent[0].data as { result: unknown }).result).toEqual({});
+    host.stop();
+  });
+
   it('routes signEvent after onConsent resolves true', async () => {
     const win = createFakeWindow() as DispatchableWindow;
     const input: NostrEvent = { kind: 1, content: 'hi' };

--- a/packages/nosskey-iframe/src/host.ts
+++ b/packages/nosskey-iframe/src/host.ts
@@ -12,6 +12,7 @@ import {
   type NosskeyRequest,
   type NosskeyResponse,
   type NosskeyVisibility,
+  type RelayMap,
   isNosskeyRequest,
 } from './protocol.js';
 
@@ -39,6 +40,11 @@ export interface NosskeyIframeHostOptions {
   requireUserConsent?: boolean;
   /** Called to obtain user consent. Required when `requireUserConsent` is true. */
   onConsent?: (request: ConsentRequest) => Promise<boolean>;
+  /**
+   * Resolves the relay map returned by NIP-07 `getRelays()`. Read-only and
+   * never prompts the user. Omit to return an empty map.
+   */
+  onGetRelays?: () => Promise<RelayMap>;
   /** Override the window used to install the message listener. Defaults to globalThis.window. */
   window?: Window;
 }
@@ -48,6 +54,7 @@ interface ResolvedOptions {
   allowedOrigins: string[] | '*';
   requireUserConsent: boolean;
   onConsent?: (request: ConsentRequest) => Promise<boolean>;
+  onGetRelays?: () => Promise<RelayMap>;
   window: Window;
 }
 
@@ -61,6 +68,7 @@ function resolveOptions(options: NosskeyIframeHostOptions): ResolvedOptions {
     allowedOrigins: options.allowedOrigins ?? '*',
     requireUserConsent: options.requireUserConsent ?? true,
     onConsent: options.onConsent,
+    onGetRelays: options.onGetRelays,
     window: win,
   };
 }
@@ -167,6 +175,11 @@ export class NosskeyIframeHost {
           throw new HostError('NO_KEY', 'No key is configured in the iframe.');
         }
         return manager.getPublicKey();
+      }
+      case 'getRelays': {
+        const { onGetRelays } = this.#options;
+        if (!onGetRelays) return {} satisfies RelayMap;
+        return onGetRelays();
       }
       case 'signEvent': {
         const event = request.params?.event;

--- a/packages/nosskey-iframe/src/index.ts
+++ b/packages/nosskey-iframe/src/index.ts
@@ -23,4 +23,5 @@ export type {
   NosskeyRequestParams,
   NosskeyResponse,
   NosskeyVisibility,
+  RelayMap,
 } from './protocol.js';

--- a/packages/nosskey-iframe/src/protocol.ts
+++ b/packages/nosskey-iframe/src/protocol.ts
@@ -9,7 +9,12 @@
 import type { NostrEvent } from 'nosskey-sdk';
 
 /** Supported NIP-07 methods the iframe provider can execute. */
-export type NosskeyMethod = 'getPublicKey' | 'signEvent';
+export type NosskeyMethod = 'getPublicKey' | 'signEvent' | 'getRelays';
+
+/**
+ * NIP-07 `getRelays()` return shape: a map of relay URL to read/write flags.
+ */
+export type RelayMap = Record<string, { read: boolean; write: boolean }>;
 
 /** Error codes returned in a {@link NosskeyResponse}. */
 export type NosskeyErrorCode =
@@ -77,7 +82,7 @@ function isPlainObject(x: unknown): x is Record<string, unknown> {
 }
 
 function isSupportedMethod(x: unknown): x is NosskeyMethod {
-  return x === 'getPublicKey' || x === 'signEvent';
+  return x === 'getPublicKey' || x === 'signEvent' || x === 'getRelays';
 }
 
 function isErrorCode(x: unknown): x is NosskeyErrorCode {


### PR DESCRIPTION
Adds the `getRelays()` NIP-07 method to the nosskey-iframe bridge so
parent apps can fetch the user's preferred relay list. The relay map is
sourced from the iframe-providing app via a new `onGetRelays` callback
on `NosskeyIframeHost` (mirroring the existing `onConsent` pattern), so
the SDK stays focused on key management. The Svelte example app
persists relays to `localStorage` and exposes an editor on the settings
screen.

https://claude.ai/code/session_01Kohe4bL6Mc2pjjwbfJrArc