### PR TITLE
docs(todo): sync completed Phase 2/6 items with implementation

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,7 +5,7 @@
 - [ ] 他のNostrライブラリとの統合例をドキュメントに追加
 
 ## 実装関連
-- [ ] PWKのリレーへのバックアップを行うイベントの作成機能（リレーへのパブリッシュはSDKの責務外とする）
+- [ ] `NostrKeyInfo` のリレーへのバックアップを行うイベントの作成機能（リレーへのパブリッシュはSDKの責務外とする） — **優先度低**: `credentialId` / `salt` 等の機密性のあるメタデータを第三者リレーに送ることになり、Nostr pubkey と特定パスキーの紐付けがリンク可能になるプライバシーリスクがある。実装する場合は暗号化形式・許容リレーの設計を慎重に検討する必要あり
 - [ ] NIP-17 sealed DM (kind:14 + gift-wrap) サポート — 受け取った NIP-44 暗号文を kind:13 seal でラップし、ephemeral 鍵で kind:1059 gift-wrap 化する 3 段構成。SDK に「ランダム ephemeral 秘密鍵で署名する API」を追加する必要があり、現状の `signEvent`（登録済み鍵専用）とは別経路。**動作確認用の実装は `examples/parent-sample/src/nip17.ts` にあり、セクション 7 の "Send NIP-17 DM" で他クライアントとの受信検証が可能** (ブランチ `claude/nip44-iframe-sample-KnGuu`)。SDK 本体への昇格は再利用ニーズが出てから検討する。
 - [x] iframeでNosskeyを使用できるNosskey-iframe(仮)の作成 — 段階1〜4完了 (`nosskey-iframe` パッケージ: protocol / host / client)。ブランチ `claude/add-iframe-support-2tKuX`
 - [x] Nosskey-iframe(仮)の参照実装の作成 — 段階5〜7完了 (Svelteアプリの `#/iframe` ルート、ConsentDialog、Timeline/relay 機能削除、README 追記)。ブランチ `claude/continue-iframe-support-mCrAL`。段階8 (E2E 手動検証) は別途

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -20,8 +20,8 @@
 - [x] `nip04.encrypt / decrypt` の追加 — NIP-04（レガシー DM、AES-256-CBC）を SDK (`packages/nosskey-sdk/src/nip04.ts`)、iframe、ConsentDialog で実装。ラウンドトリップテスト追加。ブランチ `claude/review-todos-nFRqm`
 
 #### Phase 2: UX・セキュリティ改善
-- [ ] オリジン別の許可記憶 — 「このサイトを常に許可」チェックボックスと localStorage 保存
-- [ ] メソッド別の同意ポリシー設定 — signEvent / nip44 / nip04 ごとに「毎回確認 / 常に許可 / 拒否」
+- [x] オリジン別の許可記憶 — 「このサイトを常に許可」で origin×method を `localStorage` (`nosskey_trusted_origins_v2`、設計書の `nosskey_trusted_origins` から v1 ユーザー無し前提で破壊的置換) に保存。`examples/svelte-app/src/store/app-state.ts` (`TrustedOriginEntry` / 永続化) + `examples/svelte-app/src/utils/consent-gating.ts` (`evaluateConsent`) + `ConsentDialog.svelte`
+- [x] メソッド別の同意ポリシー設定 — `signEvent` / `nip44` / `nip04` ごとに「毎回確認 / 常に許可 / 拒否」を保持。`ConsentPolicy` 型 + `policyKeyFor()`（nip44/nip04 encrypt/decrypt は同バケット集約） + `localStorage` (`nosskey_consent_policy`)。評価順は deny > always > trusted-origin > ask
 
 #### Phase 3: 接続堅牢化
 - [ ] ヘルスチェック（ping/pong） — 定期的な接続確認メッセージ
@@ -35,9 +35,9 @@
 - [ ] Safari 向け `window.open()` フォールバック — Safari PRF サポート安定後に対応
 
 #### Phase 6: ダイアログ UX 改善
-- [ ] ダイアログ表示内容の整理 — kind ラベル化・content プレビュー・詳細折りたたみ
-- [ ] スタイル整理 — CSS variables 化・レスポンシブ対応
-- [ ] テーマ・言語を親から渡す — URL クエリパラメータ (`?theme=dark&lang=en`) 経由
+- [x] ダイアログ表示内容の整理 — `kindLabel()` で kind ラベル化、content は 100 文字プレビュー、`<details>` で raw event JSON を折りたたみ表示、nip44/nip04 では `renderPeerPubkey()` で相手 pubkey を短縮表示（`examples/svelte-app/src/components/ConsentDialog.svelte`）
+- [x] スタイル整理 — `--color-card` / `--color-text` 等の CSS variables 化と `@media (max-width: 480px)` レスポンシブ対応（`ConsentDialog.svelte`）
+- [ ] テーマ・言語を親から渡す — URL クエリパラメータ (`?theme=dark&lang=en`) 経由。Svelte アプリ側の受信 (`app-state.ts` / `i18n-store.ts`) は実装済み。`NosskeyIframeClient` 側の `theme` / `lang` オプション追加・URL 自動付与が未実装
 - [ ] 設定ページへのリンク遷移 — NO_KEY エラー時のセットアップ誘導
 
 #### Phase 7: フレームワーク導入しやすさの改善（低優先）


### PR DESCRIPTION
Phase 2 のオリジン別許可記憶・メソッド別同意ポリシー、Phase 6 のダイアロ
グ表示整理・スタイル整理は既に実装済みのためチェックを付与し、参照ファ
イルと localStorage キー名 (v2 破壊的置換含む)・評価順を追記。Phase 6
テーマ/言語クエリは Svelte 側受信のみ実装済みである旨を補記。