### PR TITLE
fix(iframe): invalidate SDK key cache on storage swap + SAA-first detect

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,7 +11,9 @@
       "./packages/*/dist",
       "./packages/*/node_modules",
       "./dist",
-      "./node_modules"
+      "./node_modules",
+      "./examples/*/coverage",
+      "./packages/*/coverage"
     ]
   },
   "linter": {

--- a/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
+++ b/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
@@ -35,11 +35,12 @@ function postVisibility(visible: boolean): void {
 
 async function detectInitialState(): Promise<void> {
   const manager = getNosskeyManager();
-  if (manager.hasKeyInfo()) {
-    uiState = 'running';
-    return;
-  }
   if (typeof document.requestStorageAccess !== 'function') {
+    // No Storage Access API: partitioned localStorage is all we can see.
+    if (manager.hasKeyInfo()) {
+      uiState = 'running';
+      return;
+    }
     uiState = 'unsupported';
     postVisibility(true);
     return;
@@ -48,11 +49,21 @@ async function detectInitialState(): Promise<void> {
   // top-level × iframe origin pair resolve without a user gesture, so a
   // returning user skips the dialog. First visits and expired grants reject
   // with NotAllowedError, and we fall back to the manual button.
+  //
+  // Do NOT short-circuit on hasKeyInfo() above this point — see
+  // applyStorageGrant() for why the SAA call must run first.
   let handle: StorageAccessHandle | null;
   try {
     handle = await callRequestStorageAccess();
   } catch (err) {
     if (err instanceof DOMException && err.name === 'NotAllowedError') {
+      // No silent grant. Fall back to partitioned key info if available so the
+      // user can still sign with their cached key; first-party data (relays,
+      // etc.) stays unreachable until they explicitly grant access.
+      if (manager.hasKeyInfo()) {
+        uiState = 'running';
+        return;
+      }
       uiState = 'partitioned';
       postVisibility(true);
       return;

--- a/examples/svelte-app/src/iframe-mode.ts
+++ b/examples/svelte-app/src/iframe-mode.ts
@@ -2,7 +2,7 @@ import type { ConsentRequest, NosskeyIframeHostOptions } from 'nosskey-iframe';
 import { NosskeyIframeHost } from 'nosskey-iframe';
 import { get, writable } from 'svelte/store';
 import { getNosskeyManager } from './services/nosskey-manager.service.js';
-import { RELAYS_STORAGE_KEY, loadRelays } from './services/relays-store.js';
+import { loadRelays } from './services/relays-store.js';
 import { consentPolicy, incrementDenyCount, trustedOrigins } from './store/app-state.js';
 import { evaluateConsent, policyKeyFor } from './utils/consent-gating.js';
 
@@ -106,26 +106,7 @@ export function startIframeHost(overrides: Partial<NosskeyIframeHostOptions> = {
     // Read through the SDK's storage handle so we hit first-party storage
     // when the user has granted access (Chromium keeps window.localStorage
     // partitioned even after the grant — only the handle points at it).
-    onGetRelays: async () => {
-      // DIAG (一時): A/C/D 切り分け用ログ。原因確定後に必ず元の 1 行
-      //   `onGetRelays: async () => loadRelays(manager.getStorageOptions().storage),`
-      // に戻すこと。
-      const storage = manager.getStorageOptions().storage;
-      const fallback = typeof window !== 'undefined' ? window.localStorage : null;
-      const handleRaw = storage?.getItem(RELAYS_STORAGE_KEY) ?? null;
-      const fallbackRaw = fallback?.getItem(RELAYS_STORAGE_KEY) ?? null;
-      const result = loadRelays(storage);
-      console.log('[nosskey][onGetRelays][diag]', {
-        hasHandle: !!storage,
-        handleSameAsWindow: storage === fallback,
-        handleRawLength: handleRaw?.length ?? 0,
-        handleRawSnippet: handleRaw ? handleRaw.slice(0, 200) : null,
-        windowRawLength: fallbackRaw?.length ?? 0,
-        windowRawSnippet: fallbackRaw ? fallbackRaw.slice(0, 200) : null,
-        resultKeys: Object.keys(result),
-      });
-      return result;
-    },
+    onGetRelays: async () => loadRelays(manager.getStorageOptions().storage),
     ...overrides,
   });
   host.start();

--- a/packages/nosskey-sdk/src/nosskey.spec.ts
+++ b/packages/nosskey-sdk/src/nosskey.spec.ts
@@ -704,6 +704,85 @@ describe('NosskeyManager', () => {
       expect(customStorage.setItem).toHaveBeenCalled();
     });
 
+    it('storage を差し替えると in-memory cache が invalidate される', () => {
+      const keyInfoA: NostrKeyInfo = {
+        credentialId: bytesToHex(mockCredentialId),
+        pubkey: 'pubkey-from-storage-a',
+        salt: '6e6f7374722d6b6579',
+      };
+      const keyInfoB: NostrKeyInfo = {
+        credentialId: bytesToHex(mockCredentialId),
+        pubkey: 'pubkey-from-storage-b',
+        salt: '6e6f7374722d6b6579',
+      };
+      const storageA = createMockStorage();
+      (storageA.getItem as ReturnType<typeof vi.fn>).mockImplementation((key: string) =>
+        key === 'nosskey_keyinfo' ? JSON.stringify(keyInfoA) : null
+      );
+      const storageB = createMockStorage();
+      (storageB.getItem as ReturnType<typeof vi.fn>).mockImplementation((key: string) =>
+        key === 'nosskey_keyinfo' ? JSON.stringify(keyInfoB) : null
+      );
+
+      const nosskey = new NosskeyManager({
+        storageOptions: { enabled: true, storage: storageA },
+      });
+      expect(nosskey.getCurrentKeyInfo()?.pubkey).toBe('pubkey-from-storage-a');
+
+      nosskey.setStorageOptions({ storage: storageB });
+
+      expect(nosskey.getCurrentKeyInfo()?.pubkey).toBe('pubkey-from-storage-b');
+    });
+
+    it('同じ storage 参照を渡し直した場合は cache を保持する', () => {
+      const keyInfo: NostrKeyInfo = {
+        credentialId: bytesToHex(mockCredentialId),
+        pubkey: 'cached-pubkey',
+        salt: '6e6f7374722d6b6579',
+      };
+      const customStorage = createMockStorage();
+      (customStorage.getItem as ReturnType<typeof vi.fn>).mockImplementation((key: string) =>
+        key === 'nosskey_keyinfo' ? JSON.stringify(keyInfo) : null
+      );
+
+      const nosskey = new NosskeyManager({
+        storageOptions: { enabled: true, storage: customStorage },
+      });
+      const getItemMock = customStorage.getItem as ReturnType<typeof vi.fn>;
+      const callsAfterCtor = getItemMock.mock.calls.length;
+
+      nosskey.setStorageOptions({ storage: customStorage });
+      const result = nosskey.getCurrentKeyInfo();
+
+      expect(result?.pubkey).toBe('cached-pubkey');
+      // 同参照なので invalidate されず、追加の storage.getItem は発生しない
+      expect(getItemMock.mock.calls.length).toBe(callsAfterCtor);
+    });
+
+    it('storageKey のみ変更しても cache は保持される', () => {
+      const keyInfo: NostrKeyInfo = {
+        credentialId: bytesToHex(mockCredentialId),
+        pubkey: 'cached-pubkey',
+        salt: '6e6f7374722d6b6579',
+      };
+      const customStorage = createMockStorage();
+      (customStorage.getItem as ReturnType<typeof vi.fn>).mockImplementation((key: string) =>
+        key === 'nosskey_keyinfo' ? JSON.stringify(keyInfo) : null
+      );
+
+      const nosskey = new NosskeyManager({
+        storageOptions: { enabled: true, storage: customStorage },
+      });
+      const getItemMock = customStorage.getItem as ReturnType<typeof vi.fn>;
+      const callsAfterCtor = getItemMock.mock.calls.length;
+
+      nosskey.setStorageOptions({ storageKey: 'other-key' });
+      const result = nosskey.getCurrentKeyInfo();
+
+      expect(result?.pubkey).toBe('cached-pubkey');
+      expect(getItemMock.mock.calls.length).toBe(callsAfterCtor);
+    });
+
     it('カスタムstorageからのロードが動作する', () => {
       const storedKeyInfo: NostrKeyInfo = {
         credentialId: bytesToHex(mockCredentialId),

--- a/packages/nosskey-sdk/src/nosskey.ts
+++ b/packages/nosskey-sdk/src/nosskey.ts
@@ -77,7 +77,15 @@ export class NosskeyManager implements NosskeyManagerLike {
    * @param options ストレージオプション
    */
   setStorageOptions(options: Partial<NostrKeyStorageOptions>): void {
+    // storage 参照が差し替わったら in-memory cache は別バケットの値を握って
+    // しまっているので破棄する。次回 getCurrentKeyInfo() で新しい storage から
+    // 読み直す。iframe で SAA grant 後に handle.localStorage を流し込む経路で
+    // partitioned 由来のキャッシュが残り続けるのを防ぐのが主目的。
+    const storageChanged = 'storage' in options && options.storage !== this.#storageOptions.storage;
     this.#storageOptions = { ...this.#storageOptions, ...options };
+    if (storageChanged) {
+      this.#currentKeyInfo = null;
+    }
 
     // ストレージが無効化された場合はストレージからNostrKeyInfoを削除
     if (options.enabled === false) {


### PR DESCRIPTION
iframe getRelays() returned {} for users who set relays via the top-level
nosskey.app Settings, because two compounding flaws kept the iframe stuck
on partitioned localStorage:

1. svelte-app: IframeHostScreen.detectInitialState() short-circuited on
   manager.hasKeyInfo() before any SAA call, so the storage handle was
   never threaded into the SDK and onGetRelays read the partitioned
   bucket instead of first-party storage.
2. nosskey-sdk: setStorageOptions({ storage }) replaced the storage ref
   but kept the #currentKeyInfo cache loaded from the prior bucket at
   construction, so even after applyStorageGrant() the SDK was holding
   key info from the wrong origin.

Re-applies the PR #45 reorder (SAA support check -> silent grant ->
applyStorageGrant first; hasKeyInfo() only as fallback in SAA-unsupported
and NotAllowedError branches) and adds the missing SDK piece:
setStorageOptions now nulls #currentKeyInfo when the storage reference
actually changes, so the next getCurrentKeyInfo() reads the new bucket.
storageKey-only changes intentionally keep the cache.

Also reverts the PR #44 diagnostic log in iframe-mode.ts now that the
root cause is confirmed, and extends biome's ignore list to skip
generated coverage outputs (parent-sample coverage was breaking
format:check after test:coverage runs).

https://claude.ai/code/session_01QJgefvikSX6nHRpbEKvxrB