### PR TITLE
fix(nosskey-sdk): include README and LICENSE in npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,8 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Copied at publish-time from repo root (see packages/nosskey-sdk prepublishOnly)
+/packages/nosskey-sdk/README.md
+/packages/nosskey-sdk/README.ja.md
+/packages/nosskey-sdk/LICENSE

--- a/packages/nosskey-sdk/package.json
+++ b/packages/nosskey-sdk/package.json
@@ -4,6 +4,8 @@
   "description": "SDK for Passkey-Derived Nostr Identity a.k.a. Nosskey",
   "files": [
     "dist",
+    "README.md",
+    "README.ja.md",
     "LICENSE"
   ],
   "type": "module",
@@ -38,7 +40,8 @@
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "prepublishOnly": "npm run build"
+    "copy-docs": "cp ../../README.md ../../README.ja.md ../../LICENSE .",
+    "prepublishOnly": "npm run copy-docs && npm run build"
   },
   "dependencies": {
     "@noble/ciphers": "^2.2.0",


### PR DESCRIPTION
Copy README.md, README.ja.md, and LICENSE from repo root into
packages/nosskey-sdk/ via prepublishOnly so they ship in the npm
tarball. Without this, npmjs.com renders an empty README.