### PR TITLE
feat(parent-sample): publish NIP-17 sealed DM (kind:1059 gift wrap)

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -6,7 +6,7 @@
 
 ## 実装関連
 - [ ] PWKのリレーへのバックアップを行うイベントの作成機能（リレーへのパブリッシュはSDKの責務外とする）
-- [ ] NIP-17 sealed DM (kind:14 + gift-wrap) サポート — 受け取った NIP-44 暗号文を kind:13 seal でラップし、ephemeral 鍵で kind:1059 gift-wrap 化する 3 段構成。SDK に「ランダム ephemeral 秘密鍵で署名する API」を追加する必要があり、現状の `signEvent`（登録済み鍵専用）とは別経路。NIP-04 (kind:4) 互換 DM 送信は `examples/parent-sample` のセクション 6 で動作確認可能なので、それで足りる用途は当面そちらを使う想定。
+- [ ] NIP-17 sealed DM (kind:14 + gift-wrap) サポート — 受け取った NIP-44 暗号文を kind:13 seal でラップし、ephemeral 鍵で kind:1059 gift-wrap 化する 3 段構成。SDK に「ランダム ephemeral 秘密鍵で署名する API」を追加する必要があり、現状の `signEvent`（登録済み鍵専用）とは別経路。**動作確認用の実装は `examples/parent-sample/src/nip17.ts` にあり、セクション 7 の "Send NIP-17 DM" で他クライアントとの受信検証が可能** (ブランチ `claude/nip44-iframe-sample-KnGuu`)。SDK 本体への昇格は再利用ニーズが出てから検討する。
 - [x] iframeでNosskeyを使用できるNosskey-iframe(仮)の作成 — 段階1〜4完了 (`nosskey-iframe` パッケージ: protocol / host / client)。ブランチ `claude/add-iframe-support-2tKuX`
 - [x] Nosskey-iframe(仮)の参照実装の作成 — 段階5〜7完了 (Svelteアプリの `#/iframe` ルート、ConsentDialog、Timeline/relay 機能削除、README 追記)。ブランチ `claude/continue-iframe-support-mCrAL`。段階8 (E2E 手動検証) は別途
 - [x] iframe を埋め込む親ページ側のサンプル実装 (`NosskeyIframeClient` を使った最小デモ) を `examples/parent-sample/` に追加

--- a/examples/parent-sample/README.md
+++ b/examples/parent-sample/README.md
@@ -24,7 +24,11 @@ host example (`svelte-app` on port 5173), exercising the cross-origin
    Encrypt and decrypt each prompt the consent dialog independently.
 7. **NIP-04 encrypt / decrypt** (legacy): same shape as NIP-44, with a
    deprecation warning. Useful for verifying interop with older clients.
-8. Surface `NosskeyIframeError.code` values such as `NO_KEY`,
+8. **NIP-17 sealed DM** (gift-wrapped kind:1059): builds a kind:14 rumor,
+   NIP-44 seals it as kind:13, NIP-44 wraps that as kind:1059 signed by an
+   ephemeral key, and publishes to a relay. Compatible clients (Amethyst,
+   0xchat, Coracle, Damus chat) decrypt it automatically.
+9. Surface `NosskeyIframeError.code` values such as `NO_KEY`,
    `USER_REJECTED`, `NOT_AUTHORIZED` in the log.
 
 ## Run locally
@@ -84,9 +88,35 @@ button that combines the steps above into one flow:
    `tags: [["p", your_pubkey]]` and decrypt it with their own NIP-04
    implementation.
 
-> NIP-04 is the legacy DM kind. NIP-17 (sealed DM via NIP-44 + gift-wrap)
-> is the modern recommendation but requires SDK-side gift-wrap support;
-> see `docs/todo.md` for the planned work.
+### Sending a NIP-17 sealed DM (recommended)
+
+Section **7. NIP-17 sealed DM** publishes a gift-wrapped kind:1059 event
+that compatible clients (Amethyst, 0xchat, Coracle, Damus chat) recognize
+as a private message. Steps:
+
+1. Click **Use my pubkey** to self-encrypt for one-account verification, or
+   paste any recipient hex pubkey.
+2. Type the message.
+3. Confirm the Relay URL in section 4 points at a relay both ends use
+   (default `wss://relay.damus.io`).
+4. Click **Send NIP-17 DM**. Two consent dialogs appear:
+   - NIP-44 encrypt for the kind:13 seal (shows the rumor JSON preview).
+   - signEvent for the kind:13 seal.
+5. The relay's `OK` ack appears in the log along with the gift wrap event
+   id and the ephemeral pubkey.
+6. Open Amethyst (Android), 0xchat (web/mobile), or any other NIP-17 client
+   signed in with the recipient npub and verify the DM arrives in the inbox
+   with the correct plaintext.
+
+> The sample sends a single gift wrap addressed to the peer. NIP-17 also
+> lets the sender wrap a copy to themselves to keep an outbox visible
+> across their own devices; that's intentionally skipped here — verifying
+> reception in another client only needs the recipient copy.
+
+The NIP-17 helper (`src/nip17.ts`) is self-contained and only depends on
+`@noble/curves` for the ephemeral keypair and the SDK's exported
+`nip44Encrypt` for the gift-wrap layer; the seal layer goes through the
+iframe so the user's Nosskey never leaves the host origin.
 
 ## Browser support
 

--- a/examples/parent-sample/package.json
+++ b/examples/parent-sample/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "lint": "cd ../.. && biome check ./examples/parent-sample/src",
     "format": "cd ../.. && biome check --write ./examples/parent-sample/src",
     "format:check": "cd ../.. && biome check ./examples/parent-sample/src"

--- a/examples/parent-sample/package.json
+++ b/examples/parent-sample/package.json
@@ -12,6 +12,8 @@
     "format:check": "cd ../.. && biome check ./examples/parent-sample/src"
   },
   "dependencies": {
+    "@noble/curves": "^2.2.0",
+    "@noble/hashes": "^2.2.0",
     "nosskey-iframe": "*",
     "nosskey-sdk": "*"
   },

--- a/examples/parent-sample/src/main.ts
+++ b/examples/parent-sample/src/main.ts
@@ -1,5 +1,6 @@
 import { NosskeyIframeClient, NosskeyIframeError } from 'nosskey-iframe';
 import type { NostrEvent } from 'nosskey-sdk';
+import { sendNip17Dm } from './nip17.js';
 
 interface NostrProvider {
   getPublicKey(): Promise<string>;
@@ -165,6 +166,28 @@ app.innerHTML = `
   </section>
 
   <section>
+    <h2>7. NIP-17 sealed DM (gift-wrapped kind:1059)</h2>
+    <p class="hint">
+      Standards-compliant DM path: builds a kind:14 rumor, NIP-44 seals it
+      into a kind:13, then NIP-44 wraps that into a kind:1059 signed by a
+      throwaway ephemeral key. Compatible clients (Amethyst, 0xchat,
+      Coracle, Damus chat) listen for kind:1059 and decrypt automatically.
+      Two consent dialogs appear (NIP-44 encrypt for the seal, then sign
+      kind:13). The Relay URL is shared with section 4.
+    </p>
+    <label for="nip17-peer">Peer public key (hex, 64 chars)</label>
+    <div class="row">
+      <input id="nip17-peer" type="text" placeholder="64 hex characters" />
+      <button id="nip17-use-self" class="secondary" disabled>Use my pubkey</button>
+    </div>
+    <label for="nip17-plaintext" style="margin-top:12px;">Message</label>
+    <textarea id="nip17-plaintext">hello, NIP-17 🎁</textarea>
+    <div class="row">
+      <button id="nip17-send-dm" disabled>Send NIP-17 DM (kind:1059 → relay)</button>
+    </div>
+  </section>
+
+  <section>
     <h2>Log</h2>
     <pre id="log"></pre>
   </section>
@@ -203,6 +226,10 @@ const ui = {
   nip04Ciphertext: requireEl<HTMLTextAreaElement>('#nip04-ciphertext'),
   nip04Decrypted: requireEl<HTMLPreElement>('#nip04-decrypted'),
   nip04SendDm: requireEl<HTMLButtonElement>('#nip04-send-dm'),
+  nip17Peer: requireEl<HTMLInputElement>('#nip17-peer'),
+  nip17UseSelf: requireEl<HTMLButtonElement>('#nip17-use-self'),
+  nip17Plaintext: requireEl<HTMLTextAreaElement>('#nip17-plaintext'),
+  nip17SendDm: requireEl<HTMLButtonElement>('#nip17-send-dm'),
   status: requireEl<HTMLSpanElement>('#status'),
   log: requireEl<HTMLPreElement>('#log'),
 };
@@ -234,6 +261,8 @@ function setConnectedUI(connected: boolean): void {
   ui.nip04Encrypt.disabled = !connected;
   ui.nip04Decrypt.disabled = !connected;
   ui.nip04SendDm.disabled = !connected;
+  ui.nip17UseSelf.disabled = !connected;
+  ui.nip17SendDm.disabled = !connected;
 }
 
 function formatError(err: unknown): string {
@@ -566,6 +595,47 @@ async function nip04SendDm(): Promise<void> {
   }
 }
 
+async function nip17SendDm(): Promise<void> {
+  if (!window.nostr) return;
+  const nostr = window.nostr;
+  const peer = ui.nip17Peer.value.trim();
+  const relayUrl = ui.relayUrl.value.trim();
+  const plaintext = ui.nip17Plaintext.value;
+  if (!peer) {
+    log('NIP-17 DM aborted: peer pubkey is empty.');
+    return;
+  }
+  if (!relayUrl) {
+    log('NIP-17 DM aborted: relay URL (section 4) is empty.');
+    return;
+  }
+
+  log('NIP-17 DM: resolving sender pubkey…');
+  let senderPubkey: string;
+  try {
+    senderPubkey = await nostr.getPublicKey();
+  } catch (err) {
+    log(`NIP-17 DM getPublicKey failed: ${formatError(err)}`);
+    return;
+  }
+
+  log(`NIP-17 DM: sealing rumor for ${peer.slice(0, 8)}… (consent dialog x2)`);
+  try {
+    const result = await sendNip17Dm({
+      senderPubkey,
+      peerPubkey: peer,
+      plaintext,
+      sealEncrypt: (p, plain) => nostr.nip44.encrypt(p, plain),
+      signSeal: (draft) => nostr.signEvent(draft),
+      publish: (event) => publishEvent(relayUrl, event),
+    });
+    log(`NIP-17 DM: gift wrap id ${result.giftWrap.id ?? '(missing id)'}`);
+    log(`NIP-17 DM: ephemeral pubkey ${result.ephemeralPubkey}`);
+  } catch (err) {
+    log(`NIP-17 DM failed: ${formatError(err)}`);
+  }
+}
+
 ui.connect.addEventListener('click', () => {
   void connect();
 });
@@ -599,6 +669,12 @@ ui.nip04Decrypt.addEventListener('click', () => {
 });
 ui.nip04SendDm.addEventListener('click', () => {
   void nip04SendDm();
+});
+ui.nip17UseSelf.addEventListener('click', () => {
+  void fillSelfPubkey(ui.nip17Peer, 'NIP-17');
+});
+ui.nip17SendDm.addEventListener('click', () => {
+  void nip17SendDm();
 });
 
 log(

--- a/examples/parent-sample/src/nip17.spec.ts
+++ b/examples/parent-sample/src/nip17.spec.ts
@@ -1,0 +1,237 @@
+import { schnorr } from '@noble/curves/secp256k1.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { type NostrEvent, bytesToHex, hexToBytes, nip44Decrypt, nip44Encrypt } from 'nosskey-sdk';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildRumor, jitteredTimestamp, sendNip17Dm, signEphemeralEvent } from './nip17.js';
+
+function freshKeypair(): { secret: Uint8Array; pubkey: string } {
+  const secret = schnorr.utils.randomSecretKey();
+  const pubkey = bytesToHex(schnorr.getPublicKey(secret));
+  return { secret, pubkey };
+}
+
+function canonicalEventId(ev: NostrEvent): string {
+  const serialized = JSON.stringify([
+    0,
+    ev.pubkey,
+    ev.created_at,
+    ev.kind,
+    ev.tags ?? [],
+    ev.content,
+  ]);
+  return bytesToHex(sha256(new TextEncoder().encode(serialized)));
+}
+
+describe('jitteredTimestamp', () => {
+  it('returns a value in [now - 2 days, now]', () => {
+    const now = 1_700_000_000;
+    const twoDays = 2 * 24 * 60 * 60;
+    for (let i = 0; i < 50; i++) {
+      const ts = jitteredTimestamp(now);
+      expect(ts).toBeLessThanOrEqual(now);
+      expect(ts).toBeGreaterThanOrEqual(now - twoDays);
+    }
+  });
+
+  it('defaults to a near-current timestamp when called without an argument', () => {
+    const before = Math.floor(Date.now() / 1000);
+    const ts = jitteredTimestamp();
+    const after = Math.floor(Date.now() / 1000);
+    expect(ts).toBeLessThanOrEqual(after);
+    expect(ts).toBeGreaterThanOrEqual(before - 2 * 24 * 60 * 60);
+  });
+});
+
+describe('buildRumor', () => {
+  it('produces a kind:14 unsigned event with sender pubkey and a single p tag', () => {
+    const sender = freshKeypair().pubkey;
+    const peer = freshKeypair().pubkey;
+    const rumor = buildRumor(sender, peer, 'hello');
+
+    expect(rumor.kind).toBe(14);
+    expect(rumor.pubkey).toBe(sender);
+    expect(rumor.tags).toEqual([['p', peer]]);
+    expect(rumor.content).toBe('hello');
+    expect(rumor.id).toMatch(/^[0-9a-f]{64}$/);
+    // Rumors are NEVER signed per NIP-59.
+    expect(rumor.sig).toBeUndefined();
+  });
+
+  it('computes the id from the canonical NIP-01 serialization', () => {
+    const sender = freshKeypair().pubkey;
+    const peer = freshKeypair().pubkey;
+    const rumor = buildRumor(sender, peer, 'canonical check');
+
+    expect(rumor.id).toBe(canonicalEventId(rumor));
+  });
+
+  it('preserves non-ASCII content unescaped (NIP-01 §id requires raw UTF-8)', () => {
+    const { pubkey: sender } = freshKeypair();
+    const { pubkey: peer } = freshKeypair();
+    const content = 'hello, NIP-17 🎁';
+    const rumor = buildRumor(sender, peer, content);
+
+    // Recompute the id using JSON.stringify directly — it must match the
+    // helper's output, which proves we're not double-escaping the emoji.
+    expect(rumor.id).toBe(canonicalEventId(rumor));
+    expect(rumor.content).toBe(content);
+  });
+});
+
+describe('signEphemeralEvent', () => {
+  it('fills pubkey and id, and produces a verifying schnorr signature', () => {
+    const { secret, pubkey } = freshKeypair();
+    const draft = {
+      kind: 1059,
+      created_at: 1_700_000_000,
+      tags: [['p', freshKeypair().pubkey]],
+      content: 'gift wrap content',
+    };
+
+    const signed = signEphemeralEvent(draft, secret);
+
+    expect(signed.kind).toBe(1059);
+    expect(signed.created_at).toBe(draft.created_at);
+    expect(signed.tags).toEqual(draft.tags);
+    expect(signed.content).toBe(draft.content);
+    expect(signed.pubkey).toBe(pubkey);
+    expect(signed.id).toBe(canonicalEventId(signed));
+    expect(signed.sig).toMatch(/^[0-9a-f]{128}$/);
+
+    // BIP340 verification: sig must validate against (id, pubkey).
+    expect(
+      schnorr.verify(
+        hexToBytes(signed.sig as string),
+        hexToBytes(signed.id as string),
+        hexToBytes(pubkey)
+      )
+    ).toBe(true);
+  });
+
+  it('produces signatures bound to the event id (mutated content fails verification)', () => {
+    const { secret, pubkey } = freshKeypair();
+    const signed = signEphemeralEvent(
+      { kind: 1, created_at: 0, tags: [], content: 'original' },
+      secret
+    );
+
+    const tamperedId = canonicalEventId({ ...signed, content: 'tampered' } as NostrEvent);
+    expect(tamperedId).not.toBe(signed.id);
+    expect(
+      schnorr.verify(hexToBytes(signed.sig as string), hexToBytes(tamperedId), hexToBytes(pubkey))
+    ).toBe(false);
+  });
+});
+
+describe('sendNip17Dm', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('orchestrates rumor → seal → gift wrap and decrypts back to the rumor', async () => {
+    const sender = freshKeypair();
+    const recipient = freshKeypair();
+    const plaintext = 'hello, NIP-17 🎁';
+
+    // The seal layer normally goes through the iframe (NIP-44 with the
+    // user's Nosskey + signEvent). Here we satisfy those callbacks with the
+    // sender's plain key so the test can decrypt the seal end-to-end.
+    const sealEncrypt = vi.fn(async (peer: string, plain: string) =>
+      nip44Encrypt(plain, sender.secret, peer)
+    );
+    const signSeal = vi.fn(async (draft: NostrEvent) => {
+      const filled = { ...draft, pubkey: sender.pubkey };
+      const id = canonicalEventId(filled);
+      const sig = bytesToHex(schnorr.sign(hexToBytes(id), sender.secret));
+      return { ...filled, id, sig };
+    });
+    const publish = vi.fn(async (_event: NostrEvent) => undefined);
+
+    const result = await sendNip17Dm({
+      senderPubkey: sender.pubkey,
+      peerPubkey: recipient.pubkey,
+      plaintext,
+      sealEncrypt,
+      signSeal,
+      publish,
+    });
+
+    // sealEncrypt was called with the recipient pubkey and the rumor JSON.
+    expect(sealEncrypt).toHaveBeenCalledTimes(1);
+    const [encryptedPeer, encryptedPlain] = sealEncrypt.mock.calls[0];
+    expect(encryptedPeer).toBe(recipient.pubkey);
+    const rumorParsed = JSON.parse(encryptedPlain) as NostrEvent;
+    expect(rumorParsed.kind).toBe(14);
+    expect(rumorParsed.pubkey).toBe(sender.pubkey);
+    expect(rumorParsed.tags).toEqual([['p', recipient.pubkey]]);
+    expect(rumorParsed.content).toBe(plaintext);
+    expect(rumorParsed.sig).toBeUndefined();
+
+    // signSeal was called with a kind:13 draft, empty tags, jittered ts.
+    expect(signSeal).toHaveBeenCalledTimes(1);
+    const sealDraft = signSeal.mock.calls[0][0];
+    const now = Math.floor(Date.now() / 1000);
+    expect(sealDraft.kind).toBe(13);
+    expect(sealDraft.tags).toEqual([]);
+    expect(sealDraft.content).toBe(await sealEncrypt.mock.results[0].value);
+    expect(sealDraft.created_at).toBeLessThanOrEqual(now + 1);
+    expect(sealDraft.created_at).toBeGreaterThanOrEqual(now - 2 * 24 * 60 * 60);
+
+    // publish was called with the gift wrap returned in result.
+    expect(publish).toHaveBeenCalledTimes(1);
+    const published = publish.mock.calls[0][0];
+    expect(published).toBe(result.giftWrap);
+    expect(published.kind).toBe(1059);
+    expect(published.tags).toEqual([['p', recipient.pubkey]]);
+    expect(published.pubkey).toBe(result.ephemeralPubkey);
+    expect(published.created_at).toBeLessThanOrEqual(now + 1);
+    expect(published.created_at).toBeGreaterThanOrEqual(now - 2 * 24 * 60 * 60);
+
+    // The gift wrap signature verifies against the ephemeral pubkey.
+    expect(
+      schnorr.verify(
+        hexToBytes(published.sig as string),
+        hexToBytes(published.id as string),
+        hexToBytes(result.ephemeralPubkey)
+      )
+    ).toBe(true);
+
+    // Recipient-side decryption: peel the gift wrap, then the seal, then
+    // recover the original rumor with the original plaintext.
+    const sealJson = nip44Decrypt(published.content, recipient.secret, result.ephemeralPubkey);
+    const seal = JSON.parse(sealJson) as NostrEvent;
+    expect(seal.kind).toBe(13);
+    expect(seal.pubkey).toBe(sender.pubkey);
+
+    const rumorJson = nip44Decrypt(seal.content, recipient.secret, sender.pubkey);
+    const recoveredRumor = JSON.parse(rumorJson) as NostrEvent;
+    expect(recoveredRumor.kind).toBe(14);
+    expect(recoveredRumor.pubkey).toBe(sender.pubkey);
+    expect(recoveredRumor.content).toBe(plaintext);
+    expect(recoveredRumor.tags).toEqual([['p', recipient.pubkey]]);
+  });
+
+  it('propagates seal-encryption failure without calling signSeal or publish', async () => {
+    const sender = freshKeypair();
+    const recipient = freshKeypair();
+    const sealEncrypt = vi.fn(async () => {
+      throw new Error('user rejected');
+    });
+    const signSeal = vi.fn();
+    const publish = vi.fn();
+
+    await expect(
+      sendNip17Dm({
+        senderPubkey: sender.pubkey,
+        peerPubkey: recipient.pubkey,
+        plaintext: 'x',
+        sealEncrypt,
+        signSeal,
+        publish,
+      })
+    ).rejects.toThrow('user rejected');
+
+    expect(signSeal).not.toHaveBeenCalled();
+    expect(publish).not.toHaveBeenCalled();
+  });
+});

--- a/examples/parent-sample/src/nip17.ts
+++ b/examples/parent-sample/src/nip17.ts
@@ -1,0 +1,141 @@
+/**
+ * NIP-17 sealed direct message helpers, scoped to the parent-sample app.
+ *
+ * Spec:
+ * - https://github.com/nostr-protocol/nips/blob/master/17.md
+ * - https://github.com/nostr-protocol/nips/blob/master/59.md (gift wrap)
+ *
+ * Three-layer construction per send:
+ *   kind:14  rumor       — chat message, NEVER signed (no `sig`)
+ *   kind:13  seal        — NIP-44 encrypts the rumor JSON, signed by sender
+ *   kind:1059 gift wrap  — NIP-44 encrypts the seal JSON with an EPHEMERAL
+ *                          keypair, signed by that ephemeral key
+ *
+ * Only the seal step needs the user's Nosskey (NIP-44 encrypt + signEvent),
+ * so it is delegated to callbacks the caller wires up against the iframe
+ * client. The gift-wrap step uses a throwaway secp256k1 keypair generated
+ * locally with `@noble/curves`.
+ */
+import { schnorr } from '@noble/curves/secp256k1.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { type NostrEvent, bytesToHex, hexToBytes, nip44Encrypt } from 'nosskey-sdk';
+
+const KIND_CHAT_MESSAGE = 14;
+const KIND_SEAL = 13;
+const KIND_GIFT_WRAP = 1059;
+
+/** NIP-59 §3: jitter `created_at` up to two days into the past. */
+const TWO_DAYS_SECONDS = 2 * 24 * 60 * 60;
+
+/** Random `created_at` between `now - TWO_DAYS_SECONDS` and `now`. */
+export function jitteredTimestamp(now = Math.floor(Date.now() / 1000)): number {
+  return now - Math.floor(Math.random() * TWO_DAYS_SECONDS);
+}
+
+interface CanonicalDraft {
+  pubkey: string;
+  created_at: number;
+  kind: number;
+  tags: string[][];
+  content: string;
+}
+
+/** NIP-01 event id: sha256(JSON([0, pubkey, created_at, kind, tags, content])). */
+function computeEventId(draft: CanonicalDraft): string {
+  const serialized = JSON.stringify([
+    0,
+    draft.pubkey,
+    draft.created_at,
+    draft.kind,
+    draft.tags,
+    draft.content,
+  ]);
+  return bytesToHex(sha256(new TextEncoder().encode(serialized)));
+}
+
+/**
+ * Build kind:14 chat-message rumor. Rumors carry an `id` for the seal layer
+ * to reference but are deliberately left unsigned.
+ */
+export function buildRumor(senderPubkey: string, peerPubkey: string, content: string): NostrEvent {
+  const draft: CanonicalDraft = {
+    pubkey: senderPubkey,
+    created_at: Math.floor(Date.now() / 1000),
+    kind: KIND_CHAT_MESSAGE,
+    tags: [['p', peerPubkey]],
+    content,
+  };
+  return { ...draft, id: computeEventId(draft) };
+}
+
+/**
+ * Schnorr-sign a draft event with the given ephemeral secret. Used for the
+ * kind:1059 gift wrap, whose pubkey is intentionally unrelated to the
+ * sender's Nosskey.
+ */
+export function signEphemeralEvent(
+  draft: { kind: number; created_at: number; tags: string[][]; content: string },
+  ephemeralSecret: Uint8Array
+): NostrEvent {
+  const pubkey = bytesToHex(schnorr.getPublicKey(ephemeralSecret));
+  const id = computeEventId({ ...draft, pubkey });
+  const sig = bytesToHex(schnorr.sign(hexToBytes(id), ephemeralSecret));
+  return { ...draft, pubkey, id, sig };
+}
+
+export interface SendNip17DmInputs {
+  senderPubkey: string;
+  peerPubkey: string;
+  plaintext: string;
+  /** NIP-44 encrypt with the user's Nosskey (typically iframe nip44.encrypt). */
+  sealEncrypt: (peer: string, plain: string) => Promise<string>;
+  /** Sign a kind:13 draft with the user's Nosskey (typically iframe signEvent). */
+  signSeal: (draft: NostrEvent) => Promise<NostrEvent>;
+  /** Publish the finalized kind:1059 to a relay. */
+  publish: (event: NostrEvent) => Promise<void>;
+}
+
+export interface Nip17SendResult {
+  giftWrap: NostrEvent;
+  ephemeralPubkey: string;
+}
+
+/**
+ * Build and publish a NIP-17 sealed DM addressed to `peerPubkey`.
+ *
+ * Sends a single gift wrap to the peer. NIP-17 also lets a sender wrap a
+ * copy to themselves to keep an outbox; that's intentionally skipped here —
+ * verifying receipt in another client only requires the recipient copy.
+ */
+export async function sendNip17Dm(inputs: SendNip17DmInputs): Promise<Nip17SendResult> {
+  const { senderPubkey, peerPubkey, plaintext, sealEncrypt, signSeal, publish } = inputs;
+
+  const rumor = buildRumor(senderPubkey, peerPubkey, plaintext);
+
+  const sealCiphertext = await sealEncrypt(peerPubkey, JSON.stringify(rumor));
+  const seal = await signSeal({
+    kind: KIND_SEAL,
+    content: sealCiphertext,
+    tags: [],
+    created_at: jitteredTimestamp(),
+  });
+
+  const ephemeralSecret = schnorr.utils.randomSecretKey();
+  const ephemeralPubkey = bytesToHex(schnorr.getPublicKey(ephemeralSecret));
+
+  const wrapCiphertext = nip44Encrypt(JSON.stringify(seal), ephemeralSecret, peerPubkey);
+
+  const giftWrap = signEphemeralEvent(
+    {
+      kind: KIND_GIFT_WRAP,
+      content: wrapCiphertext,
+      tags: [['p', peerPubkey]],
+      created_at: jitteredTimestamp(),
+    },
+    ephemeralSecret
+  );
+
+  await publish(giftWrap);
+
+  return { giftWrap, ephemeralPubkey };
+}

--- a/examples/parent-sample/tsconfig.json
+++ b/examples/parent-sample/tsconfig.json
@@ -16,5 +16,5 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "vite.config.ts", "vitest.config.ts"]
 }

--- a/examples/parent-sample/vitest.config.ts
+++ b/examples/parent-sample/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.{test,spec}.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.{test,spec}.ts', 'src/main.ts'],
+      reportOnFailure: true,
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,8 @@
     "examples/parent-sample": {
       "version": "0.0.0",
       "dependencies": {
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
         "nosskey-iframe": "*",
         "nosskey-sdk": "*"
       },


### PR DESCRIPTION
Verifies NIP-44 end-to-end through the iframe by building kind:14 →
kind:13 (NIP-44 seal via iframe) → kind:1059 (NIP-44 wrap with an
ephemeral key signed locally) and publishing to a relay, so compatible
clients (Amethyst, 0xchat, Coracle) can receive it.

https://claude.ai/code/session_01GsubT756W6RSoX242jDJ2d