### PR TITLE
feat(svelte-app): add consent gating and clearer dialog (Phase 2 + 6-A)

### DIFF
--- a/examples/svelte-app/src/components/ConsentDialog.svelte
+++ b/examples/svelte-app/src/components/ConsentDialog.svelte
@@ -3,11 +3,14 @@ import { type NosskeyMethod, isDecryptMethod, isEncryptMethod } from 'nosskey-if
 import { i18n } from '../i18n/i18n-store.js';
 import { approveConsent, pendingConsent, rejectConsent } from '../iframe-mode.js';
 import { hexToNpub } from '../utils/bech32-converter.js';
+import { kindLabel } from '../utils/event-kind-labels.js';
 import Button from './ui/button/Button.svelte';
 
-const CONTENT_PREVIEW_LIMIT = 240;
-const NPUB_HEAD = 12;
+const CONTENT_PREVIEW_LIMIT = 100;
+const NPUB_HEAD = 8;
 const NPUB_TAIL = 8;
+
+let trustOrigin = $state(false);
 
 function truncate(value: string, limit = CONTENT_PREVIEW_LIMIT): string {
   if (value.length <= limit) return value;
@@ -52,6 +55,16 @@ function dialogTitle(method: NosskeyMethod, t: typeof $i18n.t.consent): string {
   if (isDecryptMethod(method)) return t.titleDecrypt;
   return t.titleEncrypt;
 }
+
+function handleApprove() {
+  approveConsent({ trustOrigin });
+  trustOrigin = false;
+}
+
+function handleReject() {
+  rejectConsent();
+  trustOrigin = false;
+}
 </script>
 
 {#if $pendingConsent}
@@ -72,7 +85,10 @@ function dialogTitle(method: NosskeyMethod, t: typeof $i18n.t.consent): string {
 
         {#if c.event}
           <dt>{$i18n.t.consent.eventKind}</dt>
-          <dd>{c.event.kind}</dd>
+          <dd>
+            {kindLabel(c.event.kind, $i18n.t.consent.kindLabel)}
+            <span class="muted">(kind:{c.event.kind})</span>
+          </dd>
           <dt>{$i18n.t.consent.eventContent}</dt>
           <dd><pre>{truncate(c.event.content ?? '')}</pre></dd>
           <dt>{$i18n.t.consent.eventTags}</dt>
@@ -107,11 +123,23 @@ function dialogTitle(method: NosskeyMethod, t: typeof $i18n.t.consent): string {
         {/if}
       </dl>
 
+      {#if c.event}
+        <details class="consent-raw">
+          <summary>{$i18n.t.consent.showRaw}</summary>
+          <pre>{JSON.stringify(c.event, null, 2)}</pre>
+        </details>
+      {/if}
+
+      <label class="consent-trust">
+        <input type="checkbox" bind:checked={trustOrigin} />
+        <span>{$i18n.t.consent.alwaysAllowSite}</span>
+      </label>
+
       <div class="consent-actions">
-        <Button variant="danger" onclick={rejectConsent}>
+        <Button variant="danger" onclick={handleReject}>
           {$i18n.t.consent.reject}
         </Button>
-        <Button variant="primary" onclick={approveConsent}>
+        <Button variant="primary" onclick={handleApprove}>
           {$i18n.t.consent.approve}
         </Button>
       </div>
@@ -170,7 +198,7 @@ function dialogTitle(method: NosskeyMethod, t: typeof $i18n.t.consent): string {
     display: grid;
     grid-template-columns: max-content 1fr;
     gap: 6px 12px;
-    margin: 12px 0 20px;
+    margin: 12px 0 12px;
   }
 
   .consent-event dt {
@@ -189,6 +217,37 @@ function dialogTitle(method: NosskeyMethod, t: typeof $i18n.t.consent): string {
 
   .muted {
     color: var(--color-text-muted);
+  }
+
+  .consent-raw {
+    margin: 0 0 16px;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 8px 12px;
+  }
+
+  .consent-raw summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+  }
+
+  .consent-raw pre {
+    margin-top: 8px;
+    max-height: 240px;
+    overflow: auto;
+  }
+
+  .consent-trust {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0 0 16px;
+    cursor: pointer;
+  }
+
+  .consent-trust input[type='checkbox'] {
+    margin: 0;
   }
 
   .consent-actions {

--- a/examples/svelte-app/src/components/ConsentDialog.svelte
+++ b/examples/svelte-app/src/components/ConsentDialog.svelte
@@ -10,6 +10,9 @@ const CONTENT_PREVIEW_LIMIT = 100;
 const NPUB_HEAD = 8;
 const NPUB_TAIL = 8;
 
+// `{#if $pendingConsent}` 配下のため、ダイアログがアンマウント・再マウントされる
+// 度に false で再初期化される。承認/拒否後の明示リセットも併せて行うのは、
+// 同じインスタンスのまま次の request が即セットされる稀なケースでの保険。
 let trustOrigin = $state(false);
 
 function truncate(value: string, limit = CONTENT_PREVIEW_LIMIT): string {
@@ -140,7 +143,7 @@ function handleReject() {
           {$i18n.t.consent.reject}
         </Button>
         <Button variant="primary" onclick={handleApprove}>
-          {$i18n.t.consent.approve}
+          {trustOrigin ? $i18n.t.consent.approveAndTrust : $i18n.t.consent.approve}
         </Button>
       </div>
     </div>

--- a/examples/svelte-app/src/components/screens/SettingsScreen.svelte
+++ b/examples/svelte-app/src/components/screens/SettingsScreen.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 import { i18n } from '../../i18n/i18n-store.js';
 import AppInfo from '../settings/AppInfo.svelte';
+import ConsentPolicySettings from '../settings/ConsentPolicySettings.svelte';
 import LanguageSettings from '../settings/LanguageSettings.svelte';
 import LocalStorageSection from '../settings/LocalStorageSection.svelte';
 import RelaySettings from '../settings/RelaySettings.svelte';
+import TrustedOriginsSettings from '../settings/TrustedOriginsSettings.svelte';
 import ThemeSettings from '../settings/theme-settings.svelte';
 </script>
 
@@ -13,6 +15,8 @@ import ThemeSettings from '../settings/theme-settings.svelte';
   <LanguageSettings />
   <ThemeSettings />
   <RelaySettings />
+  <ConsentPolicySettings />
+  <TrustedOriginsSettings />
   <AppInfo />
 </div>
 

--- a/examples/svelte-app/src/components/settings/ConsentPolicySettings.svelte
+++ b/examples/svelte-app/src/components/settings/ConsentPolicySettings.svelte
@@ -1,20 +1,31 @@
 <script lang="ts">
 import { i18n } from '../../i18n/i18n-store.js';
-import { type ConsentDecision, type ConsentPolicy, consentPolicy } from '../../store/app-state.js';
+import {
+  type ConsentDecision,
+  type ConsentPolicy,
+  POLICY_KEYS,
+  type PolicyKey,
+  consentPolicy,
+  denyCounts,
+  resetDenyCounts,
+  storageCorruption,
+} from '../../store/app-state.js';
 import CardSection from '../ui/CardSection.svelte';
+import Button from '../ui/button/Button.svelte';
 
-const METHOD_KEYS = [
-  'signEvent',
-  'nip44',
-  'nip04',
-] as const satisfies readonly (keyof ConsentPolicy)[];
 const OPTIONS: ConsentDecision[] = ['ask', 'always', 'deny'];
+
+let savedMessage = $state('');
 
 function setDecision(method: keyof ConsentPolicy, value: ConsentDecision) {
   consentPolicy.update((current) => ({ ...current, [method]: value }));
+  savedMessage = $i18n.t.settings.consentPolicy.saved;
+  setTimeout(() => {
+    savedMessage = '';
+  }, 2000);
 }
 
-function methodLabel(method: keyof ConsentPolicy): string {
+function methodLabel(method: PolicyKey): string {
   return $i18n.t.settings.consentPolicy.methodLabel[method];
 }
 
@@ -26,8 +37,14 @@ function optionLabel(option: ConsentDecision): string {
 <CardSection title={$i18n.t.settings.consentPolicy.title}>
   <p class="description">{$i18n.t.settings.consentPolicy.description}</p>
 
+  {#if $storageCorruption.consentPolicy || $storageCorruption.trustedOrigins}
+    <p class="corruption-warning" role="alert">
+      {$i18n.t.settings.consentPolicy.corruptionWarning}
+    </p>
+  {/if}
+
   <div class="policy-grid">
-    {#each METHOD_KEYS as method (method)}
+    {#each POLICY_KEYS as method (method)}
       <fieldset class="policy-row">
         <legend>{methodLabel(method)}</legend>
         <div class="radio-group">
@@ -44,9 +61,29 @@ function optionLabel(option: ConsentDecision): string {
             </label>
           {/each}
         </div>
+        {#if $denyCounts[method] > 0}
+          <p class="deny-count" aria-live="polite">
+            {@html $i18n.t.settings.consentPolicy.denyCount.replace(
+              '{count}',
+              `<strong>${$denyCounts[method]}</strong>`
+            )}
+          </p>
+        {/if}
       </fieldset>
     {/each}
   </div>
+
+  {#if $denyCounts.signEvent > 0 || $denyCounts.nip44 > 0 || $denyCounts.nip04 > 0}
+    <div class="deny-actions">
+      <Button variant="secondary" size="small" onclick={resetDenyCounts}>
+        {$i18n.t.settings.consentPolicy.resetDenyCounts}
+      </Button>
+    </div>
+  {/if}
+
+  {#if savedMessage}
+    <div class="saved-message" aria-live="polite">{savedMessage}</div>
+  {/if}
 </CardSection>
 
 <style>
@@ -54,6 +91,16 @@ function optionLabel(option: ConsentDecision): string {
     margin-bottom: 15px;
     color: var(--color-text-secondary);
     transition: color 0.3s ease;
+  }
+
+  .corruption-warning {
+    margin: 0 0 12px;
+    padding: 10px 12px;
+    border-radius: 8px;
+    background-color: var(--color-warning-bg, #fff7e0);
+    border: 1px solid var(--color-warning-border, #e6c452);
+    color: var(--color-warning, #8a6d00);
+    font-size: 0.9rem;
   }
 
   .policy-grid {
@@ -91,5 +138,27 @@ function optionLabel(option: ConsentDecision): string {
 
   .radio-group input[type='radio'] {
     margin: 0;
+  }
+
+  .deny-count {
+    margin: 6px 0 0;
+    font-size: 0.85rem;
+    color: var(--color-text-secondary);
+  }
+
+  .deny-actions {
+    margin-top: 12px;
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .saved-message {
+    margin-top: 12px;
+    padding: 8px 12px;
+    background-color: var(--color-success-bg);
+    border: 1px solid var(--color-success-border);
+    border-radius: 8px;
+    color: var(--color-success);
+    font-size: 0.9rem;
   }
 </style>

--- a/examples/svelte-app/src/components/settings/ConsentPolicySettings.svelte
+++ b/examples/svelte-app/src/components/settings/ConsentPolicySettings.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+import { i18n } from '../../i18n/i18n-store.js';
+import { type ConsentDecision, type ConsentPolicy, consentPolicy } from '../../store/app-state.js';
+import CardSection from '../ui/CardSection.svelte';
+
+const METHOD_KEYS = [
+  'signEvent',
+  'nip44',
+  'nip04',
+] as const satisfies readonly (keyof ConsentPolicy)[];
+const OPTIONS: ConsentDecision[] = ['ask', 'always', 'deny'];
+
+function setDecision(method: keyof ConsentPolicy, value: ConsentDecision) {
+  consentPolicy.update((current) => ({ ...current, [method]: value }));
+}
+
+function methodLabel(method: keyof ConsentPolicy): string {
+  return $i18n.t.settings.consentPolicy.methodLabel[method];
+}
+
+function optionLabel(option: ConsentDecision): string {
+  return $i18n.t.settings.consentPolicy.option[option];
+}
+</script>
+
+<CardSection title={$i18n.t.settings.consentPolicy.title}>
+  <p class="description">{$i18n.t.settings.consentPolicy.description}</p>
+
+  <div class="policy-grid">
+    {#each METHOD_KEYS as method (method)}
+      <fieldset class="policy-row">
+        <legend>{methodLabel(method)}</legend>
+        <div class="radio-group">
+          {#each OPTIONS as option (option)}
+            <label>
+              <input
+                type="radio"
+                name="consent-policy-{method}"
+                value={option}
+                checked={$consentPolicy[method] === option}
+                onchange={() => setDecision(method, option)}
+              />
+              {optionLabel(option)}
+            </label>
+          {/each}
+        </div>
+      </fieldset>
+    {/each}
+  </div>
+</CardSection>
+
+<style>
+  .description {
+    margin-bottom: 15px;
+    color: var(--color-text-secondary);
+    transition: color 0.3s ease;
+  }
+
+  .policy-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .policy-row {
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 8px 12px;
+    margin: 0;
+  }
+
+  .policy-row legend {
+    padding: 0 6px;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+  }
+
+  .radio-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 4px;
+  }
+
+  .radio-group label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+  }
+
+  .radio-group input[type='radio'] {
+    margin: 0;
+  }
+</style>

--- a/examples/svelte-app/src/components/settings/TrustedOriginsSettings.svelte
+++ b/examples/svelte-app/src/components/settings/TrustedOriginsSettings.svelte
@@ -1,11 +1,30 @@
 <script lang="ts">
 import { i18n } from '../../i18n/i18n-store.js';
-import { trustedOrigins } from '../../store/app-state.js';
+import { type PolicyKey, trustedOrigins } from '../../store/app-state.js';
 import CardSection from '../ui/CardSection.svelte';
 import Button from '../ui/button/Button.svelte';
 
-function removeOrigin(origin: string) {
-  trustedOrigins.update((list) => list.filter((entry) => entry !== origin));
+function removeMethod(origin: string, method: PolicyKey) {
+  if (!confirm($i18n.t.settings.trustedOrigins.confirmRemove)) return;
+  trustedOrigins.update((list) =>
+    list
+      .map((entry) =>
+        entry.origin === origin
+          ? { ...entry, methods: entry.methods.filter((m) => m !== method) }
+          : entry
+      )
+      // すべてのメソッドが外れたエントリは破棄する
+      .filter((entry) => entry.methods.length > 0)
+  );
+}
+
+function removeAll(origin: string) {
+  if (!confirm($i18n.t.settings.trustedOrigins.confirmRemoveAll)) return;
+  trustedOrigins.update((list) => list.filter((entry) => entry.origin !== origin));
+}
+
+function methodLabel(method: PolicyKey): string {
+  return $i18n.t.settings.consentPolicy.methodLabel[method];
 }
 </script>
 
@@ -16,12 +35,28 @@ function removeOrigin(origin: string) {
     <p class="empty">{$i18n.t.settings.trustedOrigins.empty}</p>
   {:else}
     <ul class="origin-list">
-      {#each $trustedOrigins as origin (origin)}
+      {#each $trustedOrigins as entry (entry.origin)}
         <li class="origin-item">
-          <code class="origin-url" title={origin}>{origin}</code>
-          <Button variant="danger" size="small" onclick={() => removeOrigin(origin)}>
-            {$i18n.t.settings.trustedOrigins.removeButton}
-          </Button>
+          <div class="origin-header">
+            <code class="origin-url" title={entry.origin}>{entry.origin}</code>
+            <Button variant="danger" size="small" onclick={() => removeAll(entry.origin)}>
+              {$i18n.t.settings.trustedOrigins.removeAllButton}
+            </Button>
+          </div>
+          <ul class="method-list">
+            {#each entry.methods as method (method)}
+              <li class="method-item">
+                <span class="method-label">{methodLabel(method)}</span>
+                <Button
+                  variant="secondary"
+                  size="small"
+                  onclick={() => removeMethod(entry.origin, method)}
+                >
+                  {$i18n.t.settings.trustedOrigins.removeButton}
+                </Button>
+              </li>
+            {/each}
+          </ul>
         </li>
       {/each}
     </ul>
@@ -47,17 +82,23 @@ function removeOrigin(origin: string) {
     margin: 0;
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 12px;
   }
 
   .origin-item {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 8px 12px;
+    padding: 10px 12px;
     background-color: var(--color-tertiary);
     border: 1px solid var(--color-border);
     border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .origin-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
   }
 
   .origin-url {
@@ -67,5 +108,28 @@ function removeOrigin(origin: string) {
     white-space: nowrap;
     font-family: monospace;
     color: var(--color-text);
+  }
+
+  .method-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .method-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 4px 8px;
+    border-radius: 6px;
+  }
+
+  .method-label {
+    flex: 1 1 auto;
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
   }
 </style>

--- a/examples/svelte-app/src/components/settings/TrustedOriginsSettings.svelte
+++ b/examples/svelte-app/src/components/settings/TrustedOriginsSettings.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+import { i18n } from '../../i18n/i18n-store.js';
+import { trustedOrigins } from '../../store/app-state.js';
+import CardSection from '../ui/CardSection.svelte';
+import Button from '../ui/button/Button.svelte';
+
+function removeOrigin(origin: string) {
+  trustedOrigins.update((list) => list.filter((entry) => entry !== origin));
+}
+</script>
+
+<CardSection title={$i18n.t.settings.trustedOrigins.title}>
+  <p class="description">{$i18n.t.settings.trustedOrigins.description}</p>
+
+  {#if $trustedOrigins.length === 0}
+    <p class="empty">{$i18n.t.settings.trustedOrigins.empty}</p>
+  {:else}
+    <ul class="origin-list">
+      {#each $trustedOrigins as origin (origin)}
+        <li class="origin-item">
+          <code class="origin-url" title={origin}>{origin}</code>
+          <Button variant="danger" size="small" onclick={() => removeOrigin(origin)}>
+            {$i18n.t.settings.trustedOrigins.removeButton}
+          </Button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</CardSection>
+
+<style>
+  .description {
+    margin-bottom: 15px;
+    color: var(--color-text-secondary);
+    transition: color 0.3s ease;
+  }
+
+  .empty {
+    margin: 10px 0;
+    color: var(--color-text-secondary);
+    font-style: italic;
+  }
+
+  .origin-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .origin-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 12px;
+    background-color: var(--color-tertiary);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+  }
+
+  .origin-url {
+    flex: 1 1 240px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: monospace;
+    color: var(--color-text);
+  }
+</style>

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -166,6 +166,26 @@ export interface TranslationData {
       invalidUrl: string;
       empty: string;
     };
+    trustedOrigins: {
+      title: string;
+      description: string;
+      empty: string;
+      removeButton: string;
+    };
+    consentPolicy: {
+      title: string;
+      description: string;
+      methodLabel: {
+        signEvent: string;
+        nip44: string;
+        nip04: string;
+      };
+      option: {
+        ask: string;
+        always: string;
+        deny: string;
+      };
+    };
   };
   navigation: {
     account: string;
@@ -194,6 +214,19 @@ export interface TranslationData {
     peerPubkey: string;
     plaintext: string;
     decryptNoPreview: string;
+    alwaysAllowSite: string;
+    showRaw: string;
+    kindLabel: {
+      textNote: string;
+      follows: string;
+      legacyDm: string;
+      repost: string;
+      reaction: string;
+      channelMessage: string;
+      giftWrap: string;
+      longForm: string;
+      unknown: string;
+    };
   };
   iframeHost: {
     running: string;
@@ -369,6 +402,28 @@ export const ja: TranslationData = {
       invalidUrl: 'wss:// または ws:// で始まる URL を入力してください。',
       empty: 'リレーが登録されていません。',
     },
+    trustedOrigins: {
+      title: '信頼済みサイト',
+      description:
+        '同意ダイアログで「このサイトを常に許可」を選んだサイトの一覧です。削除すると次回から再度確認が表示されます。',
+      empty: '信頼済みサイトはまだありません。',
+      removeButton: '削除',
+    },
+    consentPolicy: {
+      title: 'メソッド別の同意ポリシー',
+      description:
+        'リクエスト種別ごとに既定の挙動を設定できます。「常に許可」はサイトを問わずスキップ、「拒否」はダイアログを出さずに即拒否します。',
+      methodLabel: {
+        signEvent: 'イベント署名 (signEvent)',
+        nip44: 'NIP-44 暗号化 / 復号',
+        nip04: 'NIP-04 暗号化 / 復号（レガシー）',
+      },
+      option: {
+        ask: '毎回確認',
+        always: '常に許可',
+        deny: '拒否',
+      },
+    },
     exportKeyInfo: {
       title: '鍵情報のエクスポート',
       description:
@@ -413,6 +468,19 @@ export const ja: TranslationData = {
     peerPubkey: '相手の公開鍵',
     plaintext: '平文',
     decryptNoPreview: '暗号文の内容は復号後にしか確認できません。',
+    alwaysAllowSite: 'このサイトを常に許可（同意ダイアログをスキップ）',
+    showRaw: '生のイベント JSON を表示',
+    kindLabel: {
+      textNote: 'テキストノート',
+      follows: 'フォローリスト',
+      legacyDm: 'ダイレクトメッセージ（NIP-04 レガシー）',
+      repost: 'リポスト',
+      reaction: 'リアクション',
+      channelMessage: 'チャンネルメッセージ',
+      giftWrap: 'Gift Wrap',
+      longForm: '長文記事',
+      unknown: 'その他のイベント',
+    },
   },
   iframeHost: {
     running: 'Nosskey iframe が起動中です。親アプリからの署名リクエストを待機します。',
@@ -590,6 +658,28 @@ export const en: TranslationData = {
       invalidUrl: 'Please enter a URL starting with wss:// or ws://.',
       empty: 'No relays configured.',
     },
+    trustedOrigins: {
+      title: 'Trusted sites',
+      description:
+        'Sites you marked as "always allow" in the consent dialog. Removing a site will make the dialog reappear on the next request.',
+      empty: 'No trusted sites yet.',
+      removeButton: 'Remove',
+    },
+    consentPolicy: {
+      title: 'Per-method consent policy',
+      description:
+        'Set the default behavior for each request type. "Always allow" skips the dialog regardless of site, "Deny" rejects without prompting.',
+      methodLabel: {
+        signEvent: 'Sign event (signEvent)',
+        nip44: 'NIP-44 encrypt / decrypt',
+        nip04: 'NIP-04 encrypt / decrypt (legacy)',
+      },
+      option: {
+        ask: 'Ask every time',
+        always: 'Always allow',
+        deny: 'Deny',
+      },
+    },
     exportKeyInfo: {
       title: 'Export KeyInfo',
       description:
@@ -634,6 +724,19 @@ export const en: TranslationData = {
     peerPubkey: 'Peer public key',
     plaintext: 'Plaintext',
     decryptNoPreview: 'Ciphertext contents are only visible after decryption.',
+    alwaysAllowSite: 'Always allow this site (skip the consent dialog)',
+    showRaw: 'Show raw event JSON',
+    kindLabel: {
+      textNote: 'Text note',
+      follows: 'Follow list',
+      legacyDm: 'Direct message (NIP-04 legacy)',
+      repost: 'Repost',
+      reaction: 'Reaction',
+      channelMessage: 'Channel message',
+      giftWrap: 'Gift wrap',
+      longForm: 'Long-form article',
+      unknown: 'Other event',
+    },
   },
   iframeHost: {
     running: 'Nosskey iframe is running and waiting for signing requests from the parent app.',

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -171,6 +171,9 @@ export interface TranslationData {
       description: string;
       empty: string;
       removeButton: string;
+      removeAllButton: string;
+      confirmRemove: string;
+      confirmRemoveAll: string;
     };
     consentPolicy: {
       title: string;
@@ -405,9 +408,12 @@ export const ja: TranslationData = {
     trustedOrigins: {
       title: '信頼済みサイト',
       description:
-        '同意ダイアログで「このサイトを常に許可」を選んだサイトの一覧です。削除すると次回から再度確認が表示されます。',
+        '同意ダイアログで「このサイトを常に許可」を選んだサイトとメソッドの一覧です。許可はメソッドごとに記録され、他のメソッドは別途確認されます。削除すると次回から再度確認が表示されます。',
       empty: '信頼済みサイトはまだありません。',
-      removeButton: '削除',
+      removeButton: 'このメソッドを削除',
+      removeAllButton: 'すべて削除',
+      confirmRemove: 'このメソッドの自動許可を解除しますか？',
+      confirmRemoveAll: 'このサイトの自動許可をすべて解除しますか？',
     },
     consentPolicy: {
       title: 'メソッド別の同意ポリシー',
@@ -661,9 +667,12 @@ export const en: TranslationData = {
     trustedOrigins: {
       title: 'Trusted sites',
       description:
-        'Sites you marked as "always allow" in the consent dialog. Removing a site will make the dialog reappear on the next request.',
+        'Sites and methods you marked as "always allow" in the consent dialog. Trust is recorded per method; other methods are confirmed separately. Removing an entry will make the dialog reappear on the next request.',
       empty: 'No trusted sites yet.',
-      removeButton: 'Remove',
+      removeButton: 'Remove this method',
+      removeAllButton: 'Remove all',
+      confirmRemove: 'Remove auto-approval for this method?',
+      confirmRemoveAll: 'Remove auto-approval for this site entirely?',
     },
     consentPolicy: {
       title: 'Per-method consent policy',

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -188,6 +188,10 @@ export interface TranslationData {
         always: string;
         deny: string;
       };
+      denyCount: string;
+      resetDenyCounts: string;
+      saved: string;
+      corruptionWarning: string;
     };
   };
   navigation: {
@@ -429,6 +433,11 @@ export const ja: TranslationData = {
         always: '常に許可',
         deny: '拒否',
       },
+      denyCount: 'このセッションで {count} 件を自動拒否しました。',
+      resetDenyCounts: '拒否カウンタをリセット',
+      saved: '保存しました。',
+      corruptionWarning:
+        '保存された同意設定の一部が不正な形式だったため、デフォルト値に戻しました。意図しない設定変更がないか確認してください。',
     },
     exportKeyInfo: {
       title: '鍵情報のエクスポート',
@@ -688,6 +697,11 @@ export const en: TranslationData = {
         always: 'Always allow',
         deny: 'Deny',
       },
+      denyCount: 'Auto-rejected {count} request(s) this session.',
+      resetDenyCounts: 'Reset deny counter',
+      saved: 'Saved.',
+      corruptionWarning:
+        'Some stored consent settings were invalid and have been reset to defaults. Please verify your settings have not been altered unexpectedly.',
     },
     exportKeyInfo: {
       title: 'Export KeyInfo',

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -224,16 +224,20 @@ export interface TranslationData {
     alwaysAllowSite: string;
     showRaw: string;
     kindLabel: {
+      metadata: string;
       textNote: string;
       follows: string;
       legacyDm: string;
       repost: string;
       reaction: string;
       channelMessage: string;
+      rumor: string;
+      seal: string;
       giftWrap: string;
       longForm: string;
       unknown: string;
     };
+    approveAndTrust: string;
   };
   iframeHost: {
     running: string;
@@ -486,16 +490,20 @@ export const ja: TranslationData = {
     alwaysAllowSite: 'このサイトを常に許可（同意ダイアログをスキップ）',
     showRaw: '生のイベント JSON を表示',
     kindLabel: {
+      metadata: 'プロフィール (metadata)',
       textNote: 'テキストノート',
       follows: 'フォローリスト',
       legacyDm: 'ダイレクトメッセージ（NIP-04 レガシー）',
       repost: 'リポスト',
       reaction: 'リアクション',
       channelMessage: 'チャンネルメッセージ',
+      rumor: 'NIP-17 Rumor',
+      seal: 'NIP-17 Seal',
       giftWrap: 'Gift Wrap',
       longForm: '長文記事',
       unknown: 'その他のイベント',
     },
+    approveAndTrust: '常に許可して承認',
   },
   iframeHost: {
     running: 'Nosskey iframe が起動中です。親アプリからの署名リクエストを待機します。',
@@ -750,16 +758,20 @@ export const en: TranslationData = {
     alwaysAllowSite: 'Always allow this site (skip the consent dialog)',
     showRaw: 'Show raw event JSON',
     kindLabel: {
+      metadata: 'Profile (metadata)',
       textNote: 'Text note',
       follows: 'Follow list',
       legacyDm: 'Direct message (NIP-04 legacy)',
       repost: 'Repost',
       reaction: 'Reaction',
       channelMessage: 'Channel message',
+      rumor: 'NIP-17 rumor',
+      seal: 'NIP-17 seal',
       giftWrap: 'Gift wrap',
       longForm: 'Long-form article',
       unknown: 'Other event',
     },
+    approveAndTrust: 'Approve and always allow',
   },
   iframeHost: {
     running: 'Nosskey iframe is running and waiting for signing requests from the parent app.',

--- a/examples/svelte-app/src/iframe-mode.spec.ts
+++ b/examples/svelte-app/src/iframe-mode.spec.ts
@@ -1,0 +1,123 @@
+import type { ConsentRequest } from 'nosskey-iframe';
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { approveConsent, onConsent, pendingConsent, rejectConsent } from './iframe-mode.js';
+import { consentPolicy, denyCounts, resetDenyCounts, trustedOrigins } from './store/app-state.js';
+
+const origin = 'https://parent.example';
+
+const signRequest: ConsentRequest = {
+  origin,
+  method: 'signEvent',
+  event: {
+    kind: 1,
+    content: 'hello',
+    tags: [],
+    created_at: 0,
+    pubkey: '',
+    id: '',
+    sig: '',
+  },
+};
+
+const nip04Request: ConsentRequest = {
+  origin,
+  method: 'nip04_decrypt',
+  pubkey: 'a'.repeat(64),
+};
+
+beforeEach(() => {
+  trustedOrigins.set([]);
+  consentPolicy.set({ signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
+  resetDenyCounts();
+  pendingConsent.set(null);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('onConsent', () => {
+  it('resolves true immediately when policy is always (no dialog)', async () => {
+    consentPolicy.set({ signEvent: 'always', nip44: 'ask', nip04: 'ask' });
+    const result = await onConsent(signRequest);
+    expect(result).toBe(true);
+    expect(get(pendingConsent)).toBeNull();
+  });
+
+  it('resolves false immediately when policy is deny, warns, and increments counter', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    consentPolicy.set({ signEvent: 'ask', nip44: 'ask', nip04: 'deny' });
+    const result = await onConsent(nip04Request);
+    expect(result).toBe(false);
+    expect(get(pendingConsent)).toBeNull();
+    expect(get(denyCounts).nip04).toBe(1);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('resolves true immediately when origin is trusted for the method', async () => {
+    trustedOrigins.set([{ origin, methods: ['nip04'] }]);
+    const result = await onConsent(nip04Request);
+    expect(result).toBe(true);
+  });
+
+  it('falls through to ask when origin is trusted for a different method', async () => {
+    trustedOrigins.set([{ origin, methods: ['signEvent'] }]);
+    const promise = onConsent(nip04Request);
+    expect(get(pendingConsent)).not.toBeNull();
+    rejectConsent();
+    expect(await promise).toBe(false);
+  });
+
+  it('approveConsent without trustOrigin does not add origin to trusted list', async () => {
+    const promise = onConsent(signRequest);
+    expect(get(pendingConsent)).not.toBeNull();
+    approveConsent();
+    expect(await promise).toBe(true);
+    expect(get(trustedOrigins)).toEqual([]);
+  });
+
+  it('approveConsent with trustOrigin adds origin × method to trusted list', async () => {
+    const promise = onConsent(signRequest);
+    approveConsent({ trustOrigin: true });
+    expect(await promise).toBe(true);
+    expect(get(trustedOrigins)).toEqual([{ origin, methods: ['signEvent'] }]);
+  });
+
+  it('approveConsent with trustOrigin appends a new method to an existing entry', async () => {
+    trustedOrigins.set([{ origin, methods: ['signEvent'] }]);
+    const promise = onConsent(nip04Request);
+    approveConsent({ trustOrigin: true });
+    expect(await promise).toBe(true);
+    expect(get(trustedOrigins)).toEqual([{ origin, methods: ['signEvent', 'nip04'] }]);
+  });
+
+  it('approveConsent with trustOrigin is idempotent for a method already trusted', async () => {
+    trustedOrigins.set([{ origin, methods: ['nip04'] }]);
+    // 既に trust 済みなら policy=ask の経路に乗らないが、念のためポリシーを上書きして
+    // ダイアログ経路に流して同 method を再度許可した時に重複しないことを確認する。
+    consentPolicy.set({ signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
+    trustedOrigins.set([{ origin, methods: [] }]); // この origin はリストに居るが method 空
+    const promise = onConsent(nip04Request);
+    approveConsent({ trustOrigin: true });
+    await promise;
+    expect(get(trustedOrigins)).toEqual([{ origin, methods: ['nip04'] }]);
+  });
+
+  it('rejectConsent does not add to trusted list even if checkbox was checked', async () => {
+    // rejectConsent は ApproveOptions を渡さない。Reject 経路で trust が漏れない回帰防止。
+    const promise = onConsent(signRequest);
+    rejectConsent();
+    expect(await promise).toBe(false);
+    expect(get(trustedOrigins)).toEqual([]);
+  });
+
+  it('deny policy beats trusted origin', async () => {
+    trustedOrigins.set([{ origin, methods: ['signEvent'] }]);
+    consentPolicy.set({ signEvent: 'deny', nip44: 'ask', nip04: 'ask' });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await onConsent(signRequest);
+    expect(result).toBe(false);
+    expect(get(denyCounts).signEvent).toBe(1);
+  });
+});

--- a/examples/svelte-app/src/iframe-mode.ts
+++ b/examples/svelte-app/src/iframe-mode.ts
@@ -4,7 +4,7 @@ import { get, writable } from 'svelte/store';
 import { getNosskeyManager } from './services/nosskey-manager.service.js';
 import { loadRelays } from './services/relays-store.js';
 import { consentPolicy, trustedOrigins } from './store/app-state.js';
-import { evaluateConsent } from './utils/consent-gating.js';
+import { evaluateConsent, policyKeyFor } from './utils/consent-gating.js';
 
 export interface ApproveOptions {
   /** チェックボックス「このサイトを常に許可」が ON のときに渡される。 */
@@ -17,9 +17,24 @@ export interface PendingConsent extends ConsentRequest {
 
 export const pendingConsent = writable<PendingConsent | null>(null);
 
-function rememberOriginIfRequested(origin: string, options?: ApproveOptions): void {
+/**
+ * `trustOrigin` が ON のとき、リクエストの origin × method 単位で信頼リストに追加する。
+ * すべてのメソッドを許可するのではなく、現在のリクエスト method（policyKey 単位）のみを許可する点に注意。
+ */
+function rememberOriginIfRequested(
+  request: ConsentRequest,
+  options: ApproveOptions | undefined
+): void {
   if (!options?.trustOrigin) return;
-  trustedOrigins.update((list) => (list.includes(origin) ? list : [...list, origin]));
+  const key = policyKeyFor(request.method);
+  trustedOrigins.update((list) => {
+    const existing = list.find((entry) => entry.origin === request.origin);
+    if (!existing) return [...list, { origin: request.origin, methods: [key] }];
+    if (existing.methods.includes(key)) return list;
+    return list.map((entry) =>
+      entry.origin === request.origin ? { ...entry, methods: [...entry.methods, key] } : entry
+    );
+  });
 }
 
 function onConsent(request: ConsentRequest): Promise<boolean> {
@@ -34,7 +49,7 @@ function onConsent(request: ConsentRequest): Promise<boolean> {
     pendingConsent.set({
       ...request,
       resolve: (approved, options) => {
-        if (approved) rememberOriginIfRequested(request.origin, options);
+        if (approved) rememberOriginIfRequested(request, options);
         resolve(approved);
       },
     });
@@ -65,6 +80,9 @@ export function startIframeHost(overrides: Partial<NosskeyIframeHostOptions> = {
   const manager = getNosskeyManager();
   const host = new NosskeyIframeHost({
     manager,
+    // NOTE: 'allowedOrigins: *' は postMessage の入口を全許可するデバッグ用設定。
+    // 「信頼済みオリジン」機能はあくまでダイアログを抑制するレイヤーであり、
+    // ここで原点フィルタを行うものではない。プロダクション統合時は親オリジンを限定すること。
     allowedOrigins: '*',
     requireUserConsent: true,
     onConsent,

--- a/examples/svelte-app/src/iframe-mode.ts
+++ b/examples/svelte-app/src/iframe-mode.ts
@@ -3,7 +3,7 @@ import { NosskeyIframeHost } from 'nosskey-iframe';
 import { get, writable } from 'svelte/store';
 import { getNosskeyManager } from './services/nosskey-manager.service.js';
 import { loadRelays } from './services/relays-store.js';
-import { consentPolicy, trustedOrigins } from './store/app-state.js';
+import { consentPolicy, incrementDenyCount, trustedOrigins } from './store/app-state.js';
 import { evaluateConsent, policyKeyFor } from './utils/consent-gating.js';
 
 export interface ApproveOptions {
@@ -43,7 +43,17 @@ function onConsent(request: ConsentRequest): Promise<boolean> {
     policy: get(consentPolicy),
   });
   if (evaluation.decision === 'approve') return Promise.resolve(true);
-  if (evaluation.decision === 'reject') return Promise.resolve(false);
+  if (evaluation.decision === 'reject') {
+    // deny ポリシーは黙って拒否すると、悪意ある親からのプローブ
+    // (e.g. 任意 pubkey に対する nip04_decrypt 要求) をユーザーに知られず
+    // 試され続ける可能性がある。最低限 warn＋カウンタで観測できるようにする。
+    const key = policyKeyFor(request.method);
+    console.warn(
+      `[nosskey] consent auto-rejected for ${request.method} from ${request.origin} (policy=deny)`
+    );
+    incrementDenyCount(key);
+    return Promise.resolve(false);
+  }
 
   return new Promise<boolean>((resolve) => {
     pendingConsent.set({

--- a/examples/svelte-app/src/iframe-mode.ts
+++ b/examples/svelte-app/src/iframe-mode.ts
@@ -37,7 +37,14 @@ function rememberOriginIfRequested(
   });
 }
 
-function onConsent(request: ConsentRequest): Promise<boolean> {
+/**
+ * `NosskeyIframeHost.onConsent` 実装。テスト容易性のため export する。
+ * - ストアから現在のポリシー / 信頼リストを読み、純粋判定 (`evaluateConsent`) に委譲
+ * - `deny` 経路では warn＋カウンタ加算
+ * - `ask` 経路では `pendingConsent` をセットしてユーザー操作を待つ。承認時に
+ *   `trustOrigin` オプションが立っていれば origin × method を信頼リストに追加
+ */
+export function onConsent(request: ConsentRequest): Promise<boolean> {
   const evaluation = evaluateConsent(request, {
     trustedOrigins: get(trustedOrigins),
     policy: get(consentPolicy),

--- a/examples/svelte-app/src/iframe-mode.ts
+++ b/examples/svelte-app/src/iframe-mode.ts
@@ -1,24 +1,49 @@
 import type { ConsentRequest, NosskeyIframeHostOptions } from 'nosskey-iframe';
 import { NosskeyIframeHost } from 'nosskey-iframe';
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import { getNosskeyManager } from './services/nosskey-manager.service.js';
 import { loadRelays } from './services/relays-store.js';
+import { consentPolicy, trustedOrigins } from './store/app-state.js';
+import { evaluateConsent } from './utils/consent-gating.js';
+
+export interface ApproveOptions {
+  /** チェックボックス「このサイトを常に許可」が ON のときに渡される。 */
+  trustOrigin?: boolean;
+}
 
 export interface PendingConsent extends ConsentRequest {
-  resolve: (approved: boolean) => void;
+  resolve: (approved: boolean, options?: ApproveOptions) => void;
 }
 
 export const pendingConsent = writable<PendingConsent | null>(null);
 
+function rememberOriginIfRequested(origin: string, options?: ApproveOptions): void {
+  if (!options?.trustOrigin) return;
+  trustedOrigins.update((list) => (list.includes(origin) ? list : [...list, origin]));
+}
+
 function onConsent(request: ConsentRequest): Promise<boolean> {
+  const evaluation = evaluateConsent(request, {
+    trustedOrigins: get(trustedOrigins),
+    policy: get(consentPolicy),
+  });
+  if (evaluation.decision === 'approve') return Promise.resolve(true);
+  if (evaluation.decision === 'reject') return Promise.resolve(false);
+
   return new Promise<boolean>((resolve) => {
-    pendingConsent.set({ ...request, resolve });
+    pendingConsent.set({
+      ...request,
+      resolve: (approved, options) => {
+        if (approved) rememberOriginIfRequested(request.origin, options);
+        resolve(approved);
+      },
+    });
   });
 }
 
-export function approveConsent(): void {
+export function approveConsent(options?: ApproveOptions): void {
   pendingConsent.update((current) => {
-    current?.resolve(true);
+    current?.resolve(true, options);
     return null;
   });
 }

--- a/examples/svelte-app/src/store/app-state.ts
+++ b/examples/svelte-app/src/store/app-state.ts
@@ -5,10 +5,19 @@ export type ScreenName = 'account' | 'settings' | 'key' | 'iframe';
 
 export type ConsentDecision = 'ask' | 'always' | 'deny';
 
-export interface ConsentPolicy {
-  signEvent: ConsentDecision;
-  nip44: ConsentDecision;
-  nip04: ConsentDecision;
+/** ポリシーキーは `signEvent` / `nip44` / `nip04` の 3 種で、暗号化と復号は同一バケットに集約される。 */
+export type PolicyKey = 'signEvent' | 'nip44' | 'nip04';
+export const POLICY_KEYS: readonly PolicyKey[] = ['signEvent', 'nip44', 'nip04'] as const;
+
+export type ConsentPolicy = Record<PolicyKey, ConsentDecision>;
+
+/**
+ * 信頼済みエントリ。`origin` のすべての操作を許可するのではなく、
+ * `methods` に含まれるポリシーキーのみダイアログを省略する。
+ */
+export interface TrustedOriginEntry {
+  origin: string;
+  methods: PolicyKey[];
 }
 
 const DEFAULT_CONSENT_POLICY: ConsentPolicy = {
@@ -17,11 +26,17 @@ const DEFAULT_CONSENT_POLICY: ConsentPolicy = {
   nip04: 'ask',
 };
 
-const TRUSTED_ORIGINS_KEY = 'nosskey_trusted_origins';
+// v2: メソッドスコープ付きエントリの形式。旧 `nosskey_trusted_origins`
+// (`string[]`) は破壊的に置き換える（v1 ユーザー無し前提）。
+const TRUSTED_ORIGINS_KEY = 'nosskey_trusted_origins_v2';
 const CONSENT_POLICY_KEY = 'nosskey_consent_policy';
 
 function isConsentDecision(value: unknown): value is ConsentDecision {
   return value === 'ask' || value === 'always' || value === 'deny';
+}
+
+function isPolicyKey(value: unknown): value is PolicyKey {
+  return value === 'signEvent' || value === 'nip44' || value === 'nip04';
 }
 
 export function isScreenName(hash: string): hash is ScreenName {
@@ -46,7 +61,7 @@ export type ThemeMode = 'light' | 'dark' | 'auto';
 export const currentTheme = writable<ThemeMode>('dark');
 
 // 同意ゲート設定
-export const trustedOrigins = writable<string[]>([]);
+export const trustedOrigins = writable<TrustedOriginEntry[]>([]);
 export const consentPolicy = writable<ConsentPolicy>({ ...DEFAULT_CONSENT_POLICY });
 
 // 秘密鍵情報のキャッシュ設定を読み込む
@@ -81,16 +96,29 @@ function loadThemeSetting(): ThemeMode {
   return 'dark';
 }
 
-// 信頼済みオリジンを読み込む
-function loadTrustedOrigins(): string[] {
+// 信頼済みオリジン (v2: メソッドスコープ付き) を読み込む
+function loadTrustedOrigins(): TrustedOriginEntry[] {
   if (typeof window === 'undefined') return [];
   const raw = localStorage.getItem(TRUSTED_ORIGINS_KEY);
   if (!raw) return [];
   try {
     const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed) && parsed.every((v): v is string => typeof v === 'string')) {
-      return parsed;
+    if (!Array.isArray(parsed)) return [];
+    const result: TrustedOriginEntry[] = [];
+    for (const entry of parsed) {
+      if (
+        entry &&
+        typeof entry === 'object' &&
+        typeof (entry as { origin?: unknown }).origin === 'string' &&
+        Array.isArray((entry as { methods?: unknown }).methods)
+      ) {
+        const methods = (entry as { methods: unknown[] }).methods.filter(isPolicyKey);
+        if (methods.length > 0) {
+          result.push({ origin: (entry as { origin: string }).origin, methods });
+        }
+      }
     }
+    return result;
   } catch {
     // 破損した値は無視してデフォルトを返す
   }

--- a/examples/svelte-app/src/store/app-state.ts
+++ b/examples/svelte-app/src/store/app-state.ts
@@ -3,6 +3,27 @@ import { getNosskeyManager } from '../services/nosskey-manager.service.js';
 
 export type ScreenName = 'account' | 'settings' | 'key' | 'iframe';
 
+export type ConsentDecision = 'ask' | 'always' | 'deny';
+
+export interface ConsentPolicy {
+  signEvent: ConsentDecision;
+  nip44: ConsentDecision;
+  nip04: ConsentDecision;
+}
+
+const DEFAULT_CONSENT_POLICY: ConsentPolicy = {
+  signEvent: 'ask',
+  nip44: 'ask',
+  nip04: 'ask',
+};
+
+const TRUSTED_ORIGINS_KEY = 'nosskey_trusted_origins';
+const CONSENT_POLICY_KEY = 'nosskey_consent_policy';
+
+function isConsentDecision(value: unknown): value is ConsentDecision {
+  return value === 'ask' || value === 'always' || value === 'deny';
+}
+
 export function isScreenName(hash: string): hash is ScreenName {
   return new Set<string>(['account', 'settings', 'key', 'iframe']).has(hash);
 }
@@ -23,6 +44,10 @@ export const cacheTimeout = writable<number>(300); // キャッシュのタイ�
 // テーマ設定
 export type ThemeMode = 'light' | 'dark' | 'auto';
 export const currentTheme = writable<ThemeMode>('dark');
+
+// 同意ゲート設定
+export const trustedOrigins = writable<string[]>([]);
+export const consentPolicy = writable<ConsentPolicy>({ ...DEFAULT_CONSENT_POLICY });
 
 // 秘密鍵情報のキャッシュ設定を読み込む
 function loadCacheSecretsSetting() {
@@ -56,6 +81,39 @@ function loadThemeSetting(): ThemeMode {
   return 'dark';
 }
 
+// 信頼済みオリジンを読み込む
+function loadTrustedOrigins(): string[] {
+  if (typeof window === 'undefined') return [];
+  const raw = localStorage.getItem(TRUSTED_ORIGINS_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.every((v): v is string => typeof v === 'string')) {
+      return parsed;
+    }
+  } catch {
+    // 破損した値は無視してデフォルトを返す
+  }
+  return [];
+}
+
+// 同意ポリシーを読み込む
+function loadConsentPolicy(): ConsentPolicy {
+  if (typeof window === 'undefined') return { ...DEFAULT_CONSENT_POLICY };
+  const raw = localStorage.getItem(CONSENT_POLICY_KEY);
+  if (!raw) return { ...DEFAULT_CONSENT_POLICY };
+  try {
+    const parsed = JSON.parse(raw) as Partial<Record<keyof ConsentPolicy, unknown>>;
+    return {
+      signEvent: isConsentDecision(parsed.signEvent) ? parsed.signEvent : 'ask',
+      nip44: isConsentDecision(parsed.nip44) ? parsed.nip44 : 'ask',
+      nip04: isConsentDecision(parsed.nip04) ? parsed.nip04 : 'ask',
+    };
+  } catch {
+    return { ...DEFAULT_CONSENT_POLICY };
+  }
+}
+
 // 初期化
 try {
   cacheSecrets.set(loadCacheSecretsSetting());
@@ -78,6 +136,21 @@ try {
   currentTheme.subscribe((value) => {
     if (typeof window !== 'undefined') {
       localStorage.setItem('nosskey_theme', value);
+    }
+  });
+
+  trustedOrigins.set(loadTrustedOrigins());
+  consentPolicy.set(loadConsentPolicy());
+
+  trustedOrigins.subscribe((value) => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(TRUSTED_ORIGINS_KEY, JSON.stringify(value));
+    }
+  });
+
+  consentPolicy.subscribe((value) => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(CONSENT_POLICY_KEY, JSON.stringify(value));
     }
   });
 } catch (e) {

--- a/examples/svelte-app/src/store/app-state.ts
+++ b/examples/svelte-app/src/store/app-state.ts
@@ -64,6 +64,35 @@ export const currentTheme = writable<ThemeMode>('dark');
 export const trustedOrigins = writable<TrustedOriginEntry[]>([]);
 export const consentPolicy = writable<ConsentPolicy>({ ...DEFAULT_CONSENT_POLICY });
 
+/**
+ * `deny` ポリシーで自動拒否された回数。サイレントに拒否され続けて
+ * 親アプリのプローブを許してしまわないよう、ユーザーに可視化する。
+ * メソッドキー単位で集計し、永続化はしない（プロセス内のみ）。
+ */
+export const denyCounts = writable<Record<PolicyKey, number>>({
+  signEvent: 0,
+  nip44: 0,
+  nip04: 0,
+});
+
+export function incrementDenyCount(key: PolicyKey): void {
+  denyCounts.update((current) => ({ ...current, [key]: current[key] + 1 }));
+}
+
+export function resetDenyCounts(): void {
+  denyCounts.set({ signEvent: 0, nip44: 0, nip04: 0 });
+}
+
+/**
+ * localStorage に保存された設定が破損していたことを示すフラグ。
+ * 破損は黙ってデフォルト復帰させるが、Settings 画面で可視化する。
+ * メモリ内のみで保持（次回起動時はキー単位で再評価される）。
+ */
+export const storageCorruption = writable<{
+  trustedOrigins: boolean;
+  consentPolicy: boolean;
+}>({ trustedOrigins: false, consentPolicy: false });
+
 // 秘密鍵情報のキャッシュ設定を読み込む
 function loadCacheSecretsSetting() {
   if (typeof window !== 'undefined') {
@@ -96,6 +125,14 @@ function loadThemeSetting(): ThemeMode {
   return 'dark';
 }
 
+function markCorruption(field: 'trustedOrigins' | 'consentPolicy', reason: string): void {
+  // セキュリティ設定の沈黙降格を避けるため、破損は warn＋フラグで明示的に通知する。
+  // フェイルクローズに倒すと「明日突然サイトにアクセスできない」事象になるため、
+  // ここでは「黙ってデフォルト」ではなく「デフォルトに戻したことを表に出す」方針。
+  console.warn(`[nosskey] stored ${field} appears corrupted: ${reason}. Resetting to defaults.`);
+  storageCorruption.update((current) => ({ ...current, [field]: true }));
+}
+
 // 信頼済みオリジン (v2: メソッドスコープ付き) を読み込む
 function loadTrustedOrigins(): TrustedOriginEntry[] {
   if (typeof window === 'undefined') return [];
@@ -103,8 +140,12 @@ function loadTrustedOrigins(): TrustedOriginEntry[] {
   if (!raw) return [];
   try {
     const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
+    if (!Array.isArray(parsed)) {
+      markCorruption('trustedOrigins', 'not an array');
+      return [];
+    }
     const result: TrustedOriginEntry[] = [];
+    let droppedAny = false;
     for (const entry of parsed) {
       if (
         entry &&
@@ -115,14 +156,17 @@ function loadTrustedOrigins(): TrustedOriginEntry[] {
         const methods = (entry as { methods: unknown[] }).methods.filter(isPolicyKey);
         if (methods.length > 0) {
           result.push({ origin: (entry as { origin: string }).origin, methods });
+          continue;
         }
       }
+      droppedAny = true;
     }
+    if (droppedAny) markCorruption('trustedOrigins', 'invalid entries dropped');
     return result;
-  } catch {
-    // 破損した値は無視してデフォルトを返す
+  } catch (err) {
+    markCorruption('trustedOrigins', err instanceof Error ? err.message : String(err));
+    return [];
   }
-  return [];
 }
 
 // 同意ポリシーを読み込む
@@ -132,12 +176,22 @@ function loadConsentPolicy(): ConsentPolicy {
   if (!raw) return { ...DEFAULT_CONSENT_POLICY };
   try {
     const parsed = JSON.parse(raw) as Partial<Record<keyof ConsentPolicy, unknown>>;
-    return {
+    const result: ConsentPolicy = {
       signEvent: isConsentDecision(parsed.signEvent) ? parsed.signEvent : 'ask',
       nip44: isConsentDecision(parsed.nip44) ? parsed.nip44 : 'ask',
       nip04: isConsentDecision(parsed.nip04) ? parsed.nip04 : 'ask',
     };
-  } catch {
+    // 元の値が consent decision でない場合 (deny が ask に降格したケース等) は
+    // セキュリティ設定の沈黙降格に該当するため、警告フラグを立てる。
+    for (const key of POLICY_KEYS) {
+      if (parsed[key] !== undefined && !isConsentDecision(parsed[key])) {
+        markCorruption('consentPolicy', `invalid value for ${key}`);
+        break;
+      }
+    }
+    return result;
+  } catch (err) {
+    markCorruption('consentPolicy', err instanceof Error ? err.message : String(err));
     return { ...DEFAULT_CONSENT_POLICY };
   }
 }

--- a/examples/svelte-app/src/utils/consent-gating.spec.ts
+++ b/examples/svelte-app/src/utils/consent-gating.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import type { ConsentPolicy } from '../store/app-state.js';
+import { evaluateConsent, policyKeyFor } from './consent-gating.js';
+
+const askPolicy: ConsentPolicy = {
+  signEvent: 'ask',
+  nip44: 'ask',
+  nip04: 'ask',
+};
+
+describe('policyKeyFor', () => {
+  it.each([
+    ['signEvent', 'signEvent'],
+    ['nip44_encrypt', 'nip44'],
+    ['nip44_decrypt', 'nip44'],
+    ['nip04_encrypt', 'nip04'],
+    ['nip04_decrypt', 'nip04'],
+  ] as const)('maps %s -> %s', (method, expected) => {
+    expect(policyKeyFor(method)).toBe(expected);
+  });
+});
+
+describe('evaluateConsent', () => {
+  const origin = 'https://parent.example';
+
+  it('returns ask when policy is ask and origin is not trusted', () => {
+    expect(
+      evaluateConsent({ origin, method: 'signEvent' }, { trustedOrigins: [], policy: askPolicy })
+    ).toEqual({ decision: 'ask' });
+  });
+
+  it('returns reject when policy is deny, even for trusted origin', () => {
+    const policy: ConsentPolicy = { ...askPolicy, signEvent: 'deny' };
+    expect(
+      evaluateConsent({ origin, method: 'signEvent' }, { trustedOrigins: [origin], policy })
+    ).toEqual({ decision: 'reject', reason: 'policy-deny' });
+  });
+
+  it('returns approve when policy is always', () => {
+    const policy: ConsentPolicy = { ...askPolicy, nip44: 'always' };
+    expect(
+      evaluateConsent({ origin, method: 'nip44_encrypt' }, { trustedOrigins: [], policy })
+    ).toEqual({ decision: 'approve', reason: 'policy-always' });
+  });
+
+  it('returns approve when origin is trusted and policy is ask', () => {
+    expect(
+      evaluateConsent(
+        { origin, method: 'nip04_decrypt' },
+        { trustedOrigins: [origin], policy: askPolicy }
+      )
+    ).toEqual({ decision: 'approve', reason: 'trusted-origin' });
+  });
+
+  it('treats nip44 encrypt and decrypt as the same policy bucket', () => {
+    const policy: ConsentPolicy = { ...askPolicy, nip44: 'always' };
+    for (const method of ['nip44_encrypt', 'nip44_decrypt'] as const) {
+      expect(evaluateConsent({ origin, method }, { trustedOrigins: [], policy })).toEqual({
+        decision: 'approve',
+        reason: 'policy-always',
+      });
+    }
+  });
+
+  it('treats nip04 encrypt and decrypt as the same policy bucket', () => {
+    const policy: ConsentPolicy = { ...askPolicy, nip04: 'deny' };
+    for (const method of ['nip04_encrypt', 'nip04_decrypt'] as const) {
+      expect(evaluateConsent({ origin, method }, { trustedOrigins: [origin], policy })).toEqual({
+        decision: 'reject',
+        reason: 'policy-deny',
+      });
+    }
+  });
+});

--- a/examples/svelte-app/src/utils/consent-gating.spec.ts
+++ b/examples/svelte-app/src/utils/consent-gating.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { ConsentPolicy } from '../store/app-state.js';
+import type { ConsentPolicy, TrustedOriginEntry } from '../store/app-state.js';
 import { evaluateConsent, policyKeyFor } from './consent-gating.js';
 
 const askPolicy: ConsentPolicy = {
@@ -31,8 +31,9 @@ describe('evaluateConsent', () => {
 
   it('returns reject when policy is deny, even for trusted origin', () => {
     const policy: ConsentPolicy = { ...askPolicy, signEvent: 'deny' };
+    const trusted: TrustedOriginEntry[] = [{ origin, methods: ['signEvent'] }];
     expect(
-      evaluateConsent({ origin, method: 'signEvent' }, { trustedOrigins: [origin], policy })
+      evaluateConsent({ origin, method: 'signEvent' }, { trustedOrigins: trusted, policy })
     ).toEqual({ decision: 'reject', reason: 'policy-deny' });
   });
 
@@ -43,13 +44,26 @@ describe('evaluateConsent', () => {
     ).toEqual({ decision: 'approve', reason: 'policy-always' });
   });
 
-  it('returns approve when origin is trusted and policy is ask', () => {
+  it('returns approve when origin is trusted for this method', () => {
+    const trusted: TrustedOriginEntry[] = [{ origin, methods: ['nip04'] }];
     expect(
       evaluateConsent(
         { origin, method: 'nip04_decrypt' },
-        { trustedOrigins: [origin], policy: askPolicy }
+        { trustedOrigins: trusted, policy: askPolicy }
       )
     ).toEqual({ decision: 'approve', reason: 'trusted-origin' });
+  });
+
+  it('returns ask when origin is trusted for a different method (no implicit elevation)', () => {
+    // signEvent のみ信頼している origin が、nip04_decrypt を要求してきたケース。
+    // メソッド境界を越えて自動承認しないことを保証する。
+    const trusted: TrustedOriginEntry[] = [{ origin, methods: ['signEvent'] }];
+    expect(
+      evaluateConsent(
+        { origin, method: 'nip04_decrypt' },
+        { trustedOrigins: trusted, policy: askPolicy }
+      )
+    ).toEqual({ decision: 'ask' });
   });
 
   it('treats nip44 encrypt and decrypt as the same policy bucket', () => {
@@ -64,8 +78,9 @@ describe('evaluateConsent', () => {
 
   it('treats nip04 encrypt and decrypt as the same policy bucket', () => {
     const policy: ConsentPolicy = { ...askPolicy, nip04: 'deny' };
+    const trusted: TrustedOriginEntry[] = [{ origin, methods: ['nip04'] }];
     for (const method of ['nip04_encrypt', 'nip04_decrypt'] as const) {
-      expect(evaluateConsent({ origin, method }, { trustedOrigins: [origin], policy })).toEqual({
+      expect(evaluateConsent({ origin, method }, { trustedOrigins: trusted, policy })).toEqual({
         decision: 'reject',
         reason: 'policy-deny',
       });

--- a/examples/svelte-app/src/utils/consent-gating.ts
+++ b/examples/svelte-app/src/utils/consent-gating.ts
@@ -1,5 +1,10 @@
 import type { ConsentRequest } from 'nosskey-iframe';
-import type { ConsentDecision, ConsentPolicy } from '../store/app-state.js';
+import type {
+  ConsentDecision,
+  ConsentPolicy,
+  PolicyKey,
+  TrustedOriginEntry,
+} from '../store/app-state.js';
 
 /** ダイアログ表示前の判定結果。 */
 export type ConsentEvaluation =
@@ -11,8 +16,15 @@ export type ConsentEvaluation =
  * メソッド名を `ConsentPolicy` のキーへマップする。
  * `nip44_encrypt` / `nip44_decrypt` は `nip44` に集約され、
  * `nip04_*` も同様。`signEvent` のみ単独。
+ *
+ * 全分岐を網羅。`NosskeyMethod` の union に新値が追加されたら
+ * `default` の `never` 代入で TS コンパイルエラーになる。
+ * これにより新メソッド追加時のサイレントなフォールスルーを防ぐ。
+ *
+ * 非 consent メソッド (`getPublicKey` / `getRelays`) はそもそも
+ * `onConsent` に到達しないが、防御的に throw する。
  */
-export function policyKeyFor(method: ConsentRequest['method']): keyof ConsentPolicy | null {
+export function policyKeyFor(method: ConsentRequest['method']): PolicyKey {
   switch (method) {
     case 'signEvent':
       return 'signEvent';
@@ -22,22 +34,27 @@ export function policyKeyFor(method: ConsentRequest['method']): keyof ConsentPol
     case 'nip04_encrypt':
     case 'nip04_decrypt':
       return 'nip04';
-    default:
-      return null;
+    case 'getPublicKey':
+    case 'getRelays':
+      throw new Error(`policyKeyFor called with non-consent method: ${method}`);
+    default: {
+      const exhaustive: never = method;
+      throw new Error(`Unhandled NosskeyMethod in policyKeyFor: ${String(exhaustive)}`);
+    }
   }
 }
 
 interface EvaluateContext {
-  trustedOrigins: readonly string[];
+  trustedOrigins: readonly TrustedOriginEntry[];
   policy: ConsentPolicy;
 }
 
 /**
  * 同意を求めるかどうかを副作用なく決定する。
  * 評価順は安全側優先:
- *   1. メソッドポリシーが `deny` → 即拒否
+ *   1. メソッドポリシーが `deny` → 即拒否（信頼済みオリジンより優先）
  *   2. メソッドポリシーが `always` → 即承認
- *   3. 信頼済みオリジン → 即承認
+ *   3. 信頼済みオリジン (該当メソッドが scope に含まれる) → 即承認
  *   4. それ以外 → ダイアログ表示
  */
 export function evaluateConsent(
@@ -45,13 +62,14 @@ export function evaluateConsent(
   context: EvaluateContext
 ): ConsentEvaluation {
   const key = policyKeyFor(request.method);
-  if (key) {
-    const decision: ConsentDecision = context.policy[key] ?? 'ask';
-    if (decision === 'deny') return { decision: 'reject', reason: 'policy-deny' };
-    if (decision === 'always') return { decision: 'approve', reason: 'policy-always' };
-  }
-  if (context.trustedOrigins.includes(request.origin)) {
-    return { decision: 'approve', reason: 'trusted-origin' };
-  }
+  const decision: ConsentDecision = context.policy[key] ?? 'ask';
+  if (decision === 'deny') return { decision: 'reject', reason: 'policy-deny' };
+  if (decision === 'always') return { decision: 'approve', reason: 'policy-always' };
+
+  const trusted = context.trustedOrigins.find(
+    (entry) => entry.origin === request.origin && entry.methods.includes(key)
+  );
+  if (trusted) return { decision: 'approve', reason: 'trusted-origin' };
+
   return { decision: 'ask' };
 }

--- a/examples/svelte-app/src/utils/consent-gating.ts
+++ b/examples/svelte-app/src/utils/consent-gating.ts
@@ -1,0 +1,57 @@
+import type { ConsentRequest } from 'nosskey-iframe';
+import type { ConsentDecision, ConsentPolicy } from '../store/app-state.js';
+
+/** ダイアログ表示前の判定結果。 */
+export type ConsentEvaluation =
+  | { decision: 'approve'; reason: 'policy-always' | 'trusted-origin' }
+  | { decision: 'reject'; reason: 'policy-deny' }
+  | { decision: 'ask' };
+
+/**
+ * メソッド名を `ConsentPolicy` のキーへマップする。
+ * `nip44_encrypt` / `nip44_decrypt` は `nip44` に集約され、
+ * `nip04_*` も同様。`signEvent` のみ単独。
+ */
+export function policyKeyFor(method: ConsentRequest['method']): keyof ConsentPolicy | null {
+  switch (method) {
+    case 'signEvent':
+      return 'signEvent';
+    case 'nip44_encrypt':
+    case 'nip44_decrypt':
+      return 'nip44';
+    case 'nip04_encrypt':
+    case 'nip04_decrypt':
+      return 'nip04';
+    default:
+      return null;
+  }
+}
+
+interface EvaluateContext {
+  trustedOrigins: readonly string[];
+  policy: ConsentPolicy;
+}
+
+/**
+ * 同意を求めるかどうかを副作用なく決定する。
+ * 評価順は安全側優先:
+ *   1. メソッドポリシーが `deny` → 即拒否
+ *   2. メソッドポリシーが `always` → 即承認
+ *   3. 信頼済みオリジン → 即承認
+ *   4. それ以外 → ダイアログ表示
+ */
+export function evaluateConsent(
+  request: Pick<ConsentRequest, 'origin' | 'method'>,
+  context: EvaluateContext
+): ConsentEvaluation {
+  const key = policyKeyFor(request.method);
+  if (key) {
+    const decision: ConsentDecision = context.policy[key] ?? 'ask';
+    if (decision === 'deny') return { decision: 'reject', reason: 'policy-deny' };
+    if (decision === 'always') return { decision: 'approve', reason: 'policy-always' };
+  }
+  if (context.trustedOrigins.includes(request.origin)) {
+    return { decision: 'approve', reason: 'trusted-origin' };
+  }
+  return { decision: 'ask' };
+}

--- a/examples/svelte-app/src/utils/event-kind-labels.ts
+++ b/examples/svelte-app/src/utils/event-kind-labels.ts
@@ -1,0 +1,44 @@
+/**
+ * NIP イベント kind 番号 → ユーザー可読ラベルへのマッピング。
+ * よく使われる kind のみを翻訳対象とし、未知の kind は数値そのまま返す。
+ * 翻訳は呼び出し元から `t` を受け取って解決する。
+ */
+
+export interface KindLabelMap {
+  textNote: string; // kind 1
+  follows: string; // kind 3
+  legacyDm: string; // kind 4 (NIP-04)
+  repost: string; // kind 6
+  reaction: string; // kind 7
+  channelMessage: string; // kind 42
+  giftWrap: string; // kind 1059
+  longForm: string; // kind 30023
+  unknown: string; // フォールバック (引数に kind 番号を埋め込まない)
+}
+
+/**
+ * kind 番号から人間可読ラベルを返す。`labels.unknown` 自体に番号は含まないため、
+ * 呼び出し元は通常 "<label> (kind:N)" のように整形する。
+ */
+export function kindLabel(kind: number, labels: KindLabelMap): string {
+  switch (kind) {
+    case 1:
+      return labels.textNote;
+    case 3:
+      return labels.follows;
+    case 4:
+      return labels.legacyDm;
+    case 6:
+      return labels.repost;
+    case 7:
+      return labels.reaction;
+    case 42:
+      return labels.channelMessage;
+    case 1059:
+      return labels.giftWrap;
+    case 30023:
+      return labels.longForm;
+    default:
+      return labels.unknown;
+  }
+}

--- a/examples/svelte-app/src/utils/event-kind-labels.ts
+++ b/examples/svelte-app/src/utils/event-kind-labels.ts
@@ -5,12 +5,15 @@
  */
 
 export interface KindLabelMap {
+  metadata: string; // kind 0 (NIP-01 profile)
   textNote: string; // kind 1
   follows: string; // kind 3
   legacyDm: string; // kind 4 (NIP-04)
   repost: string; // kind 6
   reaction: string; // kind 7
   channelMessage: string; // kind 42
+  rumor: string; // kind 13 (NIP-17 rumor)
+  seal: string; // kind 14 (NIP-17 seal)
   giftWrap: string; // kind 1059
   longForm: string; // kind 30023
   unknown: string; // フォールバック (引数に kind 番号を埋め込まない)
@@ -22,6 +25,8 @@ export interface KindLabelMap {
  */
 export function kindLabel(kind: number, labels: KindLabelMap): string {
   switch (kind) {
+    case 0:
+      return labels.metadata;
     case 1:
       return labels.textNote;
     case 3:
@@ -32,6 +37,10 @@ export function kindLabel(kind: number, labels: KindLabelMap): string {
       return labels.repost;
     case 7:
       return labels.reaction;
+    case 13:
+      return labels.rumor;
+    case 14:
+      return labels.seal;
     case 42:
       return labels.channelMessage;
     case 1059:


### PR DESCRIPTION
Implements three roadmap items so users can manage signing prompts more
sensibly: trust an origin once and skip future dialogs (2-A), set per-method
default behavior — ask / always / deny (2-B), and read what is being signed
without parsing raw JSON (6-A: kind labels, 100-char content preview, raw
event tucked behind a details disclosure).

https://claude.ai/code/session_01WMr7jriHi82W4SG5sh8bnY