### PR TITLE
feat(iframe): add theme/lang options to NosskeyIframeClient

### DIFF
--- a/examples/parent-sample/src/main.ts
+++ b/examples/parent-sample/src/main.ts
@@ -42,12 +42,23 @@ function setModalVisible(visible: boolean): void {
   modal?.setAttribute('aria-hidden', visible ? 'false' : 'true');
 }
 
+type ThemeChoice = 'auto' | 'light' | 'dark';
+type LangChoice = 'auto' | 'ja' | 'en';
+
 function resolveParentTheme(): 'light' | 'dark' {
   return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
 function resolveParentLang(): 'ja' | 'en' {
   return navigator.language?.toLowerCase().startsWith('ja') ? 'ja' : 'en';
+}
+
+function resolveTheme(choice: ThemeChoice): 'light' | 'dark' {
+  return choice === 'auto' ? resolveParentTheme() : choice;
+}
+
+function resolveLang(choice: LangChoice): 'ja' | 'en' {
+  return choice === 'auto' ? resolveParentLang() : choice;
 }
 
 function applyParentTheme(theme: 'light' | 'dark'): void {
@@ -57,18 +68,6 @@ function applyParentTheme(theme: 'light' | 'dark'): void {
 
 function clearParentTheme(): void {
   document.body.classList.remove('parent-theme-light', 'parent-theme-dark');
-}
-
-function withEmbeddedParam(rawUrl: string): string {
-  try {
-    const url = new URL(rawUrl, window.location.href);
-    url.searchParams.set('embedded', '1');
-    url.searchParams.set('theme', resolveParentTheme());
-    url.searchParams.set('lang', resolveParentLang());
-    return url.toString();
-  } catch {
-    return rawUrl;
-  }
 }
 
 window.addEventListener('message', (event) => {
@@ -93,6 +92,25 @@ app.innerHTML = `
     <h2>1. Connect to iframe</h2>
     <label for="iframe-url">Iframe URL</label>
     <input id="iframe-url" type="url" value="${DEFAULT_IFRAME_URL}" />
+    <div class="row">
+      <label for="parent-theme">Theme</label>
+      <select id="parent-theme">
+        <option value="auto" selected>auto</option>
+        <option value="light">light</option>
+        <option value="dark">dark</option>
+      </select>
+      <label for="parent-lang">Lang</label>
+      <select id="parent-lang">
+        <option value="auto" selected>auto</option>
+        <option value="ja">ja</option>
+        <option value="en">en</option>
+      </select>
+    </div>
+    <p class="hint">
+      Changing theme or lang while connected re-mounts the iframe with new
+      query parameters (<code>?embedded=1&amp;theme=...&amp;lang=...</code>).
+      The current session state inside the iframe is reset.
+    </p>
     <div class="row">
       <button id="connect">Connect</button>
       <button id="disconnect" class="secondary" disabled>Disconnect</button>
@@ -222,6 +240,8 @@ function requireEl<T extends Element>(selector: string): T {
 
 const ui = {
   iframeUrl: requireEl<HTMLInputElement>('#iframe-url'),
+  parentTheme: requireEl<HTMLSelectElement>('#parent-theme'),
+  parentLang: requireEl<HTMLSelectElement>('#parent-lang'),
   relayUrl: requireEl<HTMLInputElement>('#relay-url'),
   note: requireEl<HTMLTextAreaElement>('#note'),
   connect: requireEl<HTMLButtonElement>('#connect'),
@@ -269,6 +289,8 @@ function setStatus(text: string, variant: '' | 'ok' | 'err' = ''): void {
 function setConnectedUI(connected: boolean): void {
   ui.connect.disabled = connected;
   ui.iframeUrl.disabled = connected;
+  // Theme/lang selects remain enabled while connected so the user can switch
+  // and trigger a re-mount; the change handler does the disconnect+reconnect.
   ui.disconnect.disabled = !connected;
   ui.getPubkey.disabled = !connected;
   ui.getRelays.disabled = !connected;
@@ -301,11 +323,14 @@ async function connect(): Promise<void> {
     return;
   }
   setStatus('connecting…');
-  const embeddedUrl = withEmbeddedParam(iframeUrl);
-  log(`Mounting iframe: ${embeddedUrl}`);
-  applyParentTheme(resolveParentTheme());
+  const themeChoice = ui.parentTheme.value as ThemeChoice;
+  const langChoice = ui.parentLang.value as LangChoice;
+  const theme = resolveTheme(themeChoice);
+  const lang = resolveLang(langChoice);
+  log(`Mounting iframe ${iframeUrl} with theme=${theme}, lang=${lang}`);
+  applyParentTheme(theme);
   try {
-    const next = new NosskeyIframeClient({ iframeUrl: embeddedUrl });
+    const next = new NosskeyIframeClient({ iframeUrl, theme, lang });
     client = next;
     modalCard.appendChild(next.iframe);
     await next.ready();
@@ -662,6 +687,19 @@ ui.connect.addEventListener('click', () => {
   void connect();
 });
 ui.disconnect.addEventListener('click', disconnect);
+
+function remountIfConnected(reason: string): void {
+  if (!client) return;
+  log(`${reason}: re-mounting iframe…`);
+  disconnect();
+  void connect();
+}
+ui.parentTheme.addEventListener('change', () => {
+  remountIfConnected(`Theme changed to ${ui.parentTheme.value}`);
+});
+ui.parentLang.addEventListener('change', () => {
+  remountIfConnected(`Lang changed to ${ui.parentLang.value}`);
+});
 ui.getPubkey.addEventListener('click', () => {
   void getPubkey();
 });

--- a/examples/parent-sample/src/main.ts
+++ b/examples/parent-sample/src/main.ts
@@ -329,11 +329,19 @@ async function connect(): Promise<void> {
   const lang = resolveLang(langChoice);
   log(`Mounting iframe ${iframeUrl} with theme=${theme}, lang=${lang}`);
   applyParentTheme(theme);
+  let next: NosskeyIframeClient | null = null;
   try {
-    const next = new NosskeyIframeClient({ iframeUrl, theme, lang });
+    next = new NosskeyIframeClient({ iframeUrl, theme, lang });
     client = next;
     modalCard.appendChild(next.iframe);
     await next.ready();
+    // If a concurrent re-mount (theme/lang change) swapped the active client
+    // while we awaited ready(), bail out without touching shared UI state —
+    // the newer connect() owns the `client` slot now.
+    if (client !== next) {
+      next.destroy();
+      return;
+    }
     window.nostr = {
       getPublicKey: () => next.getPublicKey(),
       signEvent: (event) => next.signEvent(event),
@@ -352,13 +360,16 @@ async function connect(): Promise<void> {
     log('Received nosskey:ready. window.nostr is now available.');
   } catch (err) {
     log(`Connect failed: ${formatError(err)}`);
-    setStatus('connect failed', 'err');
-    client?.destroy();
-    client = null;
-    window.nostr = undefined;
-    setConnectedUI(false);
-    setModalVisible(false);
-    clearParentTheme();
+    next?.destroy();
+    // Only reset shared UI state if this connect() still owns the client slot.
+    if (next === null || client === next) {
+      client = null;
+      window.nostr = undefined;
+      setConnectedUI(false);
+      setModalVisible(false);
+      clearParentTheme();
+      setStatus('connect failed', 'err');
+    }
   }
 }
 

--- a/examples/parent-sample/src/main.ts
+++ b/examples/parent-sample/src/main.ts
@@ -49,16 +49,11 @@ function resolveParentTheme(): 'light' | 'dark' {
   return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
-function resolveParentLang(): 'ja' | 'en' {
-  return navigator.language?.toLowerCase().startsWith('ja') ? 'ja' : 'en';
-}
-
+// theme は親ページの body クラスに反映する必要があるため、`auto` を `light`/`dark`
+// に解決する。一方 `lang` は親ページが直接使わないので解決不要 — iframe 側の
+// i18n-store.ts が `auto` を navigator.language で解決する。
 function resolveTheme(choice: ThemeChoice): 'light' | 'dark' {
   return choice === 'auto' ? resolveParentTheme() : choice;
-}
-
-function resolveLang(choice: LangChoice): 'ja' | 'en' {
-  return choice === 'auto' ? resolveParentLang() : choice;
 }
 
 function applyParentTheme(theme: 'light' | 'dark'): void {
@@ -325,13 +320,11 @@ async function connect(): Promise<void> {
   setStatus('connecting…');
   const themeChoice = ui.parentTheme.value as ThemeChoice;
   const langChoice = ui.parentLang.value as LangChoice;
-  const theme = resolveTheme(themeChoice);
-  const lang = resolveLang(langChoice);
-  log(`Mounting iframe ${iframeUrl} with theme=${theme}, lang=${lang}`);
-  applyParentTheme(theme);
+  log(`Mounting iframe ${iframeUrl} with theme=${themeChoice}, lang=${langChoice}`);
+  applyParentTheme(resolveTheme(themeChoice));
   let next: NosskeyIframeClient | null = null;
   try {
-    next = new NosskeyIframeClient({ iframeUrl, theme, lang });
+    next = new NosskeyIframeClient({ iframeUrl, theme: themeChoice, lang: langChoice });
     client = next;
     modalCard.appendChild(next.iframe);
     await next.ready();

--- a/examples/svelte-app/src/i18n/i18n-store.ts
+++ b/examples/svelte-app/src/i18n/i18n-store.ts
@@ -36,6 +36,13 @@ function loadLanguage(): Language {
         embeddedLangOverride = true;
         return l;
       }
+      if (l === 'auto') {
+        // 親が `auto` を指定したらブラウザ言語で解決し、上書きフラグは立てる
+        // （次回スタンドアロン起動時の localStorage 書き戻しを抑止するため）。
+        embeddedLangOverride = true;
+        const browserLang = navigator.language.split('-')[0];
+        return browserLang === 'ja' ? 'ja' : 'en';
+      }
     }
 
     const saved = localStorage.getItem('nosskey_language');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1836,9 +1836,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
-      "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2960,9 +2960,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.55.4",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.4.tgz",
-      "integrity": "sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ==",
+      "version": "5.55.7",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
+      "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2975,7 +2975,7 @@
         "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.4",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
         "esrap": "^2.2.4",
         "is-reference": "^3.0.3",

--- a/packages/nosskey-iframe/src/client.spec.ts
+++ b/packages/nosskey-iframe/src/client.spec.ts
@@ -150,6 +150,86 @@ describe('NosskeyIframeClient', () => {
     client.destroy();
   });
 
+  it('appends embedded=1 and theme/lang query params when provided', () => {
+    const client = new NosskeyIframeClient({
+      iframeUrl: 'https://nosskey.example/#/iframe',
+      theme: 'dark',
+      lang: 'ja',
+      window: harness.window,
+      document: harness.document,
+      container: harness.container as unknown as HTMLElement,
+    });
+
+    const iframe = harness.iframes[0];
+    const url = new URL(iframe.src);
+    expect(url.searchParams.get('embedded')).toBe('1');
+    expect(url.searchParams.get('theme')).toBe('dark');
+    expect(url.searchParams.get('lang')).toBe('ja');
+    expect(url.hash).toBe('#/iframe');
+    client.destroy();
+  });
+
+  it('omits theme/lang params when neither option is supplied', () => {
+    const client = new NosskeyIframeClient({
+      iframeUrl: 'https://nosskey.example/#/iframe',
+      window: harness.window,
+      document: harness.document,
+      container: harness.container as unknown as HTMLElement,
+    });
+
+    const iframe = harness.iframes[0];
+    expect(iframe.src).toBe('https://nosskey.example/#/iframe');
+    client.destroy();
+  });
+
+  it('appends only theme when lang is omitted (and vice versa)', () => {
+    const themeOnly = new NosskeyIframeClient({
+      iframeUrl: 'https://nosskey.example/#/iframe',
+      theme: 'auto',
+      window: harness.window,
+      document: harness.document,
+      container: harness.container as unknown as HTMLElement,
+    });
+    const themeIframe = harness.iframes[0];
+    const themeUrl = new URL(themeIframe.src);
+    expect(themeUrl.searchParams.get('embedded')).toBe('1');
+    expect(themeUrl.searchParams.get('theme')).toBe('auto');
+    expect(themeUrl.searchParams.has('lang')).toBe(false);
+    themeOnly.destroy();
+
+    const langOnly = new NosskeyIframeClient({
+      iframeUrl: 'https://nosskey.example/#/iframe',
+      lang: 'en',
+      window: harness.window,
+      document: harness.document,
+      container: harness.container as unknown as HTMLElement,
+    });
+    const langIframe = harness.iframes[1];
+    const langUrl = new URL(langIframe.src);
+    expect(langUrl.searchParams.get('embedded')).toBe('1');
+    expect(langUrl.searchParams.get('lang')).toBe('en');
+    expect(langUrl.searchParams.has('theme')).toBe(false);
+    langOnly.destroy();
+  });
+
+  it('overrides existing embedded/theme/lang query params on the source URL', () => {
+    const client = new NosskeyIframeClient({
+      iframeUrl: 'https://nosskey.example/iframe?embedded=1&theme=light&lang=en',
+      theme: 'dark',
+      lang: 'ja',
+      window: harness.window,
+      document: harness.document,
+      container: harness.container as unknown as HTMLElement,
+    });
+
+    const iframe = harness.iframes[0];
+    const url = new URL(iframe.src);
+    expect(url.searchParams.getAll('theme')).toEqual(['dark']);
+    expect(url.searchParams.getAll('lang')).toEqual(['ja']);
+    expect(url.searchParams.getAll('embedded')).toEqual(['1']);
+    client.destroy();
+  });
+
   it('ready() resolves when a nosskey:ready message arrives from the iframe', async () => {
     const client = new NosskeyIframeClient({
       iframeUrl: 'https://nosskey.example/iframe',

--- a/packages/nosskey-iframe/src/client.spec.ts
+++ b/packages/nosskey-iframe/src/client.spec.ts
@@ -230,6 +230,42 @@ describe('NosskeyIframeClient', () => {
     client.destroy();
   });
 
+  it('resolves a relative iframeUrl against window.location.href', () => {
+    const client = new NosskeyIframeClient({
+      iframeUrl: '/iframe',
+      theme: 'dark',
+      window: harness.window,
+      document: harness.document,
+      container: harness.container as unknown as HTMLElement,
+    });
+
+    const iframe = harness.iframes[0];
+    // Harness location.href is 'https://parent.example/app/' so '/iframe'
+    // resolves under the same origin.
+    const url = new URL(iframe.src);
+    expect(url.origin).toBe('https://parent.example');
+    expect(url.pathname).toBe('/iframe');
+    expect(url.searchParams.get('embedded')).toBe('1');
+    expect(url.searchParams.get('theme')).toBe('dark');
+    client.destroy();
+  });
+
+  it("passes lang='auto' through to the iframe unchanged", () => {
+    const client = new NosskeyIframeClient({
+      iframeUrl: 'https://nosskey.example/#/iframe',
+      lang: 'auto',
+      window: harness.window,
+      document: harness.document,
+      container: harness.container as unknown as HTMLElement,
+    });
+
+    const iframe = harness.iframes[0];
+    const url = new URL(iframe.src);
+    expect(url.searchParams.get('embedded')).toBe('1');
+    expect(url.searchParams.get('lang')).toBe('auto');
+    client.destroy();
+  });
+
   it('ready() resolves when a nosskey:ready message arrives from the iframe', async () => {
     const client = new NosskeyIframeClient({
       iframeUrl: 'https://nosskey.example/iframe',

--- a/packages/nosskey-iframe/src/client.ts
+++ b/packages/nosskey-iframe/src/client.ts
@@ -26,17 +26,19 @@ export interface NosskeyIframeClientOptions {
   timeout?: number;
   /**
    * Theme to pass to the iframe via the `?theme=...` URL parameter. When set,
-   * `embedded=1` is also appended automatically. The host app applies the
-   * theme on load only; runtime switching requires destroying and re-creating
-   * the client with a new value.
+   * `embedded=1` is also appended automatically. `'auto'` is resolved inside
+   * the iframe (via `prefers-color-scheme`). The host app applies the theme
+   * on load only; runtime switching requires destroying and re-creating the
+   * client with a new value.
    */
   theme?: 'light' | 'dark' | 'auto';
   /**
    * Language to pass to the iframe via the `?lang=...` URL parameter. When
-   * set, `embedded=1` is also appended automatically. Same load-time-only
+   * set, `embedded=1` is also appended automatically. `'auto'` is resolved
+   * inside the iframe (via `navigator.language`). Same load-time-only
    * semantics as {@link theme}.
    */
-  lang?: 'ja' | 'en';
+  lang?: 'ja' | 'en' | 'auto';
   /**
    * Override the window used to install the message listener.
    * Defaults to `globalThis.window`. Primarily useful for tests.
@@ -61,6 +63,15 @@ interface Pending {
   timer: ReturnType<typeof setTimeout>;
 }
 
+/**
+ * Compose the iframe `src` URL with optional `theme` / `lang` parameters.
+ *
+ * - If neither `theme` nor `lang` is provided, returns `rawUrl` unchanged.
+ * - Otherwise, parses `rawUrl` against `baseHref`, sets `embedded=1`, and sets
+ *   each provided parameter (using `URLSearchParams.set`, which replaces any
+ *   existing value).
+ * - Returns `rawUrl` unchanged if URL parsing throws (invalid input).
+ */
 function buildIframeUrl(
   rawUrl: string,
   baseHref: string,

--- a/packages/nosskey-iframe/src/client.ts
+++ b/packages/nosskey-iframe/src/client.ts
@@ -25,6 +25,19 @@ export interface NosskeyIframeClientOptions {
   /** Request timeout in milliseconds. Defaults to 60000. */
   timeout?: number;
   /**
+   * Theme to pass to the iframe via the `?theme=...` URL parameter. When set,
+   * `embedded=1` is also appended automatically. The host app applies the
+   * theme on load only; runtime switching requires destroying and re-creating
+   * the client with a new value.
+   */
+  theme?: 'light' | 'dark' | 'auto';
+  /**
+   * Language to pass to the iframe via the `?lang=...` URL parameter. When
+   * set, `embedded=1` is also appended automatically. Same load-time-only
+   * semantics as {@link theme}.
+   */
+  lang?: 'ja' | 'en';
+  /**
    * Override the window used to install the message listener.
    * Defaults to `globalThis.window`. Primarily useful for tests.
    */
@@ -48,6 +61,30 @@ interface Pending {
   timer: ReturnType<typeof setTimeout>;
 }
 
+function buildIframeUrl(
+  rawUrl: string,
+  baseHref: string,
+  theme: NosskeyIframeClientOptions['theme'],
+  lang: NosskeyIframeClientOptions['lang']
+): string {
+  if (theme === undefined && lang === undefined) {
+    return rawUrl;
+  }
+  try {
+    const url = new URL(rawUrl, baseHref);
+    url.searchParams.set('embedded', '1');
+    if (theme !== undefined) {
+      url.searchParams.set('theme', theme);
+    }
+    if (lang !== undefined) {
+      url.searchParams.set('lang', lang);
+    }
+    return url.toString();
+  } catch {
+    return rawUrl;
+  }
+}
+
 function resolveOptions(options: NosskeyIframeClientOptions): ResolvedOptions {
   const win = options.window ?? (globalThis as unknown as { window?: Window }).window;
   if (!win) {
@@ -61,9 +98,11 @@ function resolveOptions(options: NosskeyIframeClientOptions): ResolvedOptions {
   if (!container) {
     throw new Error('NosskeyIframeClient could not determine a container element.');
   }
-  const iframeOrigin = new URL(options.iframeUrl, win.location?.href ?? 'http://localhost/').origin;
+  const baseHref = win.location?.href ?? 'http://localhost/';
+  const iframeUrl = buildIframeUrl(options.iframeUrl, baseHref, options.theme, options.lang);
+  const iframeOrigin = new URL(iframeUrl, baseHref).origin;
   return {
-    iframeUrl: options.iframeUrl,
+    iframeUrl,
     iframeOrigin,
     container,
     timeout: options.timeout ?? 60000,


### PR DESCRIPTION
Phase 6 of iframe expansion. NosskeyIframeClient now accepts `theme` and
`lang` options and auto-appends them as `?embedded=1&theme=...&lang=...`
to the iframe URL. The Svelte host app already reads these params, so
parent pages no longer need to craft URLs manually. parent-sample gets
theme/lang selects that re-mount the iframe on change.

https://claude.ai/code/session_01VLaoRMLr4ufxyKjSBwoDtk