### PR TITLE
fix(consent-dialog): center content vertically in embedded mode

### DIFF
--- a/examples/svelte-app/src/components/ConsentDialog.svelte
+++ b/examples/svelte-app/src/components/ConsentDialog.svelte
@@ -283,5 +283,8 @@ function handleReject() {
     border: 0;
     border-radius: 0;
     box-shadow: none;
+    display: flex;
+    flex-direction: column;
+    justify-content: safe center;
   }
 </style>


### PR DESCRIPTION
In embedded (iframe) mode the consent card is stretched to fill the
iframe viewport, leaving its content stuck to the top with empty space
below. Add flex column layout with safe vertical centering so the
content sits in the middle of the dialog.

https://claude.ai/code/session_01FQbYv85Tu74cfTMTV2Kvps