### PR TITLE
Revert &quot;fix(svelte-app): run Storage Access before hasKeyInfo() shortcut (#45)&quot;

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,7 +5,6 @@
 - [ ] 他のNostrライブラリとの統合例をドキュメントに追加
 
 ## 実装関連
-- [ ] `NosskeyManager.setStorageOptions({ storage })` で storage 参照を差し替えても `#currentKeyInfo` in-memory cache が invalidate されない。iframe 経由で SAA grant 適用後に partitioned localStorage 由来の旧 key info が first-party storage の鍵として誤認されるエッジケースを生む（PR #45 で表面化、退行は無いが本質的には SDK 側で塞ぐべき）。storage 差し替え時に cache をクリアして再読込するか、`applyStorageGrant` 相当が明示的に呼べる API を提供する。
 - [ ] PWKのリレーへのバックアップを行うイベントの作成機能（リレーへのパブリッシュはSDKの責務外とする）
 - [ ] NIP-17 sealed DM (kind:14 + gift-wrap) サポート — 受け取った NIP-44 暗号文を kind:13 seal でラップし、ephemeral 鍵で kind:1059 gift-wrap 化する 3 段構成。SDK に「ランダム ephemeral 秘密鍵で署名する API」を追加する必要があり、現状の `signEvent`（登録済み鍵専用）とは別経路。**動作確認用の実装は `examples/parent-sample/src/nip17.ts` にあり、セクション 7 の "Send NIP-17 DM" で他クライアントとの受信検証が可能** (ブランチ `claude/nip44-iframe-sample-KnGuu`)。SDK 本体への昇格は再利用ニーズが出てから検討する。
 - [x] iframeでNosskeyを使用できるNosskey-iframe(仮)の作成 — 段階1〜4完了 (`nosskey-iframe` パッケージ: protocol / host / client)。ブランチ `claude/add-iframe-support-2tKuX`

--- a/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
+++ b/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
@@ -35,12 +35,11 @@ function postVisibility(visible: boolean): void {
 
 async function detectInitialState(): Promise<void> {
   const manager = getNosskeyManager();
+  if (manager.hasKeyInfo()) {
+    uiState = 'running';
+    return;
+  }
   if (typeof document.requestStorageAccess !== 'function') {
-    // No Storage Access API: partitioned localStorage is all we can see.
-    if (manager.hasKeyInfo()) {
-      uiState = 'running';
-      return;
-    }
     uiState = 'unsupported';
     postVisibility(true);
     return;
@@ -49,21 +48,11 @@ async function detectInitialState(): Promise<void> {
   // top-level × iframe origin pair resolve without a user gesture, so a
   // returning user skips the dialog. First visits and expired grants reject
   // with NotAllowedError, and we fall back to the manual button.
-  //
-  // Do NOT short-circuit on hasKeyInfo() above this point — see
-  // applyStorageGrant() for why the SAA call must run first.
   let handle: StorageAccessHandle | null;
   try {
     handle = await callRequestStorageAccess();
   } catch (err) {
     if (err instanceof DOMException && err.name === 'NotAllowedError') {
-      // No silent grant. Fall back to partitioned key info if available so the
-      // user can still sign with their cached key; first-party data (relays,
-      // etc.) stays unreachable until they explicitly grant access.
-      if (manager.hasKeyInfo()) {
-        uiState = 'running';
-        return;
-      }
       uiState = 'partitioned';
       postVisibility(true);
       return;

--- a/examples/svelte-app/src/iframe-mode.ts
+++ b/examples/svelte-app/src/iframe-mode.ts
@@ -2,7 +2,7 @@ import type { ConsentRequest, NosskeyIframeHostOptions } from 'nosskey-iframe';
 import { NosskeyIframeHost } from 'nosskey-iframe';
 import { get, writable } from 'svelte/store';
 import { getNosskeyManager } from './services/nosskey-manager.service.js';
-import { loadRelays } from './services/relays-store.js';
+import { RELAYS_STORAGE_KEY, loadRelays } from './services/relays-store.js';
 import { consentPolicy, incrementDenyCount, trustedOrigins } from './store/app-state.js';
 import { evaluateConsent, policyKeyFor } from './utils/consent-gating.js';
 
@@ -106,7 +106,26 @@ export function startIframeHost(overrides: Partial<NosskeyIframeHostOptions> = {
     // Read through the SDK's storage handle so we hit first-party storage
     // when the user has granted access (Chromium keeps window.localStorage
     // partitioned even after the grant — only the handle points at it).
-    onGetRelays: async () => loadRelays(manager.getStorageOptions().storage),
+    onGetRelays: async () => {
+      // DIAG (一時): A/C/D 切り分け用ログ。原因確定後に必ず元の 1 行
+      //   `onGetRelays: async () => loadRelays(manager.getStorageOptions().storage),`
+      // に戻すこと。
+      const storage = manager.getStorageOptions().storage;
+      const fallback = typeof window !== 'undefined' ? window.localStorage : null;
+      const handleRaw = storage?.getItem(RELAYS_STORAGE_KEY) ?? null;
+      const fallbackRaw = fallback?.getItem(RELAYS_STORAGE_KEY) ?? null;
+      const result = loadRelays(storage);
+      console.log('[nosskey][onGetRelays][diag]', {
+        hasHandle: !!storage,
+        handleSameAsWindow: storage === fallback,
+        handleRawLength: handleRaw?.length ?? 0,
+        handleRawSnippet: handleRaw ? handleRaw.slice(0, 200) : null,
+        windowRawLength: fallbackRaw?.length ?? 0,
+        windowRawSnippet: fallbackRaw ? fallbackRaw.slice(0, 200) : null,
+        resultKeys: Object.keys(result),
+      });
+      return result;
+    },
     ...overrides,
   });
   host.start();


### PR DESCRIPTION
## Summary

PR #45 の修正方針が誤っていたため、squash-merge コミット `5ade554` を `git revert` で巻き戻します。

## 経緯

PR #45 では「partitioned `hasKeyInfo()` 早期 return が SAA をスキップしている」が `onGetRelays` で relays が取れない原因だと仮定し、SAA 試行を `hasKeyInfo()` チェックより前に移しました。

しかし実機テストの結果、ユーザーの利用フローは:

- リレーは **parent-sample 経由で iframe 内の Settings UI から設定**されており、保存先は `RelaySettings.svelte` の `saveRelays(relays)`（無引数）→ `window.localStorage`、すなわち **(parent-sample × nosskey.app) の partitioned localStorage**。
- iframe 起動時に SAA ダイアログも「Grant Storage Access」ボタンも経由せずに親が `getRelays` を叩いていた。

PR #45 後の挙動:

- SAA を経ない場合 `handle` が立たないため `setStorageOptions` は呼ばれず、`onGetRelays` は `window.localStorage`（= partitioned）を読み、相変わらず relays は読めるはず ……だが、ユーザーは「リレーが取得できない」状態を報告。
- 仮に SAA が成功して `setStorageOptions({ storage: handle.localStorage })` が走ると、今度は handle が指す unpartitioned 領域 (= nosskey.app トップレベル localStorage、リレー未設定で空) を読みに行き、本来 partitioned に保存されている relays を**取りこぼす**。

つまり PR #45 は「partitioned に書いて partitioned から読む」既存の動作経路に対し、SAA grant が成立した瞬間に読み先を unpartitioned に切り替えてしまう、ユースケース上の退行リスクを抱えていました。原因の切り分け（partitioned から読めない理由）が完了していないため、まず PR #45 を巻き戻し、診断ログ（PR #44）が乗った状態に戻します。

## 巻き戻し後の状態

- `IframeHostScreen.svelte`: PR #41 + PR #43 ベース。`hasKeyInfo()` 早期 return 復活
- `iframe-mode.ts`: PR #44 で入れた診断ログ (`[nosskey][onGetRelays][diag]`) が復活 → 次回切り分け用
- `docs/todo.md`: PR #45 で追加した `setStorageOptions` cache 関連 TODO 行を除去

## 次の調査方針（本 PR スコープ外）

- なぜ partitioned localStorage に保存したはずの `nosskey_relays` が `onGetRelays` から読めないのか、PR #44 の診断ログで storage 識別子（`hasHandle` / `storageKey` / `keys`）を確認
- 必要なら relays-store 側にも書き込み時刻 / 書き込み元 URL のログを足す
- 解決策の選択肢: (a) partitioned 経由のままで読み書きが揃うことを確認、(b) 親 app が relays を provide する API を追加、(c) 既定リレーをコードに同梱

## Test plan

- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm run check -w svelte-app` (0 errors / 0 warnings)
- [ ] 実機: parent-sample → iframe で `Get relays` が **revert 後** に少なくとも PR #44 マージ直後と同じ挙動に戻ること（= PR #45 由来の追加退行が無いこと）

https://claude.ai/code/session_01LuqNCVWroaWKxrzvcHberX

---
_Generated by [Claude Code](https://claude.ai/code/session_01LuqNCVWroaWKxrzvcHberX)_