### PR TITLE
fix(svelte-app): read relays through SDK storage handle in iframe mode

### DIFF
--- a/examples/svelte-app/src/iframe-mode.ts
+++ b/examples/svelte-app/src/iframe-mode.ts
@@ -37,12 +37,16 @@ export function isEmbeddedIframeMode(): boolean {
 }
 
 export function startIframeHost(overrides: Partial<NosskeyIframeHostOptions> = {}): () => void {
+  const manager = getNosskeyManager();
   const host = new NosskeyIframeHost({
-    manager: getNosskeyManager(),
+    manager,
     allowedOrigins: '*',
     requireUserConsent: true,
     onConsent,
-    onGetRelays: async () => loadRelays(),
+    // Read through the SDK's storage handle so we hit first-party storage
+    // when the user has granted access (Chromium keeps window.localStorage
+    // partitioned even after the grant — only the handle points at it).
+    onGetRelays: async () => loadRelays(manager.getStorageOptions().storage),
     ...overrides,
   });
   host.start();

--- a/examples/svelte-app/src/services/relays-store.ts
+++ b/examples/svelte-app/src/services/relays-store.ts
@@ -3,15 +3,23 @@ import type { RelayMap } from 'nosskey-iframe';
 /** localStorage key used to persist relay configuration. */
 export const RELAYS_STORAGE_KEY = 'nosskey_relays';
 
-function getStorage(): Storage | null {
+function resolveStorage(override?: Storage | null): Storage | null {
+  if (override) return override;
   return typeof localStorage !== 'undefined' ? localStorage : null;
 }
 
-/** Load the persisted relay map. Returns `{}` when missing or malformed. */
-export function loadRelays(): RelayMap {
-  const storage = getStorage();
-  if (!storage) return {};
-  const raw = storage.getItem(RELAYS_STORAGE_KEY);
+/**
+ * Load the persisted relay map. Returns `{}` when missing or malformed.
+ *
+ * Pass `storage` to read from a specific Storage handle — needed when running
+ * inside a partitioned iframe where the SDK was given a Storage Access API
+ * handle pointing at first-party storage (Chromium keeps `window.localStorage`
+ * partitioned even after the grant).
+ */
+export function loadRelays(storage?: Storage | null): RelayMap {
+  const target = resolveStorage(storage);
+  if (!target) return {};
+  const raw = target.getItem(RELAYS_STORAGE_KEY);
   if (!raw) return {};
   try {
     const parsed = JSON.parse(raw);
@@ -22,9 +30,9 @@ export function loadRelays(): RelayMap {
   }
 }
 
-/** Persist the relay map. */
-export function saveRelays(relays: RelayMap): void {
-  const storage = getStorage();
-  if (!storage) return;
-  storage.setItem(RELAYS_STORAGE_KEY, JSON.stringify(relays));
+/** Persist the relay map. See {@link loadRelays} for the `storage` parameter. */
+export function saveRelays(relays: RelayMap, storage?: Storage | null): void {
+  const target = resolveStorage(storage);
+  if (!target) return;
+  target.setItem(RELAYS_STORAGE_KEY, JSON.stringify(relays));
 }


### PR DESCRIPTION
## Summary

- `getRelays()` を cross-origin の親ページから呼ぶと常に `{}` が返る不具合を修正
- 原因: Chromium は `requestStorageAccess({ all: true })` 後も `window.localStorage` をパーティション化されたまま保持し、`StorageAccessHandle.localStorage` だけが第一者ストレージを指す。SDK の keyinfo は `manager.setStorageOptions({ storage: handle.localStorage })` で正しいハンドルを使えていたが、`loadRelays()` は `window.localStorage` を直接読んでいたため、空のパーティション側を見て `{}` を返していた
- `loadRelays`/`saveRelays` に optional な `Storage` 引数を追加し、`iframe-mode.ts` の `onGetRelays` で `manager.getStorageOptions().storage` を渡すように変更（マネージャと同じハンドルを共有）

## Test plan

- [x] `npm run format:check` 緑
- [x] `npm run build` 緑
- [x] `npm run check -w svelte-app` 緑（svelte-check 0 errors / 0 warnings）
- [x] 手動 E2E: `examples/svelte-app` (`#/settings`) でリレーを 1〜2 件追加 → `examples/parent-sample` から Connect → Grant storage access → `Get relays` を押下し、設定済みリレーが結果パネルに JSON で表示されることを確認

https://claude.ai/code/session_01Kohe4bL6Mc2pjjwbfJrArc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kohe4bL6Mc2pjjwbfJrArc)_