### PR TITLE
refactor(parent-sample): split monolithic main.ts into focused modules

### DIFF
--- a/examples/parent-sample/index.html
+++ b/examples/parent-sample/index.html
@@ -7,7 +7,154 @@
     <link rel="stylesheet" href="/src/style.css" />
   </head>
   <body>
-    <div id="app"></div>
+    <div id="app">
+      <h1>Nosskey iframe parent sample</h1>
+      <p class="subtitle">
+        Mounts the Nosskey signing iframe, exposes a NIP-07 compatible
+        <code>window.nostr</code>, and publishes a signed kind:1 note to a relay.
+      </p>
+
+      <section>
+        <h2>1. Connect to iframe</h2>
+        <label for="iframe-url">Iframe URL</label>
+        <input id="iframe-url" type="url" value="https://nosskey.app/#/iframe" />
+        <div class="row">
+          <label for="parent-theme">Theme</label>
+          <select id="parent-theme">
+            <option value="auto" selected>auto</option>
+            <option value="light">light</option>
+            <option value="dark">dark</option>
+          </select>
+          <label for="parent-lang">Lang</label>
+          <select id="parent-lang">
+            <option value="auto" selected>auto</option>
+            <option value="ja">ja</option>
+            <option value="en">en</option>
+          </select>
+        </div>
+        <p class="hint">
+          Changing theme or lang while connected re-mounts the iframe with new
+          query parameters (<code>?embedded=1&amp;theme=...&amp;lang=...</code>).
+          The current session state inside the iframe is reset.
+        </p>
+        <div class="row">
+          <button id="connect">Connect</button>
+          <button id="disconnect" class="secondary" disabled>Disconnect</button>
+          <span id="status" class="status">disconnected</span>
+        </div>
+      </section>
+
+      <section>
+        <h2>2. Get public key</h2>
+        <div class="row">
+          <button id="get-pubkey" disabled>Call window.nostr.getPublicKey()</button>
+        </div>
+      </section>
+
+      <section>
+        <h2>3. Get relays</h2>
+        <div class="row">
+          <button id="get-relays" disabled>Call window.nostr.getRelays()</button>
+        </div>
+        <pre id="relays-output">No relays fetched yet.</pre>
+      </section>
+
+      <section>
+        <h2>4. Sign &amp; publish kind:1 note</h2>
+        <label for="note">Note content</label>
+        <textarea id="note">Hello from Nosskey iframe parent sample!</textarea>
+        <label for="relay-url" style="margin-top:12px;">Relay URL</label>
+        <input id="relay-url" type="url" value="wss://relay.damus.io" />
+        <div class="row">
+          <button id="sign-publish" disabled>Sign &amp; publish</button>
+        </div>
+      </section>
+
+      <section>
+        <h2>5. NIP-44 encrypt / decrypt</h2>
+        <p class="hint">
+          Modern (recommended) DM encryption. Self-encrypt by clicking
+          <em>Use my pubkey</em> to populate the peer field with the public key
+          from this iframe — both encrypt and decrypt will use the same key,
+          so you can verify the round trip without a second account.
+        </p>
+        <label for="nip44-peer">Peer public key (hex, 64 chars)</label>
+        <div class="row">
+          <input id="nip44-peer" type="text" placeholder="64 hex characters" />
+          <button id="nip44-use-self" class="secondary" disabled>Use my pubkey</button>
+        </div>
+        <label for="nip44-plaintext" style="margin-top:12px;">Plaintext</label>
+        <textarea id="nip44-plaintext">hello, NIP-44 🌸</textarea>
+        <div class="row">
+          <button id="nip44-encrypt" disabled>Encrypt → ciphertext</button>
+          <button id="nip44-decrypt" disabled>Decrypt → plaintext</button>
+        </div>
+        <label for="nip44-ciphertext" style="margin-top:12px;">Ciphertext (base64)</label>
+        <textarea id="nip44-ciphertext" placeholder="paste a NIP-44 v2 payload here, or click Encrypt above"></textarea>
+        <label for="nip44-decrypted" style="margin-top:12px;">Decrypted output</label>
+        <pre id="nip44-decrypted">No decryption attempted yet.</pre>
+      </section>
+
+      <section>
+        <h2>6. NIP-04 encrypt / decrypt (legacy)</h2>
+        <p class="hint warn">
+          ⚠️ NIP-04 is AES-CBC without authentication and is deprecated by the
+          spec itself. Use NIP-44 for new messages. This section is provided
+          only to verify interop with older clients.
+        </p>
+        <label for="nip04-peer">Peer public key (hex, 64 chars)</label>
+        <div class="row">
+          <input id="nip04-peer" type="text" placeholder="64 hex characters" />
+          <button id="nip04-use-self" class="secondary" disabled>Use my pubkey</button>
+        </div>
+        <label for="nip04-plaintext" style="margin-top:12px;">Plaintext</label>
+        <textarea id="nip04-plaintext">hello, NIP-04 (legacy)</textarea>
+        <div class="row">
+          <button id="nip04-encrypt" disabled>Encrypt → ciphertext</button>
+          <button id="nip04-decrypt" disabled>Decrypt → plaintext</button>
+        </div>
+        <label for="nip04-ciphertext" style="margin-top:12px;">Ciphertext (base64?iv=base64)</label>
+        <textarea id="nip04-ciphertext" placeholder="paste a NIP-04 payload here, or click Encrypt above"></textarea>
+        <label for="nip04-decrypted" style="margin-top:12px;">Decrypted output</label>
+        <pre id="nip04-decrypted">No decryption attempted yet.</pre>
+        <p class="hint">
+          <strong>Send DM</strong> below encrypts the plaintext to the peer
+          pubkey, builds a kind:4 event with a <code>p</code> tag, signs it
+          through the iframe (consent dialog appears twice — once for encrypt,
+          once for sign), and publishes to the Relay URL from section 4.
+        </p>
+        <div class="row">
+          <button id="nip04-send-dm" disabled>Send DM (kind:4 → relay)</button>
+        </div>
+      </section>
+
+      <section>
+        <h2>7. NIP-17 sealed DM (gift-wrapped kind:1059)</h2>
+        <p class="hint">
+          Standards-compliant DM path: builds a kind:14 rumor, NIP-44 seals it
+          into a kind:13, then NIP-44 wraps that into a kind:1059 signed by a
+          throwaway ephemeral key. Compatible clients (Amethyst, 0xchat,
+          Coracle, Damus chat) listen for kind:1059 and decrypt automatically.
+          Two consent dialogs appear (NIP-44 encrypt for the seal, then sign
+          kind:13). The Relay URL is shared with section 4.
+        </p>
+        <label for="nip17-peer">Peer public key (hex, 64 chars)</label>
+        <div class="row">
+          <input id="nip17-peer" type="text" placeholder="64 hex characters" />
+          <button id="nip17-use-self" class="secondary" disabled>Use my pubkey</button>
+        </div>
+        <label for="nip17-plaintext" style="margin-top:12px;">Message</label>
+        <textarea id="nip17-plaintext">hello, NIP-17 🎁</textarea>
+        <div class="row">
+          <button id="nip17-send-dm" disabled>Send NIP-17 DM (kind:1059 → relay)</button>
+        </div>
+      </section>
+
+      <section>
+        <h2>Log</h2>
+        <pre id="log"></pre>
+      </section>
+    </div>
     <div id="iframe-modal" class="iframe-modal" aria-hidden="true">
       <div class="iframe-modal__backdrop"></div>
       <div

--- a/examples/parent-sample/src/main.ts
+++ b/examples/parent-sample/src/main.ts
@@ -1,20 +1,32 @@
 import { NosskeyIframeClient, NosskeyIframeError } from 'nosskey-iframe';
 import type { NostrEvent } from 'nosskey-sdk';
 import { sendNip17Dm } from './nip17.js';
-
-interface NostrProvider {
-  getPublicKey(): Promise<string>;
-  signEvent(event: NostrEvent): Promise<NostrEvent>;
-  getRelays(): Promise<Record<string, { read: boolean; write: boolean }>>;
-  nip44: {
-    encrypt(peerPubkey: string, plaintext: string): Promise<string>;
-    decrypt(peerPubkey: string, ciphertext: string): Promise<string>;
-  };
-  nip04: {
-    encrypt(peerPubkey: string, plaintext: string): Promise<string>;
-    decrypt(peerPubkey: string, ciphertext: string): Promise<string>;
-  };
-}
+import {
+  type NostrProvider,
+  formatError,
+  nip04Decrypt,
+  nip04Encrypt,
+  nip04SendDm,
+  nip44Decrypt,
+  nip44Encrypt,
+  signAndPublishNote,
+} from './nips.js';
+import { publishEvent } from './relay.js';
+import {
+  type LangChoice,
+  type ThemeChoice,
+  applyParentTheme,
+  clearParentTheme,
+  createLogger,
+  installModalVisibilityListener,
+  queryUiElements,
+  requireEl,
+  resolveTheme,
+  setConnectedUI,
+  setModalVisible,
+  setStatus,
+} from './ui.js';
+import { parsePeerPubkey, parseRelayUrl } from './validation.js';
 
 declare global {
   interface Window {
@@ -22,293 +34,19 @@ declare global {
   }
 }
 
-const DEFAULT_IFRAME_URL = 'https://nosskey.app/#/iframe';
-const DEFAULT_RELAY_URL = 'wss://relay.damus.io';
-const DEFAULT_NOTE = 'Hello from Nosskey iframe parent sample!';
-const PUBLISH_ACK_TIMEOUT_MS = 8000;
+const app = requireEl<HTMLDivElement>(document, '#app');
+const modal = requireEl<HTMLDivElement>(document, '#iframe-modal');
+const modalCard = requireEl<HTMLDivElement>(modal, '.iframe-modal__card');
 
-const app = document.querySelector<HTMLDivElement>('#app');
-if (!app) {
-  throw new Error('#app element missing from index.html');
-}
+const ui = queryUiElements(app);
+const log = createLogger(ui.log);
 
-const modal = document.querySelector<HTMLDivElement>('#iframe-modal');
-const modalCard = modal?.querySelector<HTMLDivElement>('.iframe-modal__card') ?? null;
-if (!modal || !modalCard) {
-  throw new Error('#iframe-modal markup missing from index.html');
-}
-
-function setModalVisible(visible: boolean): void {
-  modal?.setAttribute('aria-hidden', visible ? 'false' : 'true');
-}
-
-type ThemeChoice = 'auto' | 'light' | 'dark';
-type LangChoice = 'auto' | 'ja' | 'en';
-
-function resolveParentTheme(): 'light' | 'dark' {
-  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-}
-
-// theme は親ページの body クラスに反映する必要があるため、`auto` を `light`/`dark`
-// に解決する。一方 `lang` は親ページが直接使わないので解決不要 — iframe 側の
-// i18n-store.ts が `auto` を navigator.language で解決する。
-function resolveTheme(choice: ThemeChoice): 'light' | 'dark' {
-  return choice === 'auto' ? resolveParentTheme() : choice;
-}
-
-function applyParentTheme(theme: 'light' | 'dark'): void {
-  document.body.classList.remove('parent-theme-light', 'parent-theme-dark');
-  document.body.classList.add(`parent-theme-${theme}`);
-}
-
-function clearParentTheme(): void {
-  document.body.classList.remove('parent-theme-light', 'parent-theme-dark');
-}
-
-window.addEventListener('message', (event) => {
-  const data = event.data as unknown;
-  if (
-    data &&
-    typeof data === 'object' &&
-    (data as { type?: unknown }).type === 'nosskey:visibility'
-  ) {
-    setModalVisible(Boolean((data as { visible?: unknown }).visible));
-  }
-});
-
-app.innerHTML = `
-  <h1>Nosskey iframe parent sample</h1>
-  <p class="subtitle">
-    Mounts the Nosskey signing iframe, exposes a NIP-07 compatible
-    <code>window.nostr</code>, and publishes a signed kind:1 note to a relay.
-  </p>
-
-  <section>
-    <h2>1. Connect to iframe</h2>
-    <label for="iframe-url">Iframe URL</label>
-    <input id="iframe-url" type="url" value="${DEFAULT_IFRAME_URL}" />
-    <div class="row">
-      <label for="parent-theme">Theme</label>
-      <select id="parent-theme">
-        <option value="auto" selected>auto</option>
-        <option value="light">light</option>
-        <option value="dark">dark</option>
-      </select>
-      <label for="parent-lang">Lang</label>
-      <select id="parent-lang">
-        <option value="auto" selected>auto</option>
-        <option value="ja">ja</option>
-        <option value="en">en</option>
-      </select>
-    </div>
-    <p class="hint">
-      Changing theme or lang while connected re-mounts the iframe with new
-      query parameters (<code>?embedded=1&amp;theme=...&amp;lang=...</code>).
-      The current session state inside the iframe is reset.
-    </p>
-    <div class="row">
-      <button id="connect">Connect</button>
-      <button id="disconnect" class="secondary" disabled>Disconnect</button>
-      <span id="status" class="status">disconnected</span>
-    </div>
-  </section>
-
-  <section>
-    <h2>2. Get public key</h2>
-    <div class="row">
-      <button id="get-pubkey" disabled>Call window.nostr.getPublicKey()</button>
-    </div>
-  </section>
-
-  <section>
-    <h2>3. Get relays</h2>
-    <div class="row">
-      <button id="get-relays" disabled>Call window.nostr.getRelays()</button>
-    </div>
-    <pre id="relays-output">No relays fetched yet.</pre>
-  </section>
-
-  <section>
-    <h2>4. Sign &amp; publish kind:1 note</h2>
-    <label for="note">Note content</label>
-    <textarea id="note">${DEFAULT_NOTE}</textarea>
-    <label for="relay-url" style="margin-top:12px;">Relay URL</label>
-    <input id="relay-url" type="url" value="${DEFAULT_RELAY_URL}" />
-    <div class="row">
-      <button id="sign-publish" disabled>Sign &amp; publish</button>
-    </div>
-  </section>
-
-  <section>
-    <h2>5. NIP-44 encrypt / decrypt</h2>
-    <p class="hint">
-      Modern (recommended) DM encryption. Self-encrypt by clicking
-      <em>Use my pubkey</em> to populate the peer field with the public key
-      from this iframe — both encrypt and decrypt will use the same key,
-      so you can verify the round trip without a second account.
-    </p>
-    <label for="nip44-peer">Peer public key (hex, 64 chars)</label>
-    <div class="row">
-      <input id="nip44-peer" type="text" placeholder="64 hex characters" />
-      <button id="nip44-use-self" class="secondary" disabled>Use my pubkey</button>
-    </div>
-    <label for="nip44-plaintext" style="margin-top:12px;">Plaintext</label>
-    <textarea id="nip44-plaintext">hello, NIP-44 🌸</textarea>
-    <div class="row">
-      <button id="nip44-encrypt" disabled>Encrypt → ciphertext</button>
-      <button id="nip44-decrypt" disabled>Decrypt → plaintext</button>
-    </div>
-    <label for="nip44-ciphertext" style="margin-top:12px;">Ciphertext (base64)</label>
-    <textarea id="nip44-ciphertext" placeholder="paste a NIP-44 v2 payload here, or click Encrypt above"></textarea>
-    <label for="nip44-decrypted" style="margin-top:12px;">Decrypted output</label>
-    <pre id="nip44-decrypted">No decryption attempted yet.</pre>
-  </section>
-
-  <section>
-    <h2>6. NIP-04 encrypt / decrypt (legacy)</h2>
-    <p class="hint warn">
-      ⚠️ NIP-04 is AES-CBC without authentication and is deprecated by the
-      spec itself. Use NIP-44 for new messages. This section is provided
-      only to verify interop with older clients.
-    </p>
-    <label for="nip04-peer">Peer public key (hex, 64 chars)</label>
-    <div class="row">
-      <input id="nip04-peer" type="text" placeholder="64 hex characters" />
-      <button id="nip04-use-self" class="secondary" disabled>Use my pubkey</button>
-    </div>
-    <label for="nip04-plaintext" style="margin-top:12px;">Plaintext</label>
-    <textarea id="nip04-plaintext">hello, NIP-04 (legacy)</textarea>
-    <div class="row">
-      <button id="nip04-encrypt" disabled>Encrypt → ciphertext</button>
-      <button id="nip04-decrypt" disabled>Decrypt → plaintext</button>
-    </div>
-    <label for="nip04-ciphertext" style="margin-top:12px;">Ciphertext (base64?iv=base64)</label>
-    <textarea id="nip04-ciphertext" placeholder="paste a NIP-04 payload here, or click Encrypt above"></textarea>
-    <label for="nip04-decrypted" style="margin-top:12px;">Decrypted output</label>
-    <pre id="nip04-decrypted">No decryption attempted yet.</pre>
-    <p class="hint">
-      <strong>Send DM</strong> below encrypts the plaintext to the peer
-      pubkey, builds a kind:4 event with a <code>p</code> tag, signs it
-      through the iframe (consent dialog appears twice — once for encrypt,
-      once for sign), and publishes to the Relay URL from section 4.
-    </p>
-    <div class="row">
-      <button id="nip04-send-dm" disabled>Send DM (kind:4 → relay)</button>
-    </div>
-  </section>
-
-  <section>
-    <h2>7. NIP-17 sealed DM (gift-wrapped kind:1059)</h2>
-    <p class="hint">
-      Standards-compliant DM path: builds a kind:14 rumor, NIP-44 seals it
-      into a kind:13, then NIP-44 wraps that into a kind:1059 signed by a
-      throwaway ephemeral key. Compatible clients (Amethyst, 0xchat,
-      Coracle, Damus chat) listen for kind:1059 and decrypt automatically.
-      Two consent dialogs appear (NIP-44 encrypt for the seal, then sign
-      kind:13). The Relay URL is shared with section 4.
-    </p>
-    <label for="nip17-peer">Peer public key (hex, 64 chars)</label>
-    <div class="row">
-      <input id="nip17-peer" type="text" placeholder="64 hex characters" />
-      <button id="nip17-use-self" class="secondary" disabled>Use my pubkey</button>
-    </div>
-    <label for="nip17-plaintext" style="margin-top:12px;">Message</label>
-    <textarea id="nip17-plaintext">hello, NIP-17 🎁</textarea>
-    <div class="row">
-      <button id="nip17-send-dm" disabled>Send NIP-17 DM (kind:1059 → relay)</button>
-    </div>
-  </section>
-
-  <section>
-    <h2>Log</h2>
-    <pre id="log"></pre>
-  </section>
-`;
-
-function requireEl<T extends Element>(selector: string): T {
-  const el = app.querySelector<T>(selector);
-  if (!el) {
-    throw new Error(`UI element missing: ${selector}`);
-  }
-  return el;
-}
-
-const ui = {
-  iframeUrl: requireEl<HTMLInputElement>('#iframe-url'),
-  parentTheme: requireEl<HTMLSelectElement>('#parent-theme'),
-  parentLang: requireEl<HTMLSelectElement>('#parent-lang'),
-  relayUrl: requireEl<HTMLInputElement>('#relay-url'),
-  note: requireEl<HTMLTextAreaElement>('#note'),
-  connect: requireEl<HTMLButtonElement>('#connect'),
-  disconnect: requireEl<HTMLButtonElement>('#disconnect'),
-  getPubkey: requireEl<HTMLButtonElement>('#get-pubkey'),
-  getRelays: requireEl<HTMLButtonElement>('#get-relays'),
-  relaysOutput: requireEl<HTMLPreElement>('#relays-output'),
-  signPublish: requireEl<HTMLButtonElement>('#sign-publish'),
-  nip44Peer: requireEl<HTMLInputElement>('#nip44-peer'),
-  nip44UseSelf: requireEl<HTMLButtonElement>('#nip44-use-self'),
-  nip44Plaintext: requireEl<HTMLTextAreaElement>('#nip44-plaintext'),
-  nip44Encrypt: requireEl<HTMLButtonElement>('#nip44-encrypt'),
-  nip44Decrypt: requireEl<HTMLButtonElement>('#nip44-decrypt'),
-  nip44Ciphertext: requireEl<HTMLTextAreaElement>('#nip44-ciphertext'),
-  nip44Decrypted: requireEl<HTMLPreElement>('#nip44-decrypted'),
-  nip04Peer: requireEl<HTMLInputElement>('#nip04-peer'),
-  nip04UseSelf: requireEl<HTMLButtonElement>('#nip04-use-self'),
-  nip04Plaintext: requireEl<HTMLTextAreaElement>('#nip04-plaintext'),
-  nip04Encrypt: requireEl<HTMLButtonElement>('#nip04-encrypt'),
-  nip04Decrypt: requireEl<HTMLButtonElement>('#nip04-decrypt'),
-  nip04Ciphertext: requireEl<HTMLTextAreaElement>('#nip04-ciphertext'),
-  nip04Decrypted: requireEl<HTMLPreElement>('#nip04-decrypted'),
-  nip04SendDm: requireEl<HTMLButtonElement>('#nip04-send-dm'),
-  nip17Peer: requireEl<HTMLInputElement>('#nip17-peer'),
-  nip17UseSelf: requireEl<HTMLButtonElement>('#nip17-use-self'),
-  nip17Plaintext: requireEl<HTMLTextAreaElement>('#nip17-plaintext'),
-  nip17SendDm: requireEl<HTMLButtonElement>('#nip17-send-dm'),
-  status: requireEl<HTMLSpanElement>('#status'),
-  log: requireEl<HTMLPreElement>('#log'),
-};
+installModalVisibilityListener(modal);
 
 let client: NosskeyIframeClient | null = null;
 
-function log(line: string): void {
-  const ts = new Date().toISOString().slice(11, 23);
-  ui.log.textContent += `[${ts}] ${line}\n`;
-  ui.log.scrollTop = ui.log.scrollHeight;
-}
-
-function setStatus(text: string, variant: '' | 'ok' | 'err' = ''): void {
-  ui.status.textContent = text;
-  ui.status.className = variant ? `status ${variant}` : 'status';
-}
-
-function setConnectedUI(connected: boolean): void {
-  ui.connect.disabled = connected;
-  ui.iframeUrl.disabled = connected;
-  // Theme/lang selects remain enabled while connected so the user can switch
-  // and trigger a re-mount; the change handler does the disconnect+reconnect.
-  ui.disconnect.disabled = !connected;
-  ui.getPubkey.disabled = !connected;
-  ui.getRelays.disabled = !connected;
-  ui.signPublish.disabled = !connected;
-  ui.nip44UseSelf.disabled = !connected;
-  ui.nip44Encrypt.disabled = !connected;
-  ui.nip44Decrypt.disabled = !connected;
-  ui.nip04UseSelf.disabled = !connected;
-  ui.nip04Encrypt.disabled = !connected;
-  ui.nip04Decrypt.disabled = !connected;
-  ui.nip04SendDm.disabled = !connected;
-  ui.nip17UseSelf.disabled = !connected;
-  ui.nip17SendDm.disabled = !connected;
-}
-
-function formatError(err: unknown): string {
-  if (err instanceof NosskeyIframeError) {
-    return `NosskeyIframeError[${err.code}]: ${err.message}`;
-  }
-  if (err instanceof Error) {
-    return `${err.name}: ${err.message}`;
-  }
-  return String(err);
+function publish(relayUrl: string, event: NostrEvent): Promise<void> {
+  return publishEvent(relayUrl, event, { log });
 }
 
 async function connect(): Promise<void> {
@@ -317,7 +55,7 @@ async function connect(): Promise<void> {
     log('Connect aborted: iframe URL is empty.');
     return;
   }
-  setStatus('connecting…');
+  setStatus(ui.status, 'connecting…');
   const themeChoice = ui.parentTheme.value as ThemeChoice;
   const langChoice = ui.parentLang.value as LangChoice;
   log(`Mounting iframe ${iframeUrl} with theme=${themeChoice}, lang=${langChoice}`);
@@ -348,8 +86,8 @@ async function connect(): Promise<void> {
         decrypt: (peer, cipher) => next.nip04.decrypt(peer, cipher),
       },
     };
-    setConnectedUI(true);
-    setStatus('connected', 'ok');
+    setConnectedUI(ui, true);
+    setStatus(ui.status, 'connected', 'ok');
     log('Received nosskey:ready. window.nostr is now available.');
   } catch (err) {
     log(`Connect failed: ${formatError(err)}`);
@@ -358,10 +96,10 @@ async function connect(): Promise<void> {
     if (next === null || client === next) {
       client = null;
       window.nostr = undefined;
-      setConnectedUI(false);
-      setModalVisible(false);
+      setConnectedUI(ui, false);
+      setModalVisible(modal, false);
       clearParentTheme();
-      setStatus('connect failed', 'err');
+      setStatus(ui.status, 'connect failed', 'err');
     }
   }
 }
@@ -371,10 +109,10 @@ function disconnect(): void {
   client.destroy();
   client = null;
   window.nostr = undefined;
-  setConnectedUI(false);
-  setModalVisible(false);
+  setConnectedUI(ui, false);
+  setModalVisible(modal, false);
   clearParentTheme();
-  setStatus('disconnected');
+  setStatus(ui.status, 'disconnected');
   log('Iframe destroyed; window.nostr removed.');
 }
 
@@ -413,94 +151,20 @@ async function getRelays(): Promise<void> {
   }
 }
 
-function publishEvent(relayUrl: string, event: NostrEvent): Promise<void> {
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    let ws: WebSocket;
-    try {
-      ws = new WebSocket(relayUrl);
-    } catch (err) {
-      reject(err);
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      log(`Relay ${relayUrl}: no OK/NOTICE within ${PUBLISH_ACK_TIMEOUT_MS}ms, closing.`);
-      ws.close();
-      resolve();
-    }, PUBLISH_ACK_TIMEOUT_MS);
-
-    ws.addEventListener('open', () => {
-      log(`Relay ${relayUrl}: connection open, sending EVENT.`);
-      ws.send(JSON.stringify(['EVENT', event]));
-    });
-
-    ws.addEventListener('message', (msg) => {
-      const data = typeof msg.data === 'string' ? msg.data : '<binary>';
-      log(`Relay ${relayUrl}: ${data}`);
-      if (data === '<binary>') return;
-      try {
-        const parsed: unknown = JSON.parse(data);
-        if (Array.isArray(parsed) && (parsed[0] === 'OK' || parsed[0] === 'NOTICE') && !settled) {
-          settled = true;
-          clearTimeout(timer);
-          ws.close();
-          resolve();
-        }
-      } catch {
-        // Non-JSON payload — ignore and wait for timer.
-      }
-    });
-
-    ws.addEventListener('error', () => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      reject(new Error(`WebSocket error for ${relayUrl}`));
-    });
-
-    ws.addEventListener('close', () => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve();
-    });
-  });
-}
-
 async function signAndPublish(): Promise<void> {
   if (!window.nostr) return;
-  const content = ui.note.value;
-  const relayUrl = ui.relayUrl.value.trim();
-  if (!relayUrl) {
-    log('Sign aborted: relay URL is empty.');
+  const relay = parseRelayUrl(ui.relayUrl.value);
+  if (!relay.ok) {
+    log(`Sign aborted: ${relay.reason}.`);
     return;
   }
-
-  const draft: NostrEvent = {
-    kind: 1,
-    content,
-    tags: [],
-    created_at: Math.floor(Date.now() / 1000),
-  };
-
-  log('Requesting window.nostr.signEvent() for kind:1 note…');
-  let signed: NostrEvent;
-  try {
-    signed = await window.nostr.signEvent(draft);
-  } catch (err) {
-    log(`signEvent failed: ${formatError(err)}`);
-    return;
-  }
-  log(`Signed event: ${JSON.stringify(signed, null, 2)}`);
-
-  try {
-    await publishEvent(relayUrl, signed);
-  } catch (err) {
-    log(`Publish failed: ${formatError(err)}`);
-  }
+  await signAndPublishNote({
+    nostr: window.nostr,
+    content: ui.note.value,
+    relayUrl: relay.value,
+    log,
+    publish: (event) => publish(relay.value, event),
+  });
 }
 
 async function fillSelfPubkey(target: HTMLInputElement, label: string): Promise<void> {
@@ -514,149 +178,110 @@ async function fillSelfPubkey(target: HTMLInputElement, label: string): Promise<
   }
 }
 
-async function nip44Encrypt(): Promise<void> {
+async function runNip44Encrypt(): Promise<void> {
   if (!window.nostr) return;
-  const peer = ui.nip44Peer.value.trim();
-  const plain = ui.nip44Plaintext.value;
-  if (!peer) {
-    log('NIP-44 encrypt aborted: peer pubkey is empty.');
+  const peer = parsePeerPubkey(ui.nip44Peer.value);
+  if (!peer.ok) {
+    log(`NIP-44 encrypt aborted: ${peer.reason}.`);
     return;
   }
-  log(`Requesting window.nostr.nip44.encrypt() for ${plain.length} chars…`);
-  try {
-    const ciphertext = await window.nostr.nip44.encrypt(peer, plain);
+  const ciphertext = await nip44Encrypt({
+    nostr: window.nostr,
+    peer: peer.value,
+    plaintext: ui.nip44Plaintext.value,
+    log,
+  });
+  if (ciphertext !== null) {
     ui.nip44Ciphertext.value = ciphertext;
-    log(`NIP-44 encrypt OK (${ciphertext.length} chars of base64).`);
-  } catch (err) {
-    log(`NIP-44 encrypt failed: ${formatError(err)}`);
   }
 }
 
-async function nip44Decrypt(): Promise<void> {
+async function runNip44Decrypt(): Promise<void> {
   if (!window.nostr) return;
-  const peer = ui.nip44Peer.value.trim();
+  const peer = parsePeerPubkey(ui.nip44Peer.value);
   const ciphertext = ui.nip44Ciphertext.value.trim();
-  if (!peer || !ciphertext) {
+  if (!peer.ok || !ciphertext) {
     log('NIP-44 decrypt aborted: peer pubkey or ciphertext is empty.');
     return;
   }
-  log('Requesting window.nostr.nip44.decrypt()…');
-  try {
-    const plaintext = await window.nostr.nip44.decrypt(peer, ciphertext);
-    ui.nip44Decrypted.textContent = plaintext;
-    log(`NIP-44 decrypt OK (${plaintext.length} chars).`);
-  } catch (err) {
-    const msg = formatError(err);
-    log(`NIP-44 decrypt failed: ${msg}`);
-    ui.nip44Decrypted.textContent = `Error: ${msg}`;
-  }
+  const result = await nip44Decrypt({
+    nostr: window.nostr,
+    peer: peer.value,
+    ciphertext,
+    log,
+  });
+  ui.nip44Decrypted.textContent = result.ok ? result.plaintext : `Error: ${result.message}`;
 }
 
-/**
- * Run NIP-04 encryption and report length on success. Returns null on failure
- * (already logged). Shared by the encrypt button and the DM-send flow so the
- * two paths can't drift apart.
- */
-async function performNip04Encrypt(peer: string, plain: string): Promise<string | null> {
-  if (!window.nostr) return null;
-  log(`Requesting window.nostr.nip04.encrypt() for ${plain.length} chars…`);
-  try {
-    const ciphertext = await window.nostr.nip04.encrypt(peer, plain);
-    log(`NIP-04 encrypt OK (${ciphertext.length} chars).`);
-    return ciphertext;
-  } catch (err) {
-    log(`NIP-04 encrypt failed: ${formatError(err)}`);
-    return null;
-  }
-}
-
-async function nip04Encrypt(): Promise<void> {
-  const peer = ui.nip04Peer.value.trim();
-  if (!peer) {
-    log('NIP-04 encrypt aborted: peer pubkey is empty.');
+async function runNip04Encrypt(): Promise<void> {
+  if (!window.nostr) return;
+  const peer = parsePeerPubkey(ui.nip04Peer.value);
+  if (!peer.ok) {
+    log(`NIP-04 encrypt aborted: ${peer.reason}.`);
     return;
   }
-  const ciphertext = await performNip04Encrypt(peer, ui.nip04Plaintext.value);
+  const ciphertext = await nip04Encrypt({
+    nostr: window.nostr,
+    peer: peer.value,
+    plaintext: ui.nip04Plaintext.value,
+    log,
+  });
   if (ciphertext !== null) {
     ui.nip04Ciphertext.value = ciphertext;
   }
 }
 
-async function nip04Decrypt(): Promise<void> {
+async function runNip04Decrypt(): Promise<void> {
   if (!window.nostr) return;
-  const peer = ui.nip04Peer.value.trim();
+  const peer = parsePeerPubkey(ui.nip04Peer.value);
   const ciphertext = ui.nip04Ciphertext.value.trim();
-  if (!peer || !ciphertext) {
+  if (!peer.ok || !ciphertext) {
     log('NIP-04 decrypt aborted: peer pubkey or ciphertext is empty.');
     return;
   }
-  log('Requesting window.nostr.nip04.decrypt()…');
-  try {
-    const plaintext = await window.nostr.nip04.decrypt(peer, ciphertext);
-    ui.nip04Decrypted.textContent = plaintext;
-    log(`NIP-04 decrypt OK (${plaintext.length} chars).`);
-  } catch (err) {
-    const msg = formatError(err);
-    log(`NIP-04 decrypt failed: ${msg}`);
-    ui.nip04Decrypted.textContent = `Error: ${msg}`;
-  }
+  const result = await nip04Decrypt({
+    nostr: window.nostr,
+    peer: peer.value,
+    ciphertext,
+    log,
+  });
+  ui.nip04Decrypted.textContent = result.ok ? result.plaintext : `Error: ${result.message}`;
 }
 
-async function nip04SendDm(): Promise<void> {
+async function runNip04SendDm(): Promise<void> {
   if (!window.nostr) return;
-  const peer = ui.nip04Peer.value.trim();
-  const relayUrl = ui.relayUrl.value.trim();
-  if (!peer) {
-    log('NIP-04 DM aborted: peer pubkey is empty.');
+  const peer = parsePeerPubkey(ui.nip04Peer.value);
+  if (!peer.ok) {
+    log(`NIP-04 DM aborted: ${peer.reason}.`);
     return;
   }
-  if (!relayUrl) {
+  const relay = parseRelayUrl(ui.relayUrl.value);
+  if (!relay.ok) {
     log('NIP-04 DM aborted: relay URL (section 4) is empty.');
     return;
   }
-
-  // 1) encrypt — prompts encrypt consent
-  log(`NIP-04 DM: encrypting to ${peer.slice(0, 8)}…`);
-  const ciphertext = await performNip04Encrypt(peer, ui.nip04Plaintext.value);
-  if (ciphertext === null) return;
-  ui.nip04Ciphertext.value = ciphertext;
-
-  // 2) build kind:4 + p-tag, sign — prompts sign consent
-  const draft: NostrEvent = {
-    kind: 4,
-    content: ciphertext,
-    tags: [['p', peer]],
-    created_at: Math.floor(Date.now() / 1000),
-  };
-  log('NIP-04 DM: signing kind:4 event…');
-  let signed: NostrEvent;
-  try {
-    signed = await window.nostr.signEvent(draft);
-  } catch (err) {
-    log(`NIP-04 DM signEvent failed: ${formatError(err)}`);
-    return;
-  }
-  log(`NIP-04 DM: signed event id ${signed.id ?? '(missing id)'}.`);
-
-  // 3) publish via the existing WebSocket helper
-  try {
-    await publishEvent(relayUrl, signed);
-  } catch (err) {
-    log(`NIP-04 DM publish failed: ${formatError(err)}`);
-  }
+  await nip04SendDm({
+    nostr: window.nostr,
+    peer: peer.value,
+    plaintext: ui.nip04Plaintext.value,
+    log,
+    publish: (event) => publish(relay.value, event),
+    onCiphertext: (ciphertext) => {
+      ui.nip04Ciphertext.value = ciphertext;
+    },
+  });
 }
 
-async function nip17SendDm(): Promise<void> {
+async function runNip17SendDm(): Promise<void> {
   if (!window.nostr) return;
   const nostr = window.nostr;
-  const peer = ui.nip17Peer.value.trim();
-  const relayUrl = ui.relayUrl.value.trim();
-  const plaintext = ui.nip17Plaintext.value;
-  if (!peer) {
-    log('NIP-17 DM aborted: peer pubkey is empty.');
+  const peer = parsePeerPubkey(ui.nip17Peer.value);
+  if (!peer.ok) {
+    log(`NIP-17 DM aborted: ${peer.reason}.`);
     return;
   }
-  if (!relayUrl) {
+  const relay = parseRelayUrl(ui.relayUrl.value);
+  if (!relay.ok) {
     log('NIP-17 DM aborted: relay URL (section 4) is empty.');
     return;
   }
@@ -670,15 +295,15 @@ async function nip17SendDm(): Promise<void> {
     return;
   }
 
-  log(`NIP-17 DM: sealing rumor for ${peer.slice(0, 8)}… (consent dialog x2)`);
+  log(`NIP-17 DM: sealing rumor for ${peer.value.slice(0, 8)}… (consent dialog x2)`);
   try {
     const result = await sendNip17Dm({
       senderPubkey,
-      peerPubkey: peer,
-      plaintext,
+      peerPubkey: peer.value,
+      plaintext: ui.nip17Plaintext.value,
       sealEncrypt: (p, plain) => nostr.nip44.encrypt(p, plain),
       signSeal: (draft) => nostr.signEvent(draft),
-      publish: (event) => publishEvent(relayUrl, event),
+      publish: (event) => publish(relay.value, event),
     });
     log(`NIP-17 DM: gift wrap id ${result.giftWrap.id ?? '(missing id)'}`);
     log(`NIP-17 DM: ephemeral pubkey ${result.ephemeralPubkey}`);
@@ -687,17 +312,17 @@ async function nip17SendDm(): Promise<void> {
   }
 }
 
-ui.connect.addEventListener('click', () => {
-  void connect();
-});
-ui.disconnect.addEventListener('click', disconnect);
-
 function remountIfConnected(reason: string): void {
   if (!client) return;
   log(`${reason}: re-mounting iframe…`);
   disconnect();
   void connect();
 }
+
+ui.connect.addEventListener('click', () => {
+  void connect();
+});
+ui.disconnect.addEventListener('click', disconnect);
 ui.parentTheme.addEventListener('change', () => {
   remountIfConnected(`Theme changed to ${ui.parentTheme.value}`);
 });
@@ -717,28 +342,28 @@ ui.nip44UseSelf.addEventListener('click', () => {
   void fillSelfPubkey(ui.nip44Peer, 'NIP-44');
 });
 ui.nip44Encrypt.addEventListener('click', () => {
-  void nip44Encrypt();
+  void runNip44Encrypt();
 });
 ui.nip44Decrypt.addEventListener('click', () => {
-  void nip44Decrypt();
+  void runNip44Decrypt();
 });
 ui.nip04UseSelf.addEventListener('click', () => {
   void fillSelfPubkey(ui.nip04Peer, 'NIP-04');
 });
 ui.nip04Encrypt.addEventListener('click', () => {
-  void nip04Encrypt();
+  void runNip04Encrypt();
 });
 ui.nip04Decrypt.addEventListener('click', () => {
-  void nip04Decrypt();
+  void runNip04Decrypt();
 });
 ui.nip04SendDm.addEventListener('click', () => {
-  void nip04SendDm();
+  void runNip04SendDm();
 });
 ui.nip17UseSelf.addEventListener('click', () => {
   void fillSelfPubkey(ui.nip17Peer, 'NIP-17');
 });
 ui.nip17SendDm.addEventListener('click', () => {
-  void nip17SendDm();
+  void runNip17SendDm();
 });
 
 log(

--- a/examples/parent-sample/src/nips.spec.ts
+++ b/examples/parent-sample/src/nips.spec.ts
@@ -1,0 +1,238 @@
+import { NosskeyIframeError } from 'nosskey-iframe';
+import type { NostrEvent } from 'nosskey-sdk';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type NostrProvider,
+  formatError,
+  nip04Decrypt,
+  nip04Encrypt,
+  nip04SendDm,
+  nip44Decrypt,
+  nip44Encrypt,
+  signAndPublishNote,
+} from './nips.js';
+
+function createNostrMock(): NostrProvider {
+  return {
+    getPublicKey: vi.fn(),
+    signEvent: vi.fn(),
+    getRelays: vi.fn(),
+    nip44: {
+      encrypt: vi.fn(),
+      decrypt: vi.fn(),
+    },
+    nip04: {
+      encrypt: vi.fn(),
+      decrypt: vi.fn(),
+    },
+  };
+}
+
+const PEER = 'a'.repeat(64);
+
+describe('formatError', () => {
+  it('formats NosskeyIframeError with its code', () => {
+    const err = new NosskeyIframeError('NO_KEY', 'no key registered');
+    expect(formatError(err)).toBe('NosskeyIframeError[NO_KEY]: no key registered');
+  });
+
+  it('formats generic Error with name and message', () => {
+    expect(formatError(new TypeError('boom'))).toBe('TypeError: boom');
+  });
+
+  it('stringifies non-Error values', () => {
+    expect(formatError('plain string')).toBe('plain string');
+  });
+});
+
+describe('nip44Encrypt', () => {
+  it('returns ciphertext and logs success on the happy path', async () => {
+    const nostr = createNostrMock();
+    vi.mocked(nostr.nip44.encrypt).mockResolvedValue('cipher44');
+    const log = vi.fn();
+    const result = await nip44Encrypt({ nostr, peer: PEER, plaintext: 'hello', log });
+    expect(result).toBe('cipher44');
+    expect(nostr.nip44.encrypt).toHaveBeenCalledWith(PEER, 'hello');
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('NIP-44 encrypt OK'));
+  });
+
+  it('returns null and logs error on failure', async () => {
+    const nostr = createNostrMock();
+    vi.mocked(nostr.nip44.encrypt).mockRejectedValue(new Error('rejected'));
+    const log = vi.fn();
+    const result = await nip44Encrypt({ nostr, peer: PEER, plaintext: 'hi', log });
+    expect(result).toBeNull();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('NIP-44 encrypt failed'));
+  });
+});
+
+describe('nip44Decrypt', () => {
+  it('returns { ok: true, plaintext } on the happy path', async () => {
+    const nostr = createNostrMock();
+    vi.mocked(nostr.nip44.decrypt).mockResolvedValue('plain');
+    const log = vi.fn();
+    const result = await nip44Decrypt({ nostr, peer: PEER, ciphertext: 'cipher', log });
+    expect(result).toEqual({ ok: true, plaintext: 'plain' });
+  });
+
+  it('returns { ok: false, message } on failure', async () => {
+    const nostr = createNostrMock();
+    vi.mocked(nostr.nip44.decrypt).mockRejectedValue(new Error('bad mac'));
+    const log = vi.fn();
+    const result = await nip44Decrypt({ nostr, peer: PEER, ciphertext: 'cipher', log });
+    expect(result).toEqual({ ok: false, message: 'Error: bad mac' });
+  });
+});
+
+describe('nip04Encrypt / nip04Decrypt', () => {
+  it('encrypt returns ciphertext on success', async () => {
+    const nostr = createNostrMock();
+    vi.mocked(nostr.nip04.encrypt).mockResolvedValue('cipher04');
+    const result = await nip04Encrypt({
+      nostr,
+      peer: PEER,
+      plaintext: 'plain',
+      log: vi.fn(),
+    });
+    expect(result).toBe('cipher04');
+  });
+
+  it('decrypt returns { ok: false } when nostr rejects', async () => {
+    const nostr = createNostrMock();
+    vi.mocked(nostr.nip04.decrypt).mockRejectedValue(new Error('mac mismatch'));
+    const result = await nip04Decrypt({
+      nostr,
+      peer: PEER,
+      ciphertext: 'cipher',
+      log: vi.fn(),
+    });
+    expect(result).toEqual({ ok: false, message: 'Error: mac mismatch' });
+  });
+});
+
+describe('signAndPublishNote', () => {
+  it('signs a kind:1 draft and publishes the signed event', async () => {
+    const nostr = createNostrMock();
+    const signed: NostrEvent = {
+      kind: 1,
+      content: 'hi',
+      tags: [],
+      created_at: 1700000000,
+      pubkey: 'p'.repeat(64),
+      id: 'i'.repeat(64),
+      sig: 's'.repeat(128),
+    };
+    vi.mocked(nostr.signEvent).mockResolvedValue(signed);
+    const publish = vi.fn().mockResolvedValue(undefined);
+    const log = vi.fn();
+    await signAndPublishNote({
+      nostr,
+      content: 'hi',
+      relayUrl: 'wss://example',
+      log,
+      publish,
+    });
+    expect(nostr.signEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 1, content: 'hi', tags: [] })
+    );
+    expect(publish).toHaveBeenCalledWith(signed);
+  });
+
+  it('does not publish when signEvent rejects', async () => {
+    const nostr = createNostrMock();
+    vi.mocked(nostr.signEvent).mockRejectedValue(new Error('user rejected'));
+    const publish = vi.fn();
+    await signAndPublishNote({
+      nostr,
+      content: 'hi',
+      relayUrl: 'wss://example',
+      log: vi.fn(),
+      publish,
+    });
+    expect(publish).not.toHaveBeenCalled();
+  });
+});
+
+describe('nip04SendDm', () => {
+  function buildSignedKind4(content: string): NostrEvent {
+    return {
+      kind: 4,
+      content,
+      tags: [['p', PEER]],
+      created_at: 1700000000,
+      pubkey: 'p'.repeat(64),
+      id: 'i'.repeat(64),
+      sig: 's'.repeat(128),
+    };
+  }
+
+  it('encrypts, signs a kind:4 with p-tag, calls onCiphertext, then publishes', async () => {
+    const nostr = createNostrMock();
+    vi.mocked(nostr.nip04.encrypt).mockResolvedValue('cipher04');
+    vi.mocked(nostr.signEvent).mockResolvedValue(buildSignedKind4('cipher04'));
+    const publish = vi.fn().mockResolvedValue(undefined);
+    const onCiphertext = vi.fn();
+    await nip04SendDm({
+      nostr,
+      peer: PEER,
+      plaintext: 'hello',
+      log: vi.fn(),
+      publish,
+      onCiphertext,
+    });
+    expect(nostr.nip04.encrypt).toHaveBeenCalledWith(PEER, 'hello');
+    expect(onCiphertext).toHaveBeenCalledWith('cipher04');
+    expect(nostr.signEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 4, content: 'cipher04', tags: [['p', PEER]] })
+    );
+    expect(publish).toHaveBeenCalled();
+  });
+
+  it('aborts without signing or publishing if encrypt fails', async () => {
+    const nostr = createNostrMock();
+    vi.mocked(nostr.nip04.encrypt).mockRejectedValue(new Error('encrypt failed'));
+    const publish = vi.fn();
+    const onCiphertext = vi.fn();
+    await nip04SendDm({
+      nostr,
+      peer: PEER,
+      plaintext: 'hi',
+      log: vi.fn(),
+      publish,
+      onCiphertext,
+    });
+    expect(nostr.signEvent).not.toHaveBeenCalled();
+    expect(publish).not.toHaveBeenCalled();
+    expect(onCiphertext).not.toHaveBeenCalled();
+  });
+
+  it('does not publish when signEvent fails', async () => {
+    const nostr = createNostrMock();
+    vi.mocked(nostr.nip04.encrypt).mockResolvedValue('cipher04');
+    vi.mocked(nostr.signEvent).mockRejectedValue(new Error('user rejected'));
+    const publish = vi.fn();
+    await nip04SendDm({
+      nostr,
+      peer: PEER,
+      plaintext: 'hi',
+      log: vi.fn(),
+      publish,
+    });
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('works without onCiphertext callback', async () => {
+    const nostr = createNostrMock();
+    vi.mocked(nostr.nip04.encrypt).mockResolvedValue('cipher04');
+    vi.mocked(nostr.signEvent).mockResolvedValue(buildSignedKind4('cipher04'));
+    const publish = vi.fn().mockResolvedValue(undefined);
+    await nip04SendDm({
+      nostr,
+      peer: PEER,
+      plaintext: 'hi',
+      log: vi.fn(),
+      publish,
+    });
+    expect(publish).toHaveBeenCalled();
+  });
+});

--- a/examples/parent-sample/src/nips.ts
+++ b/examples/parent-sample/src/nips.ts
@@ -1,0 +1,180 @@
+/**
+ * NIP-04/44 operations and the NIP-04 send-DM flow.
+ *
+ * All functions accept a `NostrProvider` (the iframe-backed window.nostr-shape)
+ * and a `Logger` as injected dependencies. They never touch the DOM and never
+ * reach for `window.nostr` themselves — that keeps them testable with vi.fn()
+ * mocks (see nips.spec.ts).
+ */
+import { NosskeyIframeError } from 'nosskey-iframe';
+import type { NostrEvent } from 'nosskey-sdk';
+import type { Logger } from './ui.js';
+
+export interface NostrProvider {
+  getPublicKey(): Promise<string>;
+  signEvent(event: NostrEvent): Promise<NostrEvent>;
+  getRelays(): Promise<Record<string, { read: boolean; write: boolean }>>;
+  nip44: {
+    encrypt(peerPubkey: string, plaintext: string): Promise<string>;
+    decrypt(peerPubkey: string, ciphertext: string): Promise<string>;
+  };
+  nip04: {
+    encrypt(peerPubkey: string, plaintext: string): Promise<string>;
+    decrypt(peerPubkey: string, ciphertext: string): Promise<string>;
+  };
+}
+
+export function formatError(err: unknown): string {
+  if (err instanceof NosskeyIframeError) {
+    return `NosskeyIframeError[${err.code}]: ${err.message}`;
+  }
+  if (err instanceof Error) {
+    return `${err.name}: ${err.message}`;
+  }
+  return String(err);
+}
+
+export type DecryptResult = { ok: true; plaintext: string } | { ok: false; message: string };
+
+export interface EncryptInputs {
+  nostr: NostrProvider;
+  peer: string;
+  plaintext: string;
+  log: Logger;
+}
+
+export interface DecryptInputs {
+  nostr: NostrProvider;
+  peer: string;
+  ciphertext: string;
+  log: Logger;
+}
+
+export async function nip44Encrypt(inputs: EncryptInputs): Promise<string | null> {
+  const { nostr, peer, plaintext, log } = inputs;
+  log(`Requesting window.nostr.nip44.encrypt() for ${plaintext.length} chars…`);
+  try {
+    const ciphertext = await nostr.nip44.encrypt(peer, plaintext);
+    log(`NIP-44 encrypt OK (${ciphertext.length} chars of base64).`);
+    return ciphertext;
+  } catch (err) {
+    log(`NIP-44 encrypt failed: ${formatError(err)}`);
+    return null;
+  }
+}
+
+export async function nip44Decrypt(inputs: DecryptInputs): Promise<DecryptResult> {
+  const { nostr, peer, ciphertext, log } = inputs;
+  log('Requesting window.nostr.nip44.decrypt()…');
+  try {
+    const plaintext = await nostr.nip44.decrypt(peer, ciphertext);
+    log(`NIP-44 decrypt OK (${plaintext.length} chars).`);
+    return { ok: true, plaintext };
+  } catch (err) {
+    const message = formatError(err);
+    log(`NIP-44 decrypt failed: ${message}`);
+    return { ok: false, message };
+  }
+}
+
+export async function nip04Encrypt(inputs: EncryptInputs): Promise<string | null> {
+  const { nostr, peer, plaintext, log } = inputs;
+  log(`Requesting window.nostr.nip04.encrypt() for ${plaintext.length} chars…`);
+  try {
+    const ciphertext = await nostr.nip04.encrypt(peer, plaintext);
+    log(`NIP-04 encrypt OK (${ciphertext.length} chars).`);
+    return ciphertext;
+  } catch (err) {
+    log(`NIP-04 encrypt failed: ${formatError(err)}`);
+    return null;
+  }
+}
+
+export async function nip04Decrypt(inputs: DecryptInputs): Promise<DecryptResult> {
+  const { nostr, peer, ciphertext, log } = inputs;
+  log('Requesting window.nostr.nip04.decrypt()…');
+  try {
+    const plaintext = await nostr.nip04.decrypt(peer, ciphertext);
+    log(`NIP-04 decrypt OK (${plaintext.length} chars).`);
+    return { ok: true, plaintext };
+  } catch (err) {
+    const message = formatError(err);
+    log(`NIP-04 decrypt failed: ${message}`);
+    return { ok: false, message };
+  }
+}
+
+export interface SignAndPublishInputs {
+  nostr: NostrProvider;
+  content: string;
+  relayUrl: string;
+  log: Logger;
+  publish: (event: NostrEvent) => Promise<void>;
+}
+
+export async function signAndPublishNote(inputs: SignAndPublishInputs): Promise<void> {
+  const { nostr, content, log, publish } = inputs;
+  const draft: NostrEvent = {
+    kind: 1,
+    content,
+    tags: [],
+    created_at: Math.floor(Date.now() / 1000),
+  };
+
+  log('Requesting window.nostr.signEvent() for kind:1 note…');
+  let signed: NostrEvent;
+  try {
+    signed = await nostr.signEvent(draft);
+  } catch (err) {
+    log(`signEvent failed: ${formatError(err)}`);
+    return;
+  }
+  log(`Signed event: ${JSON.stringify(signed, null, 2)}`);
+
+  try {
+    await publish(signed);
+  } catch (err) {
+    log(`Publish failed: ${formatError(err)}`);
+  }
+}
+
+export interface Nip04SendDmInputs {
+  nostr: NostrProvider;
+  peer: string;
+  plaintext: string;
+  log: Logger;
+  publish: (event: NostrEvent) => Promise<void>;
+  /** Called with the encrypted ciphertext so the UI can mirror it (optional). */
+  onCiphertext?: (ciphertext: string) => void;
+}
+
+export async function nip04SendDm(inputs: Nip04SendDmInputs): Promise<void> {
+  const { nostr, peer, plaintext, log, publish, onCiphertext } = inputs;
+
+  log(`NIP-04 DM: encrypting to ${peer.slice(0, 8)}…`);
+  const ciphertext = await nip04Encrypt({ nostr, peer, plaintext, log });
+  if (ciphertext === null) return;
+  onCiphertext?.(ciphertext);
+
+  const draft: NostrEvent = {
+    kind: 4,
+    content: ciphertext,
+    tags: [['p', peer]],
+    created_at: Math.floor(Date.now() / 1000),
+  };
+  log('NIP-04 DM: signing kind:4 event…');
+  let signed: NostrEvent;
+  try {
+    signed = await nostr.signEvent(draft);
+  } catch (err) {
+    log(`NIP-04 DM signEvent failed: ${formatError(err)}`);
+    return;
+  }
+  log(`NIP-04 DM: signed event id ${signed.id ?? '(missing id)'}.`);
+
+  try {
+    await publish(signed);
+  } catch (err) {
+    log(`NIP-04 DM publish failed: ${formatError(err)}`);
+  }
+}

--- a/examples/parent-sample/src/relay.spec.ts
+++ b/examples/parent-sample/src/relay.spec.ts
@@ -1,0 +1,219 @@
+import type { NostrEvent } from 'nosskey-sdk';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_PUBLISH_ACK_TIMEOUT_MS, publishEvent } from './relay.js';
+
+class FakeWebSocket extends EventTarget {
+  static instances: FakeWebSocket[] = [];
+  static throwOnConstruct: Error | null = null;
+
+  readonly url: string;
+  sent: string[] = [];
+  closeCalled = 0;
+
+  constructor(url: string) {
+    super();
+    if (FakeWebSocket.throwOnConstruct) throw FakeWebSocket.throwOnConstruct;
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.closeCalled += 1;
+  }
+
+  triggerOpen(): void {
+    this.dispatchEvent(new Event('open'));
+  }
+
+  triggerMessage(data: string | ArrayBuffer): void {
+    const event = new Event('message') as Event & { data: string | ArrayBuffer };
+    event.data = data;
+    this.dispatchEvent(event);
+  }
+
+  triggerError(): void {
+    this.dispatchEvent(new Event('error'));
+  }
+
+  triggerClose(): void {
+    this.dispatchEvent(new Event('close'));
+  }
+}
+
+const fakeWebSocket = FakeWebSocket as unknown as typeof WebSocket;
+
+const SIGNED_EVENT: NostrEvent = {
+  kind: 1,
+  content: 'hi',
+  tags: [],
+  created_at: 1700000000,
+  pubkey: 'p'.repeat(64),
+  id: 'i'.repeat(64),
+  sig: 's'.repeat(128),
+};
+
+beforeEach(() => {
+  FakeWebSocket.instances = [];
+  FakeWebSocket.throwOnConstruct = null;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('publishEvent', () => {
+  it('sends ["EVENT", signed] on open', async () => {
+    const log = vi.fn();
+    const promise = publishEvent('wss://example', SIGNED_EVENT, {
+      log,
+      webSocketImpl: fakeWebSocket,
+    });
+    const ws = FakeWebSocket.instances[0];
+    expect(ws).toBeDefined();
+    ws.triggerOpen();
+    expect(ws.sent).toEqual([JSON.stringify(['EVENT', SIGNED_EVENT])]);
+    // settle so the promise doesn't dangle
+    ws.triggerMessage(JSON.stringify(['OK', SIGNED_EVENT.id, true, '']));
+    await promise;
+    expect(ws.closeCalled).toBe(1);
+  });
+
+  it('resolves on first OK frame and closes the socket', async () => {
+    const log = vi.fn();
+    const promise = publishEvent('wss://example', SIGNED_EVENT, {
+      log,
+      webSocketImpl: fakeWebSocket,
+    });
+    const ws = FakeWebSocket.instances[0];
+    ws.triggerMessage(JSON.stringify(['OK', SIGNED_EVENT.id, true, '']));
+    await expect(promise).resolves.toBeUndefined();
+    expect(ws.closeCalled).toBe(1);
+  });
+
+  it('resolves on NOTICE frame as well', async () => {
+    const log = vi.fn();
+    const promise = publishEvent('wss://example', SIGNED_EVENT, {
+      log,
+      webSocketImpl: fakeWebSocket,
+    });
+    const ws = FakeWebSocket.instances[0];
+    ws.triggerMessage(JSON.stringify(['NOTICE', 'rate limited']));
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('ignores binary frames and keeps waiting', async () => {
+    vi.useFakeTimers();
+    const log = vi.fn();
+    const promise = publishEvent('wss://example', SIGNED_EVENT, {
+      log,
+      timeoutMs: 1000,
+      webSocketImpl: fakeWebSocket,
+    });
+    const ws = FakeWebSocket.instances[0];
+    ws.triggerMessage(new ArrayBuffer(4));
+    // Binary frame must be logged but not settle the promise.
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('<binary>'));
+    vi.advanceTimersByTime(1000);
+    await expect(promise).resolves.toBeUndefined();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('no OK/NOTICE within 1000ms'));
+  });
+
+  it('resolves after timeout with a logged message and closes the socket', async () => {
+    vi.useFakeTimers();
+    const log = vi.fn();
+    const promise = publishEvent('wss://example', SIGNED_EVENT, {
+      log,
+      timeoutMs: 500,
+      webSocketImpl: fakeWebSocket,
+    });
+    const ws = FakeWebSocket.instances[0];
+    vi.advanceTimersByTime(500);
+    await expect(promise).resolves.toBeUndefined();
+    expect(ws.closeCalled).toBe(1);
+    expect(log).toHaveBeenCalledWith('Relay wss://example: no OK/NOTICE within 500ms, closing.');
+  });
+
+  it('uses DEFAULT_PUBLISH_ACK_TIMEOUT_MS when no timeoutMs is provided', async () => {
+    vi.useFakeTimers();
+    const log = vi.fn();
+    const promise = publishEvent('wss://example', SIGNED_EVENT, {
+      log,
+      webSocketImpl: fakeWebSocket,
+    });
+    vi.advanceTimersByTime(DEFAULT_PUBLISH_ACK_TIMEOUT_MS);
+    await expect(promise).resolves.toBeUndefined();
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining(`within ${DEFAULT_PUBLISH_ACK_TIMEOUT_MS}ms`)
+    );
+  });
+
+  it('rejects on socket error before settle', async () => {
+    const log = vi.fn();
+    const promise = publishEvent('wss://example', SIGNED_EVENT, {
+      log,
+      webSocketImpl: fakeWebSocket,
+    });
+    const ws = FakeWebSocket.instances[0];
+    ws.triggerError();
+    await expect(promise).rejects.toThrow('WebSocket error for wss://example');
+  });
+
+  it('resolves on close event when never settled', async () => {
+    const log = vi.fn();
+    const promise = publishEvent('wss://example', SIGNED_EVENT, {
+      log,
+      webSocketImpl: fakeWebSocket,
+    });
+    const ws = FakeWebSocket.instances[0];
+    ws.triggerClose();
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('ignores duplicate close/error events after the first OK', async () => {
+    const log = vi.fn();
+    const promise = publishEvent('wss://example', SIGNED_EVENT, {
+      log,
+      webSocketImpl: fakeWebSocket,
+    });
+    const ws = FakeWebSocket.instances[0];
+    ws.triggerMessage(JSON.stringify(['OK', SIGNED_EVENT.id, true, '']));
+    await promise;
+    expect(ws.closeCalled).toBe(1);
+    // Subsequent events must not throw or re-resolve.
+    expect(() => {
+      ws.triggerError();
+      ws.triggerClose();
+    }).not.toThrow();
+    expect(ws.closeCalled).toBe(1);
+  });
+
+  it('ignores non-JSON text frames', async () => {
+    vi.useFakeTimers();
+    const log = vi.fn();
+    const promise = publishEvent('wss://example', SIGNED_EVENT, {
+      log,
+      timeoutMs: 100,
+      webSocketImpl: fakeWebSocket,
+    });
+    const ws = FakeWebSocket.instances[0];
+    ws.triggerMessage('not json at all');
+    expect(log).toHaveBeenCalledWith('Relay wss://example: not json at all');
+    vi.advanceTimersByTime(100);
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('rejects if the WebSocket constructor throws synchronously', async () => {
+    const log = vi.fn();
+    FakeWebSocket.throwOnConstruct = new Error('bad url');
+    await expect(
+      publishEvent('wss://example', SIGNED_EVENT, {
+        log,
+        webSocketImpl: fakeWebSocket,
+      })
+    ).rejects.toThrow('bad url');
+  });
+});

--- a/examples/parent-sample/src/relay.ts
+++ b/examples/parent-sample/src/relay.ts
@@ -1,0 +1,80 @@
+/**
+ * WebSocket relay publish helper. Opens a connection, sends ["EVENT", signed],
+ * and resolves on the first OK/NOTICE frame (or close, or timeout).
+ *
+ * Test seam: `webSocketImpl` lets specs inject a fake constructor so the state
+ * machine can be exercised without a real network. `log` is injected so the
+ * helper has no DOM coupling.
+ */
+import type { NostrEvent } from 'nosskey-sdk';
+import type { Logger } from './ui.js';
+
+export const DEFAULT_PUBLISH_ACK_TIMEOUT_MS = 8000;
+
+export interface PublishOptions {
+  log: Logger;
+  timeoutMs?: number;
+  webSocketImpl?: typeof WebSocket;
+}
+
+export function publishEvent(
+  relayUrl: string,
+  event: NostrEvent,
+  opts: PublishOptions
+): Promise<void> {
+  const { log, timeoutMs = DEFAULT_PUBLISH_ACK_TIMEOUT_MS, webSocketImpl = WebSocket } = opts;
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let ws: WebSocket;
+    try {
+      ws = new webSocketImpl(relayUrl);
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      log(`Relay ${relayUrl}: no OK/NOTICE within ${timeoutMs}ms, closing.`);
+      ws.close();
+      resolve();
+    }, timeoutMs);
+
+    ws.addEventListener('open', () => {
+      log(`Relay ${relayUrl}: connection open, sending EVENT.`);
+      ws.send(JSON.stringify(['EVENT', event]));
+    });
+
+    ws.addEventListener('message', (msg) => {
+      const data = typeof msg.data === 'string' ? msg.data : '<binary>';
+      log(`Relay ${relayUrl}: ${data}`);
+      if (data === '<binary>') return;
+      try {
+        const parsed: unknown = JSON.parse(data);
+        if (Array.isArray(parsed) && (parsed[0] === 'OK' || parsed[0] === 'NOTICE') && !settled) {
+          settled = true;
+          clearTimeout(timer);
+          ws.close();
+          resolve();
+        }
+      } catch {
+        // Non-JSON payload — ignore and wait for timer.
+      }
+    });
+
+    ws.addEventListener('error', () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new Error(`WebSocket error for ${relayUrl}`));
+    });
+
+    ws.addEventListener('close', () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}

--- a/examples/parent-sample/src/ui.ts
+++ b/examples/parent-sample/src/ui.ts
@@ -1,0 +1,163 @@
+/**
+ * DOM/UI helpers for the parent-sample app. Nothing in here knows about
+ * nostr business logic — it queries elements declared in index.html, applies
+ * theme classes, manages modal visibility, and renders log/status lines.
+ */
+
+export type ThemeChoice = 'auto' | 'light' | 'dark';
+export type LangChoice = 'auto' | 'ja' | 'en';
+export type Logger = (line: string) => void;
+
+export interface UiElements {
+  iframeUrl: HTMLInputElement;
+  parentTheme: HTMLSelectElement;
+  parentLang: HTMLSelectElement;
+  relayUrl: HTMLInputElement;
+  note: HTMLTextAreaElement;
+  connect: HTMLButtonElement;
+  disconnect: HTMLButtonElement;
+  getPubkey: HTMLButtonElement;
+  getRelays: HTMLButtonElement;
+  relaysOutput: HTMLPreElement;
+  signPublish: HTMLButtonElement;
+  nip44Peer: HTMLInputElement;
+  nip44UseSelf: HTMLButtonElement;
+  nip44Plaintext: HTMLTextAreaElement;
+  nip44Encrypt: HTMLButtonElement;
+  nip44Decrypt: HTMLButtonElement;
+  nip44Ciphertext: HTMLTextAreaElement;
+  nip44Decrypted: HTMLPreElement;
+  nip04Peer: HTMLInputElement;
+  nip04UseSelf: HTMLButtonElement;
+  nip04Plaintext: HTMLTextAreaElement;
+  nip04Encrypt: HTMLButtonElement;
+  nip04Decrypt: HTMLButtonElement;
+  nip04Ciphertext: HTMLTextAreaElement;
+  nip04Decrypted: HTMLPreElement;
+  nip04SendDm: HTMLButtonElement;
+  nip17Peer: HTMLInputElement;
+  nip17UseSelf: HTMLButtonElement;
+  nip17Plaintext: HTMLTextAreaElement;
+  nip17SendDm: HTMLButtonElement;
+  status: HTMLSpanElement;
+  log: HTMLPreElement;
+}
+
+export function requireEl<T extends Element>(parent: ParentNode, selector: string): T {
+  const el = parent.querySelector<T>(selector);
+  if (!el) {
+    throw new Error(`UI element missing: ${selector}`);
+  }
+  return el;
+}
+
+export function queryUiElements(app: ParentNode): UiElements {
+  return {
+    iframeUrl: requireEl<HTMLInputElement>(app, '#iframe-url'),
+    parentTheme: requireEl<HTMLSelectElement>(app, '#parent-theme'),
+    parentLang: requireEl<HTMLSelectElement>(app, '#parent-lang'),
+    relayUrl: requireEl<HTMLInputElement>(app, '#relay-url'),
+    note: requireEl<HTMLTextAreaElement>(app, '#note'),
+    connect: requireEl<HTMLButtonElement>(app, '#connect'),
+    disconnect: requireEl<HTMLButtonElement>(app, '#disconnect'),
+    getPubkey: requireEl<HTMLButtonElement>(app, '#get-pubkey'),
+    getRelays: requireEl<HTMLButtonElement>(app, '#get-relays'),
+    relaysOutput: requireEl<HTMLPreElement>(app, '#relays-output'),
+    signPublish: requireEl<HTMLButtonElement>(app, '#sign-publish'),
+    nip44Peer: requireEl<HTMLInputElement>(app, '#nip44-peer'),
+    nip44UseSelf: requireEl<HTMLButtonElement>(app, '#nip44-use-self'),
+    nip44Plaintext: requireEl<HTMLTextAreaElement>(app, '#nip44-plaintext'),
+    nip44Encrypt: requireEl<HTMLButtonElement>(app, '#nip44-encrypt'),
+    nip44Decrypt: requireEl<HTMLButtonElement>(app, '#nip44-decrypt'),
+    nip44Ciphertext: requireEl<HTMLTextAreaElement>(app, '#nip44-ciphertext'),
+    nip44Decrypted: requireEl<HTMLPreElement>(app, '#nip44-decrypted'),
+    nip04Peer: requireEl<HTMLInputElement>(app, '#nip04-peer'),
+    nip04UseSelf: requireEl<HTMLButtonElement>(app, '#nip04-use-self'),
+    nip04Plaintext: requireEl<HTMLTextAreaElement>(app, '#nip04-plaintext'),
+    nip04Encrypt: requireEl<HTMLButtonElement>(app, '#nip04-encrypt'),
+    nip04Decrypt: requireEl<HTMLButtonElement>(app, '#nip04-decrypt'),
+    nip04Ciphertext: requireEl<HTMLTextAreaElement>(app, '#nip04-ciphertext'),
+    nip04Decrypted: requireEl<HTMLPreElement>(app, '#nip04-decrypted'),
+    nip04SendDm: requireEl<HTMLButtonElement>(app, '#nip04-send-dm'),
+    nip17Peer: requireEl<HTMLInputElement>(app, '#nip17-peer'),
+    nip17UseSelf: requireEl<HTMLButtonElement>(app, '#nip17-use-self'),
+    nip17Plaintext: requireEl<HTMLTextAreaElement>(app, '#nip17-plaintext'),
+    nip17SendDm: requireEl<HTMLButtonElement>(app, '#nip17-send-dm'),
+    status: requireEl<HTMLSpanElement>(app, '#status'),
+    log: requireEl<HTMLPreElement>(app, '#log'),
+  };
+}
+
+function resolveParentTheme(): 'light' | 'dark' {
+  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+// theme は親ページの body クラスに反映する必要があるため、`auto` を `light`/`dark`
+// に解決する。一方 `lang` は親ページが直接使わないので解決不要 — iframe 側の
+// i18n-store.ts が `auto` を navigator.language で解決する。
+export function resolveTheme(choice: ThemeChoice): 'light' | 'dark' {
+  return choice === 'auto' ? resolveParentTheme() : choice;
+}
+
+export function applyParentTheme(theme: 'light' | 'dark'): void {
+  document.body.classList.remove('parent-theme-light', 'parent-theme-dark');
+  document.body.classList.add(`parent-theme-${theme}`);
+}
+
+export function clearParentTheme(): void {
+  document.body.classList.remove('parent-theme-light', 'parent-theme-dark');
+}
+
+export function setModalVisible(modal: HTMLElement, visible: boolean): void {
+  modal.setAttribute('aria-hidden', visible ? 'false' : 'true');
+}
+
+export function installModalVisibilityListener(modal: HTMLElement): void {
+  window.addEventListener('message', (event) => {
+    const data = event.data as unknown;
+    if (
+      data &&
+      typeof data === 'object' &&
+      (data as { type?: unknown }).type === 'nosskey:visibility'
+    ) {
+      setModalVisible(modal, Boolean((data as { visible?: unknown }).visible));
+    }
+  });
+}
+
+export function createLogger(logEl: HTMLPreElement): Logger {
+  return (line: string) => {
+    const ts = new Date().toISOString().slice(11, 23);
+    logEl.textContent += `[${ts}] ${line}\n`;
+    logEl.scrollTop = logEl.scrollHeight;
+  };
+}
+
+export function setStatus(
+  statusEl: HTMLSpanElement,
+  text: string,
+  variant: '' | 'ok' | 'err' = ''
+): void {
+  statusEl.textContent = text;
+  statusEl.className = variant ? `status ${variant}` : 'status';
+}
+
+export function setConnectedUI(ui: UiElements, connected: boolean): void {
+  ui.connect.disabled = connected;
+  ui.iframeUrl.disabled = connected;
+  // Theme/lang selects remain enabled while connected so the user can switch
+  // and trigger a re-mount; the change handler does the disconnect+reconnect.
+  ui.disconnect.disabled = !connected;
+  ui.getPubkey.disabled = !connected;
+  ui.getRelays.disabled = !connected;
+  ui.signPublish.disabled = !connected;
+  ui.nip44UseSelf.disabled = !connected;
+  ui.nip44Encrypt.disabled = !connected;
+  ui.nip44Decrypt.disabled = !connected;
+  ui.nip04UseSelf.disabled = !connected;
+  ui.nip04Encrypt.disabled = !connected;
+  ui.nip04Decrypt.disabled = !connected;
+  ui.nip04SendDm.disabled = !connected;
+  ui.nip17UseSelf.disabled = !connected;
+  ui.nip17SendDm.disabled = !connected;
+}

--- a/examples/parent-sample/src/validation.spec.ts
+++ b/examples/parent-sample/src/validation.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { parsePeerPubkey, parseRelayUrl } from './validation.js';
+
+describe('parsePeerPubkey', () => {
+  it('rejects an empty string', () => {
+    expect(parsePeerPubkey('')).toEqual({ ok: false, reason: 'peer pubkey is empty' });
+  });
+
+  it('rejects whitespace-only input', () => {
+    expect(parsePeerPubkey('   \t\n')).toEqual({ ok: false, reason: 'peer pubkey is empty' });
+  });
+
+  it('accepts a non-empty value and returns the trimmed value', () => {
+    const hex = 'a'.repeat(64);
+    expect(parsePeerPubkey(`  ${hex}  `)).toEqual({ ok: true, value: hex });
+  });
+
+  it('does not validate the pubkey format (matches current behavior)', () => {
+    // Intentional: the existing sample does not pre-validate the pubkey shape —
+    // a malformed key surfaces as an error from the iframe instead. This test
+    // pins that behavior.
+    expect(parsePeerPubkey('npub1example')).toEqual({ ok: true, value: 'npub1example' });
+  });
+});
+
+describe('parseRelayUrl', () => {
+  it('rejects an empty string', () => {
+    expect(parseRelayUrl('')).toEqual({ ok: false, reason: 'relay URL is empty' });
+  });
+
+  it('rejects whitespace-only input', () => {
+    expect(parseRelayUrl('   ')).toEqual({ ok: false, reason: 'relay URL is empty' });
+  });
+
+  it('accepts any non-empty trimmed value (matches current behavior)', () => {
+    expect(parseRelayUrl('  wss://relay.damus.io  ')).toEqual({
+      ok: true,
+      value: 'wss://relay.damus.io',
+    });
+  });
+
+  it('does not validate the URL scheme', () => {
+    // Intentional: the existing sample does not pre-validate scheme — the WebSocket
+    // constructor surfaces the error instead. This test pins that behavior.
+    expect(parseRelayUrl('not-a-url')).toEqual({ ok: true, value: 'not-a-url' });
+  });
+});

--- a/examples/parent-sample/src/validation.ts
+++ b/examples/parent-sample/src/validation.ts
@@ -1,0 +1,19 @@
+/**
+ * Input parsers for the parent-sample UI. Each parser trims whitespace and
+ * returns either the cleaned value or a short reason string that the caller
+ * appends to a context-specific log message ("NIP-04 DM aborted: ...").
+ */
+
+export type ParseResult<T> = { ok: true; value: T } | { ok: false; reason: string };
+
+export function parsePeerPubkey(raw: string): ParseResult<string> {
+  const trimmed = raw.trim();
+  if (!trimmed) return { ok: false, reason: 'peer pubkey is empty' };
+  return { ok: true, value: trimmed };
+}
+
+export function parseRelayUrl(raw: string): ParseResult<string> {
+  const trimmed = raw.trim();
+  if (!trimmed) return { ok: false, reason: 'relay URL is empty' };
+  return { ok: true, value: trimmed };
+}


### PR DESCRIPTION
Extract the 747-line main.ts into a wiring-only entry point plus
testable modules: ui.ts (DOM/theme/modal/log), nips.ts (NIP-04/44
operations), relay.ts (WebSocket publish), and validation.ts (input
parsers). Business modules take NostrProvider/Logger/publish callbacks
as injected dependencies and never touch the DOM, mirroring nip17.ts.

Move the embedded HTML template into index.html as static markup and
add vitest coverage for the extracted pure functions.

https://claude.ai/code/session_01N1xEi1JQ23qWVYJ2ioxd9w