### PR TITLE
refactor(sdk): drop unused nip04 low-level barrel exports

### DIFF
--- a/docs/en/nosskey-sdk-interface.en.md
+++ b/docs/en/nosskey-sdk-interface.en.md
@@ -277,9 +277,9 @@ export interface SignOptions {
 
 In addition to the `NosskeyManager` class and type definitions, the `nosskey-sdk` entry point (barrel) exposes the following standalone functions.
 
-### Low-level Encryption Functions (NIP-44 / NIP-04)
+### Low-level NIP-44 Functions
 
-Unlike the `NosskeyManager` methods such as `nip44Encrypt()`, which manage the private key internally, these standalone functions take the private key (`Uint8Array`) directly as an argument. **Note that they share the method names but have different signatures.**
+Unlike the `NosskeyManager` methods such as `nip44Encrypt()`, which manage the private key internally, these standalone functions take the private key (`Uint8Array`) directly as an argument. **Note that they share the method names but have different signatures.** Use them when you need to encrypt with an ephemeral private key rather than the registered passkey-derived key (e.g. NIP-17 gift-wrap).
 
 ```typescript
 function nip44Encrypt(
@@ -290,16 +290,9 @@ function nip44Encrypt(
 ): string
 
 function nip44Decrypt(payload: string, ourSecretKey: Uint8Array, peerPubkeyHex: string): string
-
-function nip04Encrypt(
-  plaintext: string,
-  ourSecretKey: Uint8Array,
-  peerPubkeyHex: string,
-  ivOverride?: Uint8Array
-): string
-
-function nip04Decrypt(payload: string, ourSecretKey: Uint8Array, peerPubkeyHex: string): string
 ```
+
+The low-level NIP-04 functions are not exported. For NIP-04 encryption/decryption, use the `NosskeyManager` `nip04Encrypt()` / `nip04Decrypt()` methods.
 
 ### PRF Handler Functions
 

--- a/docs/ja/nosskey-sdk-interface.ja.md
+++ b/docs/ja/nosskey-sdk-interface.ja.md
@@ -277,9 +277,9 @@ export interface SignOptions {
 
 `nosskey-sdk` のエントリポイント（barrel）は、`NosskeyManager` クラスと型定義に加えて以下のスタンドアロン関数を公開しています。
 
-### 低レベル暗号化関数（NIP-44 / NIP-04）
+### 低レベル NIP-44 関数
 
-`NosskeyManager.nip44Encrypt()` などのメソッドが内部で秘密鍵を管理するのに対し、これらのスタンドアロン関数は秘密鍵（`Uint8Array`）を引数として直接受け取ります。**メソッドと同名でもシグネチャが異なる**点に注意してください。
+`NosskeyManager.nip44Encrypt()` メソッドが内部で秘密鍵を管理するのに対し、これらのスタンドアロン関数は秘密鍵（`Uint8Array`）を引数として直接受け取ります。**メソッドと同名でもシグネチャが異なる**点に注意してください。登録済みパスキー鍵ではなく ephemeral 秘密鍵で暗号化したいケース（NIP-17 gift-wrap など）で使用します。
 
 ```typescript
 function nip44Encrypt(
@@ -290,16 +290,9 @@ function nip44Encrypt(
 ): string
 
 function nip44Decrypt(payload: string, ourSecretKey: Uint8Array, peerPubkeyHex: string): string
-
-function nip04Encrypt(
-  plaintext: string,
-  ourSecretKey: Uint8Array,
-  peerPubkeyHex: string,
-  ivOverride?: Uint8Array
-): string
-
-function nip04Decrypt(payload: string, ourSecretKey: Uint8Array, peerPubkeyHex: string): string
 ```
+
+NIP-04 の低レベル関数はエクスポートしていません。NIP-04 の暗号化/復号は `NosskeyManager` の `nip04Encrypt()` / `nip04Decrypt()` メソッドを使用してください。
 
 ### PRF ハンドラー関数
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -3,7 +3,7 @@
 ## ドキュメント関連
 - [ ] README.mdの充実：使用方法やサンプルコードの追加
 - [ ] 他のNostrライブラリとの統合例をドキュメントに追加
-- [x] SDKインターフェースドキュメント(`docs/{ja,en}/nosskey-sdk-interface`)を実装に同期 — NIP-44/NIP-04 の4メソッド(`nip44Encrypt/Decrypt`・`nip04Encrypt/Decrypt`)、ja版 `createNostrKey` のシグネチャ(`options` 引数)、コンストラクタの `prfOptions`(+`GetPrfSecretOptions` 型)を両言語版に反映。barrel が公開する標準関数(nip44/nip04 低レベル関数・PRFハンドラー関数・バイト変換・テストユーティリティ)を「パッケージエクスポート」節として追加。`crypto-utils.ts` は削除済み
+- [x] SDKインターフェースドキュメント(`docs/{ja,en}/nosskey-sdk-interface`)を実装に同期 — NIP-44/NIP-04 の4メソッド(`nip44Encrypt/Decrypt`・`nip04Encrypt/Decrypt`)、ja版 `createNostrKey` のシグネチャ(`options` 引数)、コンストラクタの `prfOptions`(+`GetPrfSecretOptions` 型)を両言語版に反映。barrel が公開する標準関数(nip44 低レベル関数・PRFハンドラー関数・バイト変換・テストユーティリティ)を「パッケージエクスポート」節として追加。`crypto-utils.ts` および外部利用の無い nip04 低レベル関数の barrel export は削除済み
 - [ ] iframe-host ドキュメント(`docs/{ja,en}/iframe-host`)を全面更新 — 「getPublicKey/signEvent の2メソッド」前提の記述を、7メソッドのNIP-07プロバイダの実態に修正。consent対象メソッド・`getRelays`・3ボタン同意ダイアログ・`startIframeHost`/`onConsent` サンプルコード・`theme`/`lang`/`embedded`・Storage Access API を反映
 - [x] `docs/iframe-expansion-plan.md` のステータス表を実態に修正 — Phase 1-B/1-C(nip44/nip04)・2-A/2-B(オリジン別許可・メソッド別ポリシー)は実装済みなのに「未実装」表記。localStorageキー名を `nosskey_trusted_origins_v2` に、ファイルパスを `src/components/screens/` に修正
 - [x] `docs/iframe-plan.md` をアーカイブ扱いにする — 完了済み・`iframe-expansion-plan.md` に統合された旨のバナーを追記(古い3メッセージ/2メソッドのプロトコル記述が現行と混同される)

--- a/packages/nosskey-sdk/src/index.ts
+++ b/packages/nosskey-sdk/src/index.ts
@@ -12,11 +12,16 @@ export { NosskeyManager } from './nosskey.js';
 // ユーティリティのエクスポート
 export { bytesToHex, hexToBytes } from './utils.js';
 
-// NIP-44 / NIP-04 のエクスポート
-// 低レベルプリミティブ (getConversationKey / getMessageKeys) は鍵再利用や
-// nonce 再利用の足場になりうるため意図的に公開しない。
+// NIP-44 低レベル関数のエクスポート。
+// nip44Encrypt/Decrypt は ephemeral 秘密鍵での暗号化 (NIP-17 gift-wrap など、
+// 例: examples/parent-sample/src/nip17.ts) に必要。登録鍵専用の
+// NosskeyManager.nip44Encrypt メソッドでは ephemeral 鍵を扱えず代替できないため、
+// バレルからの公開を維持する。
+// nip04 の低レベル関数は外部利用が無く、NIP-04 機能は NosskeyManager の
+// nip04Encrypt/Decrypt メソッドで提供されるため公開しない。
+// getConversationKey / getMessageKeys 等のプリミティブは鍵/nonce 再利用の
+// 足場になりうるため意図的に非公開。
 export { nip44Encrypt, nip44Decrypt } from './nip44.js';
-export { nip04Encrypt, nip04Decrypt } from './nip04.js';
 
 // PRFハンドラーのエクスポート
 export { createPasskey, getPrfSecret, isPrfSupported } from './prf-handler.js';


### PR DESCRIPTION
## Summary

- `index.ts` の barrel から `nip04Encrypt` / `nip04Decrypt` のスタンドアロン関数エクスポートを削除。これらは barrel(`'nosskey-sdk'`) 経由でリポジトリ全体のどこからも import されておらず、NIP-04 機能は `NosskeyManager.nip04Encrypt()` / `nip04Decrypt()` メソッドで提供されています。
- `nip44Encrypt` / `nip44Decrypt` のエクスポートは維持。`examples/parent-sample/src/nip17.ts` の NIP-17 gift-wrap が ephemeral 秘密鍵での暗号化に使用しており、登録鍵専用の `NosskeyManager.nip44Encrypt` メソッドでは代替できないためです。残す経緯を barrel のコメントに明記しました。
- インターフェースドキュメント(`docs/{ja,en}/nosskey-sdk-interface`)の「パッケージエクスポート」節を変更後の barrel に同期。

## 背景

`crypto-utils.ts` と同様、外部利用ゼロの barrel エクスポートを整理するものです。`nip04*` の低レベル関数は SDK 内部(`nosskey.ts`)が相対 import で利用するのみで、barrel 公開は不要でした。

## Test plan

- [x] `npm run build` — 成功
- [x] `npm run test:coverage` — nosskey-sdk 270 / nosskey-iframe 85 / parent-sample 43 テスト合格
- [x] `npm run format:check` — クリーン
- [x] `npm run check -w svelte-app` — 0 errors / 0 warnings
- [x] `nip04Encrypt` / `nip04Decrypt` の barrel 経由 import がリポジトリ全体でゼロであることを確認

https://claude.ai/code/session_01TEHDUUeVmxPCEsVgFcGhLc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEHDUUeVmxPCEsVgFcGhLc)_