### PR TITLE
fix(svelte-app): sync consent/cache settings to first-party storage in iframe

### DIFF
--- a/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
+++ b/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
@@ -3,6 +3,7 @@ import { onDestroy, onMount } from 'svelte';
 import { i18n } from '../../i18n/i18n-store.js';
 import { isEmbeddedIframeMode, pendingConsent, startIframeHost } from '../../iframe-mode.js';
 import { getNosskeyManager } from '../../services/nosskey-manager.service.js';
+import { rebindSettingsStorage } from '../../store/app-state.js';
 import ConsentDialog from '../ConsentDialog.svelte';
 import Button from '../ui/button/Button.svelte';
 
@@ -117,6 +118,10 @@ function applyStorageGrant(handle: StorageAccessHandle | null): void {
     // (which shares the same manager) read the unpartitioned store.
     manager.setStorageOptions({ storage: handle.localStorage });
   }
+  // Re-point app settings (consent policy, trusted origins, cache options)
+  // at first-party storage and reload them. On Chromium that is the SAA
+  // handle; on Firefox the grant un-partitions window.localStorage itself.
+  rebindSettingsStorage(handle ? handle.localStorage : window.localStorage);
   if (manager.hasKeyInfo()) {
     uiState = 'granted';
   } else {

--- a/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
+++ b/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
@@ -3,7 +3,7 @@ import { onDestroy, onMount } from 'svelte';
 import { i18n } from '../../i18n/i18n-store.js';
 import { isEmbeddedIframeMode, pendingConsent, startIframeHost } from '../../iframe-mode.js';
 import { getNosskeyManager } from '../../services/nosskey-manager.service.js';
-import { rebindSettingsStorage } from '../../store/app-state.js';
+import { reloadSettings } from '../../store/app-state.js';
 import ConsentDialog from '../ConsentDialog.svelte';
 import Button from '../ui/button/Button.svelte';
 
@@ -118,10 +118,12 @@ function applyStorageGrant(handle: StorageAccessHandle | null): void {
     // (which shares the same manager) read the unpartitioned store.
     manager.setStorageOptions({ storage: handle.localStorage });
   }
-  // Re-point app settings (consent policy, trusted origins, cache options)
-  // at first-party storage and reload them. On Chromium that is the SAA
-  // handle; on Firefox the grant un-partitions window.localStorage itself.
-  rebindSettingsStorage(handle ? handle.localStorage : window.localStorage);
+  // The SDK manager now points at first-party storage (the SAA handle on
+  // Chromium; on Firefox the grant un-partitions window.localStorage and the
+  // manager keeps no handle). Reload app settings so consent policy, trusted
+  // origins and cache options resolve through that same storage — the one
+  // the relay sync already reads via manager.getStorageOptions().storage.
+  reloadSettings();
   if (manager.hasKeyInfo()) {
     uiState = 'granted';
   } else {

--- a/examples/svelte-app/src/components/settings/SecretCacheSettings.svelte
+++ b/examples/svelte-app/src/components/settings/SecretCacheSettings.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { i18n } from '../../i18n/i18n-store.js';
 import { clearSecretCache, getNosskeyManager } from '../../services/nosskey-manager.service.js';
-import { cacheSecrets, cacheTimeout } from '../../store/app-state.js';
+import { cacheSecrets, cacheTimeout } from '../../store/secret-cache-settings.js';
 import CardSection from '../ui/CardSection.svelte';
 import Button from '../ui/button/Button.svelte';
 

--- a/examples/svelte-app/src/services/nosskey-manager.service.ts
+++ b/examples/svelte-app/src/services/nosskey-manager.service.ts
@@ -1,5 +1,5 @@
 import { NosskeyManager } from 'nosskey-sdk';
-import { cacheSecrets, cacheTimeout } from '../store/app-state.js';
+import { cacheSecrets, cacheTimeout } from '../store/secret-cache-settings.js';
 
 // シングルトンインスタンス
 let instance: NosskeyManager | null = null;

--- a/examples/svelte-app/src/services/nosskey-manager.service.ts
+++ b/examples/svelte-app/src/services/nosskey-manager.service.ts
@@ -65,6 +65,15 @@ export function getNosskeyManager(): NosskeyManager {
   return instance;
 }
 
+/**
+ * 既に構築済みの NosskeyManager を返す。未構築なら null を返し、新規構築は
+ * 行わない。`getNosskeyManager()` は `location.host` 参照などの副作用を伴う
+ * ため、モジュール初期化時にストレージハンドルだけ覗きたい経路で使う。
+ */
+export function peekNosskeyManager(): NosskeyManager | null {
+  return instance;
+}
+
 // インスタンスのリセット（主にテスト用）
 export function resetNosskeyManager(): void {
   instance = null;

--- a/examples/svelte-app/src/store/app-state.spec.ts
+++ b/examples/svelte-app/src/store/app-state.spec.ts
@@ -1,0 +1,103 @@
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  cacheSecrets,
+  cacheTimeout,
+  consentPolicy,
+  rebindSettingsStorage,
+  trustedOrigins,
+} from './app-state.js';
+
+/** Map-backed in-memory Storage stand-in for partitioned / first-party buckets. */
+function createFakeStorage(seed: Record<string, string> = {}): Storage {
+  const map = new Map<string, string>(Object.entries(seed));
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (key) => (map.has(key) ? (map.get(key) as string) : null),
+    key: (index) => Array.from(map.keys())[index] ?? null,
+    removeItem: (key) => {
+      map.delete(key);
+    },
+    setItem: (key, value) => {
+      map.set(key, String(value));
+    },
+  };
+}
+
+beforeEach(() => {
+  trustedOrigins.set([]);
+  consentPolicy.set({ signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
+  cacheSecrets.set(true);
+  cacheTimeout.set(300);
+});
+
+describe('rebindSettingsStorage', () => {
+  it('loads consent policy and trusted origins from the rebound storage', () => {
+    const firstParty = createFakeStorage({
+      nosskey_consent_policy: JSON.stringify({ signEvent: 'always', nip44: 'deny', nip04: 'ask' }),
+      nosskey_trusted_origins_v2: JSON.stringify([
+        { origin: 'https://parent.example', methods: ['signEvent'] },
+      ]),
+    });
+    rebindSettingsStorage(firstParty);
+    expect(get(consentPolicy)).toEqual({ signEvent: 'always', nip44: 'deny', nip04: 'ask' });
+    expect(get(trustedOrigins)).toEqual([
+      { origin: 'https://parent.example', methods: ['signEvent'] },
+    ]);
+  });
+
+  it('loads cache settings from the rebound storage', () => {
+    const firstParty = createFakeStorage({
+      nosskey_cache_secrets: 'false',
+      nosskey_cache_timeout: '60',
+    });
+    rebindSettingsStorage(firstParty);
+    expect(get(cacheSecrets)).toBe(false);
+    expect(get(cacheTimeout)).toBe(60);
+  });
+
+  it('falls back to defaults when the rebound storage is empty', () => {
+    rebindSettingsStorage(createFakeStorage());
+    expect(get(consentPolicy)).toEqual({ signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
+    expect(get(trustedOrigins)).toEqual([]);
+    expect(get(cacheSecrets)).toBe(true);
+    expect(get(cacheTimeout)).toBe(300);
+  });
+
+  it('persists subsequent store updates to the rebound storage', () => {
+    const firstParty = createFakeStorage();
+    rebindSettingsStorage(firstParty);
+
+    trustedOrigins.set([{ origin: 'https://parent.example', methods: ['nip44'] }]);
+    consentPolicy.set({ signEvent: 'always', nip44: 'ask', nip04: 'ask' });
+
+    expect(JSON.parse(firstParty.getItem('nosskey_trusted_origins_v2') as string)).toEqual([
+      { origin: 'https://parent.example', methods: ['nip44'] },
+    ]);
+    expect(JSON.parse(firstParty.getItem('nosskey_consent_policy') as string)).toEqual({
+      signEvent: 'always',
+      nip44: 'ask',
+      nip04: 'ask',
+    });
+  });
+
+  it('does not write to the previous storage after rebinding', () => {
+    const partitioned = createFakeStorage();
+    const firstParty = createFakeStorage();
+    rebindSettingsStorage(partitioned);
+    rebindSettingsStorage(firstParty);
+
+    trustedOrigins.set([{ origin: 'https://parent.example', methods: ['signEvent'] }]);
+
+    // The update lands only in the currently-bound (first-party) storage.
+    expect(JSON.parse(firstParty.getItem('nosskey_trusted_origins_v2') as string)).toEqual([
+      { origin: 'https://parent.example', methods: ['signEvent'] },
+    ]);
+    // The previously-bound storage keeps whatever it held at rebind time ([]),
+    // never the post-rebind update.
+    expect(partitioned.getItem('nosskey_trusted_origins_v2')).toBe('[]');
+  });
+});

--- a/examples/svelte-app/src/store/app-state.spec.ts
+++ b/examples/svelte-app/src/store/app-state.spec.ts
@@ -1,14 +1,16 @@
+// @vitest-environment happy-dom
 import { get } from 'svelte/store';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { getNosskeyManager, resetNosskeyManager } from '../services/nosskey-manager.service.js';
 import {
   cacheSecrets,
   cacheTimeout,
   consentPolicy,
-  rebindSettingsStorage,
+  reloadSettings,
   trustedOrigins,
 } from './app-state.js';
 
-/** Map-backed in-memory Storage stand-in for partitioned / first-party buckets. */
+/** Map-backed in-memory Storage stand-in for a first-party storage handle. */
 function createFakeStorage(seed: Record<string, string> = {}): Storage {
   const map = new Map<string, string>(Object.entries(seed));
   return {
@@ -27,68 +29,69 @@ function createFakeStorage(seed: Record<string, string> = {}): Storage {
   };
 }
 
+/**
+ * Point the shared SDK manager at a fresh first-party storage handle, the
+ * way IframeHostScreen does after a Storage Access API grant. Settings then
+ * resolve their storage through the same manager handle the relay sync uses.
+ */
+function grantFirstPartyStorage(seed: Record<string, string> = {}): Storage {
+  const firstParty = createFakeStorage(seed);
+  getNosskeyManager().setStorageOptions({ storage: firstParty });
+  return firstParty;
+}
+
 beforeEach(() => {
+  resetNosskeyManager();
   trustedOrigins.set([]);
   consentPolicy.set({ signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
   cacheSecrets.set(true);
   cacheTimeout.set(300);
 });
 
-describe('rebindSettingsStorage', () => {
-  it('loads consent policy and trusted origins from the rebound storage', () => {
-    const firstParty = createFakeStorage({
+describe('reloadSettings', () => {
+  it('reads consent policy and trusted origins from the granted storage handle', () => {
+    grantFirstPartyStorage({
       nosskey_consent_policy: JSON.stringify({ signEvent: 'always', nip44: 'deny', nip04: 'ask' }),
       nosskey_trusted_origins_v2: JSON.stringify([
         { origin: 'https://parent.example', methods: ['signEvent'] },
       ]),
     });
-    rebindSettingsStorage(firstParty);
+    reloadSettings();
     expect(get(consentPolicy)).toEqual({ signEvent: 'always', nip44: 'deny', nip04: 'ask' });
     expect(get(trustedOrigins)).toEqual([
       { origin: 'https://parent.example', methods: ['signEvent'] },
     ]);
   });
 
-  it('loads cache settings from the rebound storage', () => {
-    const firstParty = createFakeStorage({
-      nosskey_cache_secrets: 'false',
-      nosskey_cache_timeout: '60',
-    });
-    rebindSettingsStorage(firstParty);
+  it('reads cache settings from the granted storage handle', () => {
+    grantFirstPartyStorage({ nosskey_cache_secrets: 'false', nosskey_cache_timeout: '60' });
+    reloadSettings();
     expect(get(cacheSecrets)).toBe(false);
     expect(get(cacheTimeout)).toBe(60);
   });
 
-  it('falls back to defaults when the rebound storage is empty', () => {
-    rebindSettingsStorage(createFakeStorage());
+  it('falls back to defaults when the granted storage is empty', () => {
+    grantFirstPartyStorage();
+    reloadSettings();
     expect(get(consentPolicy)).toEqual({ signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
     expect(get(trustedOrigins)).toEqual([]);
     expect(get(cacheSecrets)).toBe(true);
     expect(get(cacheTimeout)).toBe(300);
   });
 
-  it('persists subsequent store updates to the rebound storage', () => {
-    const firstParty = createFakeStorage();
-    rebindSettingsStorage(firstParty);
-
-    trustedOrigins.set([{ origin: 'https://parent.example', methods: ['nip44'] }]);
-    consentPolicy.set({ signEvent: 'always', nip44: 'ask', nip04: 'ask' });
-
-    expect(JSON.parse(firstParty.getItem('nosskey_trusted_origins_v2') as string)).toEqual([
-      { origin: 'https://parent.example', methods: ['nip44'] },
-    ]);
-    expect(JSON.parse(firstParty.getItem('nosskey_consent_policy') as string)).toEqual({
-      signEvent: 'always',
-      nip44: 'ask',
-      nip04: 'ask',
-    });
+  it('falls back to the default cache timeout when the stored value is corrupt', () => {
+    grantFirstPartyStorage({ nosskey_cache_timeout: 'not-a-number' });
+    reloadSettings();
+    expect(get(cacheTimeout)).toBe(300);
   });
+});
 
-  it('persists a trustedOrigins.update() to the rebound storage', () => {
-    // Mirrors iframe-mode.ts rememberOriginIfRequested: the "always allow"
-    // path during sign & publish appends via update(), not set().
-    const firstParty = createFakeStorage();
-    rebindSettingsStorage(firstParty);
+describe('settings persistence after a storage grant', () => {
+  it('persists a trustedOrigins.update() to the granted storage handle', () => {
+    // Mirrors iframe-mode.ts rememberOriginIfRequested: the consent dialog
+    // "always allow" path appends via update(), not set().
+    const firstParty = grantFirstPartyStorage();
+    reloadSettings();
 
     trustedOrigins.update((list) => [
       ...list,
@@ -100,25 +103,19 @@ describe('rebindSettingsStorage', () => {
     ]);
   });
 
-  it('falls back to the default cache timeout when the stored value is corrupt', () => {
-    rebindSettingsStorage(createFakeStorage({ nosskey_cache_timeout: 'not-a-number' }));
-    expect(get(cacheTimeout)).toBe(300);
-  });
+  it('writes through the same handle the SDK manager exposes for relay sync', () => {
+    const firstParty = grantFirstPartyStorage();
+    reloadSettings();
 
-  it('does not write to the previous storage after rebinding', () => {
-    const partitioned = createFakeStorage();
-    const firstParty = createFakeStorage();
-    rebindSettingsStorage(partitioned);
-    rebindSettingsStorage(firstParty);
+    consentPolicy.set({ signEvent: 'always', nip44: 'ask', nip04: 'ask' });
 
-    trustedOrigins.set([{ origin: 'https://parent.example', methods: ['signEvent'] }]);
-
-    // The update lands only in the currently-bound (first-party) storage.
-    expect(JSON.parse(firstParty.getItem('nosskey_trusted_origins_v2') as string)).toEqual([
-      { origin: 'https://parent.example', methods: ['signEvent'] },
-    ]);
-    // The previously-bound storage keeps whatever it held at rebind time ([]),
-    // never the post-rebind update.
-    expect(partitioned.getItem('nosskey_trusted_origins_v2')).toBe('[]');
+    // The settings handle and the relay handle are one and the same:
+    // manager.getStorageOptions().storage. No second copy is kept.
+    expect(getNosskeyManager().getStorageOptions().storage).toBe(firstParty);
+    expect(JSON.parse(firstParty.getItem('nosskey_consent_policy') as string)).toEqual({
+      signEvent: 'always',
+      nip44: 'ask',
+      nip04: 'ask',
+    });
   });
 });

--- a/examples/svelte-app/src/store/app-state.spec.ts
+++ b/examples/svelte-app/src/store/app-state.spec.ts
@@ -84,6 +84,27 @@ describe('rebindSettingsStorage', () => {
     });
   });
 
+  it('persists a trustedOrigins.update() to the rebound storage', () => {
+    // Mirrors iframe-mode.ts rememberOriginIfRequested: the "always allow"
+    // path during sign & publish appends via update(), not set().
+    const firstParty = createFakeStorage();
+    rebindSettingsStorage(firstParty);
+
+    trustedOrigins.update((list) => [
+      ...list,
+      { origin: 'https://parent.example', methods: ['signEvent'] },
+    ]);
+
+    expect(JSON.parse(firstParty.getItem('nosskey_trusted_origins_v2') as string)).toEqual([
+      { origin: 'https://parent.example', methods: ['signEvent'] },
+    ]);
+  });
+
+  it('falls back to the default cache timeout when the stored value is corrupt', () => {
+    rebindSettingsStorage(createFakeStorage({ nosskey_cache_timeout: 'not-a-number' }));
+    expect(get(cacheTimeout)).toBe(300);
+  });
+
   it('does not write to the previous storage after rebinding', () => {
     const partitioned = createFakeStorage();
     const firstParty = createFakeStorage();

--- a/examples/svelte-app/src/store/app-state.spec.ts
+++ b/examples/svelte-app/src/store/app-state.spec.ts
@@ -2,13 +2,8 @@
 import { get } from 'svelte/store';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { getNosskeyManager, resetNosskeyManager } from '../services/nosskey-manager.service.js';
-import {
-  cacheSecrets,
-  cacheTimeout,
-  consentPolicy,
-  reloadSettings,
-  trustedOrigins,
-} from './app-state.js';
+import { consentPolicy, reloadSettings, trustedOrigins } from './app-state.js';
+import { cacheSecrets, cacheTimeout } from './secret-cache-settings.js';
 
 /** Map-backed in-memory Storage stand-in for a first-party storage handle. */
 function createFakeStorage(seed: Record<string, string> = {}): Storage {

--- a/examples/svelte-app/src/store/app-state.ts
+++ b/examples/svelte-app/src/store/app-state.ts
@@ -64,6 +64,15 @@ export const currentTheme = writable<ThemeMode>('dark');
 // localStorage には書き戻さない（次回スタンドアロン起動時にユーザー設定を保つため）。
 let embeddedThemeOverride = false;
 
+/**
+ * 設定の永続化先 Storage。スタンドアロン（ファーストパーティ）では
+ * `window.localStorage` で正しい。クロスオリジン埋め込み iframe では
+ * Chromium が `window.localStorage` をパーティションのまま残すため、
+ * Storage Access API グラント後に `rebindSettingsStorage()` で
+ * first-party ハンドルへ張り替える。
+ */
+let settingsStorage: Storage | null = typeof window !== 'undefined' ? window.localStorage : null;
+
 // 同意ゲート設定
 export const trustedOrigins = writable<TrustedOriginEntry[]>([]);
 export const consentPolicy = writable<ConsentPolicy>({ ...DEFAULT_CONSENT_POLICY });
@@ -98,23 +107,17 @@ export const storageCorruption = writable<{
 }>({ trustedOrigins: false, consentPolicy: false });
 
 // 秘密鍵情報のキャッシュ設定を読み込む
-function loadCacheSecretsSetting() {
-  if (typeof window !== 'undefined') {
-    const saved = localStorage.getItem('nosskey_cache_secrets');
-    // デフォルトはtrue（キャッシュする）
-    return saved === null ? true : saved === 'true';
-  }
-  return true;
+function loadCacheSecretsSetting(storage: Storage | null = settingsStorage): boolean {
+  const saved = storage?.getItem('nosskey_cache_secrets') ?? null;
+  // デフォルトはtrue（キャッシュする）
+  return saved === null ? true : saved === 'true';
 }
 
 // キャッシュタイムアウト設定を読み込む
-function loadCacheTimeoutSetting() {
-  if (typeof window !== 'undefined') {
-    const saved = localStorage.getItem('nosskey_cache_timeout');
-    // デフォルトは300秒（5分）
-    return saved === null ? 300 : Number.parseInt(saved, 10);
-  }
-  return 300;
+function loadCacheTimeoutSetting(storage: Storage | null = settingsStorage): number {
+  const saved = storage?.getItem('nosskey_cache_timeout') ?? null;
+  // デフォルトは300秒（5分）
+  return saved === null ? 300 : Number.parseInt(saved, 10);
 }
 
 // テーマ設定を読み込む
@@ -138,9 +141,8 @@ function markCorruption(field: 'trustedOrigins' | 'consentPolicy', reason: strin
 }
 
 // 信頼済みオリジン (v2: メソッドスコープ付き) を読み込む
-function loadTrustedOrigins(): TrustedOriginEntry[] {
-  if (typeof window === 'undefined') return [];
-  const raw = localStorage.getItem(TRUSTED_ORIGINS_KEY);
+function loadTrustedOrigins(storage: Storage | null = settingsStorage): TrustedOriginEntry[] {
+  const raw = storage?.getItem(TRUSTED_ORIGINS_KEY);
   if (!raw) return [];
   try {
     const parsed = JSON.parse(raw);
@@ -174,9 +176,8 @@ function loadTrustedOrigins(): TrustedOriginEntry[] {
 }
 
 // 同意ポリシーを読み込む
-function loadConsentPolicy(): ConsentPolicy {
-  if (typeof window === 'undefined') return { ...DEFAULT_CONSENT_POLICY };
-  const raw = localStorage.getItem(CONSENT_POLICY_KEY);
+function loadConsentPolicy(storage: Storage | null = settingsStorage): ConsentPolicy {
+  const raw = storage?.getItem(CONSENT_POLICY_KEY);
   if (!raw) return { ...DEFAULT_CONSENT_POLICY };
   try {
     const parsed = JSON.parse(raw) as Partial<Record<keyof ConsentPolicy, unknown>>;
@@ -224,15 +225,11 @@ try {
 
   // 設定が変更されたら保存
   cacheSecrets.subscribe((value) => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('nosskey_cache_secrets', String(value));
-    }
+    settingsStorage?.setItem('nosskey_cache_secrets', String(value));
   });
 
   cacheTimeout.subscribe((value) => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('nosskey_cache_timeout', String(value));
-    }
+    settingsStorage?.setItem('nosskey_cache_timeout', String(value));
   });
 
   currentTheme.subscribe((value) => {
@@ -246,18 +243,33 @@ try {
   consentPolicy.set(loadConsentPolicy());
 
   trustedOrigins.subscribe((value) => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem(TRUSTED_ORIGINS_KEY, JSON.stringify(value));
-    }
+    settingsStorage?.setItem(TRUSTED_ORIGINS_KEY, JSON.stringify(value));
   });
 
   consentPolicy.subscribe((value) => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem(CONSENT_POLICY_KEY, JSON.stringify(value));
-    }
+    settingsStorage?.setItem(CONSENT_POLICY_KEY, JSON.stringify(value));
   });
 } catch (e) {
   console.error('設定の初期化に失敗しました:', e);
+}
+
+/**
+ * 設定の永続化先を first-party ストレージハンドルへ張り替え、全設定を
+ * そのハンドルから読み直す。クロスオリジン埋め込み iframe で Storage Access
+ * API のグラントを得た直後に呼ぶ。Chromium はグラント後も
+ * `window.localStorage` をパーティションのまま残すため、ハンドル経由でしか
+ * first-party ストレージへ到達できない。
+ *
+ * `.set()` により登録済みの subscriber が発火し、読み直した値がハンドルへ
+ * 書き戻される（冪等）。テーマは埋め込み時に親オリジンが指定する既存仕様の
+ * ため対象外。
+ */
+export function rebindSettingsStorage(storage: Storage): void {
+  settingsStorage = storage;
+  cacheSecrets.set(loadCacheSecretsSetting(storage));
+  cacheTimeout.set(loadCacheTimeoutSetting(storage));
+  trustedOrigins.set(loadTrustedOrigins(storage));
+  consentPolicy.set(loadConsentPolicy(storage));
 }
 
 // リセット関数

--- a/examples/svelte-app/src/store/app-state.ts
+++ b/examples/svelte-app/src/store/app-state.ts
@@ -1,5 +1,6 @@
 import { writable } from 'svelte/store';
 import { getNosskeyManager, peekNosskeyManager } from '../services/nosskey-manager.service.js';
+import { cacheSecrets, cacheTimeout } from './secret-cache-settings.js';
 
 export type ScreenName = 'account' | 'settings' | 'key' | 'iframe';
 
@@ -52,10 +53,6 @@ export const isLoggedIn = writable(false);
 // Nostrキー情報
 export const publicKey = writable<string | null>(null);
 
-// アプリケーション設定
-export const cacheSecrets = writable<boolean>(true); // 秘密鍵情報をキャッシュするかどうか
-export const cacheTimeout = writable<number>(300); // キャッシュのタイムアウト時間（秒）
-
 // テーマ設定
 export type ThemeMode = 'light' | 'dark' | 'auto';
 export const currentTheme = writable<ThemeMode>('dark');
@@ -64,27 +61,19 @@ export const currentTheme = writable<ThemeMode>('dark');
 // localStorage には書き戻さない（次回スタンドアロン起動時にユーザー設定を保つため）。
 let embeddedThemeOverride = false;
 
-// 同期的なモジュール初期化フェーズが終わったら true（成否を問わず）。
-// `resolveSettingsStorage()` が SDK マネージャを参照してよいかの判定に使う
-// （理由は同関数のコメント）。
-let settingsInitDone = false;
-
 /**
  * 設定の永続化先 Storage を解決する。SDK マネージャが Storage Access API
  * グラント後のハンドルを保持していれば、それを使う。これはリレー設定が読む
  * `manager.getStorageOptions().storage` と同一参照であり、handle の正本は
  * SDK マネージャ 1 箇所に集約される。未グラント / スタンドアロンでは
  * `window.localStorage`（= ファーストパーティ）。
+ *
+ * `peekNosskeyManager()`（未構築なら null、新規構築しない）を使うため、
+ * モジュール初期化中に呼ばれてもマネージャを構築せず安全。
  */
 function resolveSettingsStorage(): Storage | null {
-  // app-state ↔ nosskey-manager.service は循環 import。モジュール初期化中に
-  // peekNosskeyManager() を呼ぶと import 順次第で service 側の `instance` が
-  // TDZ になり ReferenceError を投げうる。初期化中は first-party storage =
-  // window.localStorage で確定なので、初期化完了まではマネージャを参照しない。
-  if (settingsInitDone) {
-    const handle = peekNosskeyManager()?.getStorageOptions().storage;
-    if (handle) return handle;
-  }
+  const handle = peekNosskeyManager()?.getStorageOptions().storage;
+  if (handle) return handle;
   return typeof window !== 'undefined' ? window.localStorage : null;
 }
 
@@ -269,12 +258,6 @@ try {
   });
 } catch (e) {
   console.error('設定の初期化に失敗しました:', e);
-} finally {
-  // 同期的な初期化フェーズの終了。初期化が例外で中断しても必ずフラグを立てる。
-  // 以降 resolveSettingsStorage() が呼ばれるのは必ずモジュール評価完了後
-  // （runtime）であり TDZ の心配はない。逆に false のまま固定すると、SAA
-  // grant 後も partitioned storage を読み続け設定同期が静かに壊れる。
-  settingsInitDone = true;
 }
 
 /**

--- a/examples/svelte-app/src/store/app-state.ts
+++ b/examples/svelte-app/src/store/app-state.ts
@@ -1,5 +1,5 @@
 import { writable } from 'svelte/store';
-import { getNosskeyManager } from '../services/nosskey-manager.service.js';
+import { getNosskeyManager, peekNosskeyManager } from '../services/nosskey-manager.service.js';
 
 export type ScreenName = 'account' | 'settings' | 'key' | 'iframe';
 
@@ -64,14 +64,28 @@ export const currentTheme = writable<ThemeMode>('dark');
 // localStorage には書き戻さない（次回スタンドアロン起動時にユーザー設定を保つため）。
 let embeddedThemeOverride = false;
 
+// 下記初期化ブロックが最後まで走り切ったら true。`resolveSettingsStorage()`
+// が SDK マネージャを参照してよいかの判定に使う（理由は同関数のコメント）。
+let settingsInitDone = false;
+
 /**
- * 設定の永続化先 Storage。スタンドアロン（ファーストパーティ）では
- * `window.localStorage` で正しい。クロスオリジン埋め込み iframe では
- * Chromium が `window.localStorage` をパーティションのまま残すため、
- * Storage Access API グラント後に `rebindSettingsStorage()` で
- * first-party ハンドルへ張り替える。
+ * 設定の永続化先 Storage を解決する。SDK マネージャが Storage Access API
+ * グラント後のハンドルを保持していれば、それを使う。これはリレー設定が読む
+ * `manager.getStorageOptions().storage` と同一参照であり、handle の正本は
+ * SDK マネージャ 1 箇所に集約される。未グラント / スタンドアロンでは
+ * `window.localStorage`（= ファーストパーティ）。
  */
-let settingsStorage: Storage | null = typeof window !== 'undefined' ? window.localStorage : null;
+function resolveSettingsStorage(): Storage | null {
+  // app-state ↔ nosskey-manager.service は循環 import。モジュール初期化中に
+  // peekNosskeyManager() を呼ぶと import 順次第で service 側の `instance` が
+  // TDZ になり ReferenceError を投げうる。初期化中は first-party storage =
+  // window.localStorage で確定なので、初期化完了まではマネージャを参照しない。
+  if (settingsInitDone) {
+    const handle = peekNosskeyManager()?.getStorageOptions().storage;
+    if (handle) return handle;
+  }
+  return typeof window !== 'undefined' ? window.localStorage : null;
+}
 
 // 同意ゲート設定
 export const trustedOrigins = writable<TrustedOriginEntry[]>([]);
@@ -107,18 +121,18 @@ export const storageCorruption = writable<{
 }>({ trustedOrigins: false, consentPolicy: false });
 
 // 秘密鍵情報のキャッシュ設定を読み込む
-function loadCacheSecretsSetting(storage: Storage | null = settingsStorage): boolean {
-  const saved = storage?.getItem('nosskey_cache_secrets') ?? null;
+function loadCacheSecretsSetting(): boolean {
+  const saved = resolveSettingsStorage()?.getItem('nosskey_cache_secrets') ?? null;
   // デフォルトはtrue（キャッシュする）
   return saved === null ? true : saved === 'true';
 }
 
 // キャッシュタイムアウト設定を読み込む
-function loadCacheTimeoutSetting(storage: Storage | null = settingsStorage): number {
-  const saved = storage?.getItem('nosskey_cache_timeout') ?? null;
+function loadCacheTimeoutSetting(): number {
+  const saved = resolveSettingsStorage()?.getItem('nosskey_cache_timeout') ?? null;
   if (saved === null) return 300; // デフォルトは300秒（5分）
-  // 破損値（NaN 等）はデフォルトに倒す。rebind 経由で first-party の壊れた値を
-  // 取り込んだ場合に NaN が SDK の timeoutMs まで伝播するのを防ぐ。
+  // 破損値（NaN 等）はデフォルトに倒す。reloadSettings 経由で first-party の
+  // 壊れた値を取り込んだ場合に NaN が SDK の timeoutMs まで伝播するのを防ぐ。
   const parsed = Number.parseInt(saved, 10);
   return Number.isFinite(parsed) ? parsed : 300;
 }
@@ -144,8 +158,8 @@ function markCorruption(field: 'trustedOrigins' | 'consentPolicy', reason: strin
 }
 
 // 信頼済みオリジン (v2: メソッドスコープ付き) を読み込む
-function loadTrustedOrigins(storage: Storage | null = settingsStorage): TrustedOriginEntry[] {
-  const raw = storage?.getItem(TRUSTED_ORIGINS_KEY);
+function loadTrustedOrigins(): TrustedOriginEntry[] {
+  const raw = resolveSettingsStorage()?.getItem(TRUSTED_ORIGINS_KEY);
   if (!raw) return [];
   try {
     const parsed = JSON.parse(raw);
@@ -179,8 +193,8 @@ function loadTrustedOrigins(storage: Storage | null = settingsStorage): TrustedO
 }
 
 // 同意ポリシーを読み込む
-function loadConsentPolicy(storage: Storage | null = settingsStorage): ConsentPolicy {
-  const raw = storage?.getItem(CONSENT_POLICY_KEY);
+function loadConsentPolicy(): ConsentPolicy {
+  const raw = resolveSettingsStorage()?.getItem(CONSENT_POLICY_KEY);
   if (!raw) return { ...DEFAULT_CONSENT_POLICY };
   try {
     const parsed = JSON.parse(raw) as Partial<Record<keyof ConsentPolicy, unknown>>;
@@ -228,11 +242,11 @@ try {
 
   // 設定が変更されたら保存
   cacheSecrets.subscribe((value) => {
-    settingsStorage?.setItem('nosskey_cache_secrets', String(value));
+    resolveSettingsStorage()?.setItem('nosskey_cache_secrets', String(value));
   });
 
   cacheTimeout.subscribe((value) => {
-    settingsStorage?.setItem('nosskey_cache_timeout', String(value));
+    resolveSettingsStorage()?.setItem('nosskey_cache_timeout', String(value));
   });
 
   currentTheme.subscribe((value) => {
@@ -246,32 +260,33 @@ try {
   consentPolicy.set(loadConsentPolicy());
 
   trustedOrigins.subscribe((value) => {
-    settingsStorage?.setItem(TRUSTED_ORIGINS_KEY, JSON.stringify(value));
+    resolveSettingsStorage()?.setItem(TRUSTED_ORIGINS_KEY, JSON.stringify(value));
   });
 
   consentPolicy.subscribe((value) => {
-    settingsStorage?.setItem(CONSENT_POLICY_KEY, JSON.stringify(value));
+    resolveSettingsStorage()?.setItem(CONSENT_POLICY_KEY, JSON.stringify(value));
   });
+
+  // 初期化完了。以降 resolveSettingsStorage() は SDK マネージャを参照する。
+  settingsInitDone = true;
 } catch (e) {
   console.error('設定の初期化に失敗しました:', e);
 }
 
 /**
- * 設定の永続化先を first-party ストレージハンドルへ張り替え、全設定を
- * そのハンドルから読み直す。クロスオリジン埋め込み iframe で Storage Access
- * API のグラントを得た直後に呼ぶ。Chromium はグラント後も
- * `window.localStorage` をパーティションのまま残すため、ハンドル経由でしか
- * first-party ストレージへ到達できない。
- *
- * `.set()` により登録済みの subscriber が発火し、読み直した値がハンドルへ
- * 書き戻される。テーマは埋め込み時に親オリジンが指定する既存仕様のため対象外。
+ * 全設定を現在のストレージ（`resolveSettingsStorage()`）から読み直す。
+ * クロスオリジン埋め込み iframe で Storage Access API のグラントを得て
+ * `NosskeyManager.setStorageOptions({ storage })` を呼んだ直後に実行する。
+ * モジュール初期化時は partitioned 側を読んでいるため、grant 後に
+ * first-party の値で上書きする必要がある。以降の subscriber 書き込みも
+ * 同じハンドル（リレー設定と共通の `manager.getStorageOptions().storage`）へ
+ * 向かう。テーマは埋め込み時に親オリジンが指定する既存仕様のため対象外。
  */
-export function rebindSettingsStorage(storage: Storage): void {
-  settingsStorage = storage;
-  cacheSecrets.set(loadCacheSecretsSetting(storage));
-  cacheTimeout.set(loadCacheTimeoutSetting(storage));
-  trustedOrigins.set(loadTrustedOrigins(storage));
-  consentPolicy.set(loadConsentPolicy(storage));
+export function reloadSettings(): void {
+  cacheSecrets.set(loadCacheSecretsSetting());
+  cacheTimeout.set(loadCacheTimeoutSetting());
+  trustedOrigins.set(loadTrustedOrigins());
+  consentPolicy.set(loadConsentPolicy());
 }
 
 // リセット関数

--- a/examples/svelte-app/src/store/app-state.ts
+++ b/examples/svelte-app/src/store/app-state.ts
@@ -64,8 +64,9 @@ export const currentTheme = writable<ThemeMode>('dark');
 // localStorage には書き戻さない（次回スタンドアロン起動時にユーザー設定を保つため）。
 let embeddedThemeOverride = false;
 
-// 下記初期化ブロックが最後まで走り切ったら true。`resolveSettingsStorage()`
-// が SDK マネージャを参照してよいかの判定に使う（理由は同関数のコメント）。
+// 同期的なモジュール初期化フェーズが終わったら true（成否を問わず）。
+// `resolveSettingsStorage()` が SDK マネージャを参照してよいかの判定に使う
+// （理由は同関数のコメント）。
 let settingsInitDone = false;
 
 /**
@@ -266,19 +267,22 @@ try {
   consentPolicy.subscribe((value) => {
     resolveSettingsStorage()?.setItem(CONSENT_POLICY_KEY, JSON.stringify(value));
   });
-
-  // 初期化完了。以降 resolveSettingsStorage() は SDK マネージャを参照する。
-  settingsInitDone = true;
 } catch (e) {
   console.error('設定の初期化に失敗しました:', e);
+} finally {
+  // 同期的な初期化フェーズの終了。初期化が例外で中断しても必ずフラグを立てる。
+  // 以降 resolveSettingsStorage() が呼ばれるのは必ずモジュール評価完了後
+  // （runtime）であり TDZ の心配はない。逆に false のまま固定すると、SAA
+  // grant 後も partitioned storage を読み続け設定同期が静かに壊れる。
+  settingsInitDone = true;
 }
 
 /**
  * 全設定を現在のストレージ（`resolveSettingsStorage()`）から読み直す。
  * クロスオリジン埋め込み iframe で Storage Access API のグラントを得て
  * `NosskeyManager.setStorageOptions({ storage })` を呼んだ直後に実行する。
- * モジュール初期化時は partitioned 側を読んでいるため、grant 後に
- * first-party の値で上書きする必要がある。以降の subscriber 書き込みも
+ * 埋め込み iframe ではモジュール初期化時に partitioned 側を読んでいるため、
+ * grant 後に first-party の値で読み直す必要がある。以降の subscriber 書き込みも
  * 同じハンドル（リレー設定と共通の `manager.getStorageOptions().storage`）へ
  * 向かう。テーマは埋め込み時に親オリジンが指定する既存仕様のため対象外。
  */

--- a/examples/svelte-app/src/store/app-state.ts
+++ b/examples/svelte-app/src/store/app-state.ts
@@ -116,8 +116,11 @@ function loadCacheSecretsSetting(storage: Storage | null = settingsStorage): boo
 // キャッシュタイムアウト設定を読み込む
 function loadCacheTimeoutSetting(storage: Storage | null = settingsStorage): number {
   const saved = storage?.getItem('nosskey_cache_timeout') ?? null;
-  // デフォルトは300秒（5分）
-  return saved === null ? 300 : Number.parseInt(saved, 10);
+  if (saved === null) return 300; // デフォルトは300秒（5分）
+  // 破損値（NaN 等）はデフォルトに倒す。rebind 経由で first-party の壊れた値を
+  // 取り込んだ場合に NaN が SDK の timeoutMs まで伝播するのを防ぐ。
+  const parsed = Number.parseInt(saved, 10);
+  return Number.isFinite(parsed) ? parsed : 300;
 }
 
 // テーマ設定を読み込む
@@ -261,8 +264,7 @@ try {
  * first-party ストレージへ到達できない。
  *
  * `.set()` により登録済みの subscriber が発火し、読み直した値がハンドルへ
- * 書き戻される（冪等）。テーマは埋め込み時に親オリジンが指定する既存仕様の
- * ため対象外。
+ * 書き戻される。テーマは埋め込み時に親オリジンが指定する既存仕様のため対象外。
  */
 export function rebindSettingsStorage(storage: Storage): void {
   settingsStorage = storage;

--- a/examples/svelte-app/src/store/secret-cache-settings.ts
+++ b/examples/svelte-app/src/store/secret-cache-settings.ts
@@ -1,0 +1,18 @@
+import { writable } from 'svelte/store';
+
+/**
+ * 秘密鍵キャッシュ設定ストア。SDK の `KeyCache`（PRF 由来の秘密鍵を一定時間
+ * メモリ保持し、操作ごとのパスキー再認証を省く仕組み）を駆動する。
+ *
+ * このモジュールは `svelte/store` だけに依存する leaf。`app-state.ts` と
+ * `nosskey-manager.service.ts` の双方から import されるが、`app-state` ⇄
+ * `nosskey-manager.service` の循環 import を生まないよう、ここにはストアの
+ * 定義のみを置く。読み込み・永続化は `app-state.ts`、SDK への反映は
+ * `nosskey-manager.service.ts` がそれぞれ担う。
+ */
+
+/** 秘密鍵情報をメモリにキャッシュするか。 */
+export const cacheSecrets = writable<boolean>(true);
+
+/** キャッシュのタイムアウト時間（秒）。 */
+export const cacheTimeout = writable<number>(300);


### PR DESCRIPTION
Consent policy, trusted origins and cache options were read/written via
the partitioned window.localStorage, so settings changed inside a
cross-origin embedded iframe (e.g. "always allow" during sign & publish)
never reached first-party storage. Route their persistence through a
rebindable storage handle and reload from the Storage Access API grant,
matching how relay settings already sync.

https://claude.ai/code/session_01VLkxsBN7CVcMEtLvTpnPDG