### PR TITLE
fix(svelte-app): run Storage Access before hasKeyInfo() shortcut

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,6 +5,7 @@
 - [ ] 他のNostrライブラリとの統合例をドキュメントに追加
 
 ## 実装関連
+- [ ] `NosskeyManager.setStorageOptions({ storage })` で storage 参照を差し替えても `#currentKeyInfo` in-memory cache が invalidate されない。iframe 経由で SAA grant 適用後に partitioned localStorage 由来の旧 key info が first-party storage の鍵として誤認されるエッジケースを生む（PR #45 で表面化、退行は無いが本質的には SDK 側で塞ぐべき）。storage 差し替え時に cache をクリアして再読込するか、`applyStorageGrant` 相当が明示的に呼べる API を提供する。
 - [ ] PWKのリレーへのバックアップを行うイベントの作成機能（リレーへのパブリッシュはSDKの責務外とする）
 - [ ] NIP-17 sealed DM (kind:14 + gift-wrap) サポート — 受け取った NIP-44 暗号文を kind:13 seal でラップし、ephemeral 鍵で kind:1059 gift-wrap 化する 3 段構成。SDK に「ランダム ephemeral 秘密鍵で署名する API」を追加する必要があり、現状の `signEvent`（登録済み鍵専用）とは別経路。**動作確認用の実装は `examples/parent-sample/src/nip17.ts` にあり、セクション 7 の "Send NIP-17 DM" で他クライアントとの受信検証が可能** (ブランチ `claude/nip44-iframe-sample-KnGuu`)。SDK 本体への昇格は再利用ニーズが出てから検討する。
 - [x] iframeでNosskeyを使用できるNosskey-iframe(仮)の作成 — 段階1〜4完了 (`nosskey-iframe` パッケージ: protocol / host / client)。ブランチ `claude/add-iframe-support-2tKuX`

--- a/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
+++ b/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
@@ -49,10 +49,9 @@ async function detectInitialState(): Promise<void> {
   // top-level × iframe origin pair resolve without a user gesture, so a
   // returning user skips the dialog. First visits and expired grants reject
   // with NotAllowedError, and we fall back to the manual button.
-  // MUST run before any hasKeyInfo() shortcut — Chromium keeps
-  // window.localStorage partitioned even after the grant, so applyStorageGrant()
-  // must thread handle.localStorage into the SDK or first-party state
-  // (e.g. relays saved via the top-level Settings UI) stays invisible.
+  //
+  // Do NOT short-circuit on hasKeyInfo() above this point — see
+  // applyStorageGrant() for why the SAA call must run first.
   let handle: StorageAccessHandle | null;
   try {
     handle = await callRequestStorageAccess();

--- a/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
+++ b/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
@@ -35,11 +35,12 @@ function postVisibility(visible: boolean): void {
 
 async function detectInitialState(): Promise<void> {
   const manager = getNosskeyManager();
-  if (manager.hasKeyInfo()) {
-    uiState = 'running';
-    return;
-  }
   if (typeof document.requestStorageAccess !== 'function') {
+    // No Storage Access API: partitioned localStorage is all we can see.
+    if (manager.hasKeyInfo()) {
+      uiState = 'running';
+      return;
+    }
     uiState = 'unsupported';
     postVisibility(true);
     return;
@@ -48,11 +49,22 @@ async function detectInitialState(): Promise<void> {
   // top-level × iframe origin pair resolve without a user gesture, so a
   // returning user skips the dialog. First visits and expired grants reject
   // with NotAllowedError, and we fall back to the manual button.
+  // MUST run before any hasKeyInfo() shortcut — Chromium keeps
+  // window.localStorage partitioned even after the grant, so applyStorageGrant()
+  // must thread handle.localStorage into the SDK or first-party state
+  // (e.g. relays saved via the top-level Settings UI) stays invisible.
   let handle: StorageAccessHandle | null;
   try {
     handle = await callRequestStorageAccess();
   } catch (err) {
     if (err instanceof DOMException && err.name === 'NotAllowedError') {
+      // No silent grant. Fall back to partitioned key info if available so the
+      // user can still sign with their cached key; first-party data (relays,
+      // etc.) stays unreachable until they explicitly grant access.
+      if (manager.hasKeyInfo()) {
+        uiState = 'running';
+        return;
+      }
       uiState = 'partitioned';
       postVisibility(true);
       return;

--- a/examples/svelte-app/src/iframe-mode.ts
+++ b/examples/svelte-app/src/iframe-mode.ts
@@ -2,7 +2,7 @@ import type { ConsentRequest, NosskeyIframeHostOptions } from 'nosskey-iframe';
 import { NosskeyIframeHost } from 'nosskey-iframe';
 import { get, writable } from 'svelte/store';
 import { getNosskeyManager } from './services/nosskey-manager.service.js';
-import { RELAYS_STORAGE_KEY, loadRelays } from './services/relays-store.js';
+import { loadRelays } from './services/relays-store.js';
 import { consentPolicy, incrementDenyCount, trustedOrigins } from './store/app-state.js';
 import { evaluateConsent, policyKeyFor } from './utils/consent-gating.js';
 
@@ -106,26 +106,7 @@ export function startIframeHost(overrides: Partial<NosskeyIframeHostOptions> = {
     // Read through the SDK's storage handle so we hit first-party storage
     // when the user has granted access (Chromium keeps window.localStorage
     // partitioned even after the grant — only the handle points at it).
-    onGetRelays: async () => {
-      // DIAG (一時): A/C/D 切り分け用ログ。原因確定後に必ず元の 1 行
-      //   `onGetRelays: async () => loadRelays(manager.getStorageOptions().storage),`
-      // に戻すこと。
-      const storage = manager.getStorageOptions().storage;
-      const fallback = typeof window !== 'undefined' ? window.localStorage : null;
-      const handleRaw = storage?.getItem(RELAYS_STORAGE_KEY) ?? null;
-      const fallbackRaw = fallback?.getItem(RELAYS_STORAGE_KEY) ?? null;
-      const result = loadRelays(storage);
-      console.log('[nosskey][onGetRelays][diag]', {
-        hasHandle: !!storage,
-        handleSameAsWindow: storage === fallback,
-        handleRawLength: handleRaw?.length ?? 0,
-        handleRawSnippet: handleRaw ? handleRaw.slice(0, 200) : null,
-        windowRawLength: fallbackRaw?.length ?? 0,
-        windowRawSnippet: fallbackRaw ? fallbackRaw.slice(0, 200) : null,
-        resultKeys: Object.keys(result),
-      });
-      return result;
-    },
+    onGetRelays: async () => loadRelays(manager.getStorageOptions().storage),
     ...overrides,
   });
   host.start();


### PR DESCRIPTION
## Summary

iframe (`nosskey.app`) の `onGetRelays` が、親 (`parent-sample`) で設定したリレーを返さず `{}` になる問題の本丸 fix。診断ログ用 PR #44 で得たフィールドログ (`hasHandle: false`) から原因を確定した上での修正。

### 根本原因

`IframeHostScreen.detectInitialState()` の冒頭に「partitioned localStorage に key_info があれば SAA をスキップして `uiState='running'`」という早期 return があり、リピーターは **`requestStorageAccess()` を一度も呼ばないまま** 起動していた。SAA grant が SDK にスレッドされないため、`manager.getStorageOptions().storage` は partitioned `window.localStorage` のままで、`onGetRelays` (first-party storage を読む) には relays が見えない状態だった。

`getPublicKey` / `signEvent` は partitioned 側の key で動くため、症状が relays 取得限定で発覚しにくかった。

### 修正

`detectInitialState()` のフローを `SAA support 判定 → silent grant 試行 → applyStorageGrant` の順に組み直し、partitioned `hasKeyInfo()` 早期 return を廃止。SAA 非対応ブラウザと `NotAllowedError` (初回 / 期限切れ) は従来通り fallback 動線を維持。

同時に PR #44 で入れた一時診断ログ (`[nosskey][onGetRelays][diag]`) を `iframe-mode.ts` から撤去。

### コミット

| sha | 内容 |
|---|---|
| `d98c06f` | fix: SAA を `hasKeyInfo()` チェックより前に実行 + 診断ログ撤去 |
| `8f8c13f` | docs: コメントを「Do NOT add early-return」形式に整理 |

### skeptical-reviewer 結果

ローカルで `skeptical-reviewer` サブエージェントを実行済み。**🔴 要対応 0 件 / リリース可** の判定。

🟡 残課題（本 PR 外、follow-up 推奨）: SDK の `setStorageOptions()` が `#currentKeyInfo` in-memory cache を invalidate しないため、`startIframeHost()` → `detectInitialState()` の順序で partitioned 由来の key info が first-party storage の鍵として誤認されるエッジケースがある。今回の修正では退行しないが本質的には SDK 側で塞ぐべき。

## Test plan

- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm run test:coverage` (287 passing)
- [x] `npm run check -w svelte-app` (0 errors / 0 warnings)
- [ ] 実機: parent-sample → iframe で `Get relays` がリレー 3 件返ること（初回はダイアログ後、2 回目以降は silent grant でダイアログ無し）
- [ ] 実機: `getPublicKey` / `signEvent` の既存動作が壊れていないこと

https://claude.ai/code/session_01LuqNCVWroaWKxrzvcHberX

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuqNCVWroaWKxrzvcHberX)_