### PR TITLE
test: strengthen coverage across all workspaces

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -56,8 +56,8 @@
 - [ ] `nosskey-elements` パッケージ追加 — `<nosskey-button>` Web Components として提供
 
 ## テスト関連
-- [ ] テストの完全性確認：すべての機能とエッジケースのカバレッジ
-- [ ] エラー処理のテスト強化
+- [x] テストの完全性確認：すべての機能とエッジケースのカバレッジ — 全4ワークスペースの未テスト公開関数・エッジケースを補完。nosskey-sdk: `bytesToBase64`/`base64ToBytes` の単体テスト、`secp-utils.ts`(`liftEvenXOnly`/`ecdhSharedX`)の新規テストファイル、NIP-44 平文長境界(1/65535バイト)・改竄ペイロード(version/MAC)テストを追加。nosskey-iframe: `isEncryptMethod`/`isDecryptMethod`・`iframe` getter のテストを追加。`examples/svelte-app` は vitest 設定が無く既存4 spec が未実行だったため `vitest.config.ts`・`test`/`test:coverage` スクリプト・依存(vitest/happy-dom/coverage-v8)を追加して有効化し、`event-kind-labels.ts` のテストも新規追加
+- [x] エラー処理のテスト強化 — 例外・拒否パスを重点補完。nosskey-sdk: ストレージ書き込み失敗(`#saveKeyInfoToStorage` の `setItem` 例外)、NIP-44 nonce override 長さ検証、NIP-04 不正IV長・非ブロック整列 ciphertext、secp256k1 の鍵長・公開鍵検証。nosskey-iframe client: 結果型不一致・Window/Document/コンテナ欠落・`crypto.randomUUID` 不在フォールバック・ready前 destroy・destroy後リクエスト。host: Window 欠落・`event.source` null・decrypt 系の NO_KEY/INVALID_REQUEST・非Error 例外の INTERNAL 化と visibility 復帰。あわせて `#saveKeyInfoToStorage` が書き込み失敗時に unhandled rejection を起こす不具合を read 側と同じ catch+log パターンで修正
 
 ## 品質とセキュリティ
 - [ ] 外部セキュリティレビュー

--- a/examples/parent-sample/src/nips.spec.ts
+++ b/examples/parent-sample/src/nips.spec.ts
@@ -97,6 +97,18 @@ describe('nip04Encrypt / nip04Decrypt', () => {
     expect(result).toBe('cipher04');
   });
 
+  it('decrypt returns { ok: true, plaintext } on success', async () => {
+    const nostr = createNostrMock();
+    vi.mocked(nostr.nip04.decrypt).mockResolvedValue('plain04');
+    const result = await nip04Decrypt({
+      nostr,
+      peer: PEER,
+      ciphertext: 'cipher',
+      log: vi.fn(),
+    });
+    expect(result).toEqual({ ok: true, plaintext: 'plain04' });
+  });
+
   it('decrypt returns { ok: false } when nostr rejects', async () => {
     const nostr = createNostrMock();
     vi.mocked(nostr.nip04.decrypt).mockRejectedValue(new Error('mac mismatch'));
@@ -150,6 +162,31 @@ describe('signAndPublishNote', () => {
       publish,
     });
     expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('logs a publish failure when publish rejects', async () => {
+    const nostr = createNostrMock();
+    const signed: NostrEvent = {
+      kind: 1,
+      content: 'hi',
+      tags: [],
+      created_at: 1700000000,
+      pubkey: 'p'.repeat(64),
+      id: 'i'.repeat(64),
+      sig: 's'.repeat(128),
+    };
+    vi.mocked(nostr.signEvent).mockResolvedValue(signed);
+    const publish = vi.fn().mockRejectedValue(new Error('relay down'));
+    const log = vi.fn();
+    await signAndPublishNote({
+      nostr,
+      content: 'hi',
+      relayUrl: 'wss://example',
+      log,
+      publish,
+    });
+    expect(publish).toHaveBeenCalledWith(signed);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Publish failed'));
   });
 });
 
@@ -234,5 +271,22 @@ describe('nip04SendDm', () => {
       publish,
     });
     expect(publish).toHaveBeenCalled();
+  });
+
+  it('logs a publish failure when publish rejects', async () => {
+    const nostr = createNostrMock();
+    vi.mocked(nostr.nip04.encrypt).mockResolvedValue('cipher04');
+    vi.mocked(nostr.signEvent).mockResolvedValue(buildSignedKind4('cipher04'));
+    const publish = vi.fn().mockRejectedValue(new Error('relay down'));
+    const log = vi.fn();
+    await nip04SendDm({
+      nostr,
+      peer: PEER,
+      plaintext: 'hi',
+      log,
+      publish,
+    });
+    expect(publish).toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('NIP-04 DM publish failed'));
   });
 });

--- a/examples/svelte-app/package.json
+++ b/examples/svelte-app/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json",
     "lint": "cd ../.. && biome check ./examples/svelte-app/src",
     "format": "cd ../.. && biome check --write ./examples/svelte-app/src",
@@ -15,10 +17,13 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@tsconfig/svelte": "^5.0.4",
+    "@vitest/coverage-v8": "^3.2.4",
+    "happy-dom": "^20.9.0",
     "svelte": "^5.55.3",
     "svelte-check": "^4.1.5",
     "typescript": "~5.7.2",
-    "vite": "^6.4.2"
+    "vite": "^6.4.2",
+    "vitest": "^3.1.2"
   },
   "dependencies": {
     "bech32": "^2.0.0",

--- a/examples/svelte-app/src/utils/event-kind-labels.spec.ts
+++ b/examples/svelte-app/src/utils/event-kind-labels.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { type KindLabelMap, kindLabel } from './event-kind-labels.js';
+
+// 各フィールドに自身の名前を入れて、どのラベルが返ったか一意に判定する。
+const labels: KindLabelMap = {
+  metadata: 'metadata',
+  textNote: 'textNote',
+  follows: 'follows',
+  legacyDm: 'legacyDm',
+  repost: 'repost',
+  reaction: 'reaction',
+  channelMessage: 'channelMessage',
+  rumor: 'rumor',
+  seal: 'seal',
+  giftWrap: 'giftWrap',
+  longForm: 'longForm',
+  unknown: 'unknown',
+};
+
+describe('kindLabel', () => {
+  it.each([
+    [0, 'metadata'],
+    [1, 'textNote'],
+    [3, 'follows'],
+    [4, 'legacyDm'],
+    [6, 'repost'],
+    [7, 'reaction'],
+    [13, 'rumor'],
+    [14, 'seal'],
+    [42, 'channelMessage'],
+    [1059, 'giftWrap'],
+    [30023, 'longForm'],
+  ])('maps kind %d to its dedicated label', (kind, expected) => {
+    expect(kindLabel(kind, labels)).toBe(expected);
+  });
+
+  it.each([2, 5, 8, 100, 9999, -1])('returns the unknown label for unmapped kind %d', (kind) => {
+    expect(kindLabel(kind, labels)).toBe('unknown');
+  });
+});

--- a/examples/svelte-app/vitest.config.ts
+++ b/examples/svelte-app/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.{test,spec}.ts'],
+    environment: 'happy-dom',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'json-summary', 'html', 'lcov'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.{test,spec}.ts', 'src/main.ts', 'src/vite-env.d.ts'],
+      reportOnFailure: true,
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,10 +47,13 @@
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
         "@tsconfig/svelte": "^5.0.4",
+        "@vitest/coverage-v8": "^3.2.4",
+        "happy-dom": "^20.9.0",
         "svelte": "^5.55.3",
         "svelte-check": "^4.1.5",
         "typescript": "~5.7.2",
-        "vite": "^6.4.2"
+        "vite": "^6.4.2",
+        "vitest": "^3.1.2"
       }
     },
     "examples/svelte-app/node_modules/typescript": {

--- a/packages/nosskey-iframe/src/client.spec.ts
+++ b/packages/nosskey-iframe/src/client.spec.ts
@@ -589,4 +589,165 @@ describe('NosskeyIframeClient', () => {
       client.destroy();
     });
   });
+
+  describe('result type validation', () => {
+    const mkClient = () =>
+      new NosskeyIframeClient({
+        iframeUrl: 'https://nosskey.example/iframe',
+        window: harness.window,
+        document: harness.document,
+        container: harness.container as unknown as HTMLElement,
+      });
+
+    it('getPublicKey rejects when the iframe returns a non-string result', async () => {
+      const client = mkClient();
+      const pending = client.getPublicKey();
+      const [request] = harness.iframes[0].contentWindow.postMessage.mock.calls[0];
+      harness.dispatchAsIframe({ type: 'nosskey:response', id: request.id, result: 42 });
+      await expect(pending).rejects.toThrow(/expected string result/);
+      client.destroy();
+    });
+
+    it('getRelays rejects when the iframe returns a non-object result', async () => {
+      const client = mkClient();
+      const pending = client.getRelays();
+      const [request] = harness.iframes[0].contentWindow.postMessage.mock.calls[0];
+      harness.dispatchAsIframe({ type: 'nosskey:response', id: request.id, result: 'not-object' });
+      await expect(pending).rejects.toThrow(/expected object result/);
+      client.destroy();
+    });
+
+    it('signEvent rejects when the iframe returns a non-object result', async () => {
+      const client = mkClient();
+      const pending = client.signEvent({ kind: 1, content: 'hi' });
+      const [request] = harness.iframes[0].contentWindow.postMessage.mock.calls[0];
+      harness.dispatchAsIframe({ type: 'nosskey:response', id: request.id, result: 'not-object' });
+      await expect(pending).rejects.toThrow(/expected NostrEvent result/);
+      client.destroy();
+    });
+
+    it('nip44.encrypt rejects when the iframe returns a non-string result', async () => {
+      const client = mkClient();
+      const pending = client.nip44.encrypt('b'.repeat(64), 'plain');
+      const [request] = harness.iframes[0].contentWindow.postMessage.mock.calls[0];
+      harness.dispatchAsIframe({ type: 'nosskey:response', id: request.id, result: {} });
+      await expect(pending).rejects.toThrow(/nip44\.encrypt: expected string result/);
+      client.destroy();
+    });
+
+    it('nip44.decrypt rejects when the iframe returns a non-string result', async () => {
+      const client = mkClient();
+      const pending = client.nip44.decrypt('b'.repeat(64), 'cipher');
+      const [request] = harness.iframes[0].contentWindow.postMessage.mock.calls[0];
+      harness.dispatchAsIframe({ type: 'nosskey:response', id: request.id, result: 7 });
+      await expect(pending).rejects.toThrow(/nip44\.decrypt: expected string result/);
+      client.destroy();
+    });
+
+    it('nip04.encrypt rejects when the iframe returns a non-string result', async () => {
+      const client = mkClient();
+      const pending = client.nip04.encrypt('b'.repeat(64), 'plain');
+      const [request] = harness.iframes[0].contentWindow.postMessage.mock.calls[0];
+      harness.dispatchAsIframe({ type: 'nosskey:response', id: request.id, result: null });
+      await expect(pending).rejects.toThrow(/nip04\.encrypt: expected string result/);
+      client.destroy();
+    });
+
+    it('nip04.decrypt rejects when the iframe returns a non-string result', async () => {
+      const client = mkClient();
+      const pending = client.nip04.decrypt('b'.repeat(64), 'cipher');
+      const [request] = harness.iframes[0].contentWindow.postMessage.mock.calls[0];
+      harness.dispatchAsIframe({ type: 'nosskey:response', id: request.id, result: false });
+      await expect(pending).rejects.toThrow(/nip04\.decrypt: expected string result/);
+      client.destroy();
+    });
+  });
+
+  describe('lifecycle and option validation', () => {
+    it('ready() rejects when destroy() is called before the iframe is ready', async () => {
+      const client = new NosskeyIframeClient({
+        iframeUrl: 'https://nosskey.example/iframe',
+        window: harness.window,
+        document: harness.document,
+        container: harness.container as unknown as HTMLElement,
+      });
+      const readyPromise = client.ready();
+      client.destroy();
+      await expect(readyPromise).rejects.toThrow(/destroyed before ready/);
+    });
+
+    it('throws when no Window is available', () => {
+      vi.stubGlobal('window', undefined);
+      try {
+        expect(
+          () => new NosskeyIframeClient({ iframeUrl: 'https://nosskey.example/iframe' })
+        ).toThrow(/requires a Window/);
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+
+    it('throws when no Document is available', () => {
+      const windowWithoutDocument = {
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+      } as unknown as Window;
+      expect(
+        () =>
+          new NosskeyIframeClient({
+            iframeUrl: 'https://nosskey.example/iframe',
+            window: windowWithoutDocument,
+          })
+      ).toThrow(/requires a Document/);
+    });
+
+    it('throws when no container element can be determined', () => {
+      const docWithoutBody = { body: null } as unknown as Document;
+      expect(
+        () =>
+          new NosskeyIframeClient({
+            iframeUrl: 'https://nosskey.example/iframe',
+            window: harness.window,
+            document: docWithoutBody,
+          })
+      ).toThrow(/could not determine a container/);
+    });
+
+    it('makeId falls back to a non-crypto id when crypto.randomUUID is unavailable', () => {
+      (harness.window as unknown as { crypto: unknown }).crypto = {};
+      const client = new NosskeyIframeClient({
+        iframeUrl: 'https://nosskey.example/iframe',
+        window: harness.window,
+        document: harness.document,
+        container: harness.container as unknown as HTMLElement,
+      });
+      const pending = client.getPublicKey();
+      pending.catch(() => undefined);
+      const [request] = harness.iframes[0].contentWindow.postMessage.mock.calls[0];
+      expect(request.id).toMatch(/^nosskey-/);
+      client.destroy();
+    });
+
+    it('exposes the mounted iframe element via the iframe getter', () => {
+      const client = new NosskeyIframeClient({
+        iframeUrl: 'https://nosskey.example/iframe',
+        window: harness.window,
+        document: harness.document,
+        container: harness.container as unknown as HTMLElement,
+      });
+      expect(client.iframe).toBe(harness.iframes[0] as unknown as HTMLIFrameElement);
+      client.destroy();
+    });
+
+    it('rejects requests issued after destroy()', async () => {
+      const client = new NosskeyIframeClient({
+        iframeUrl: 'https://nosskey.example/iframe',
+        window: harness.window,
+        document: harness.document,
+        container: harness.container as unknown as HTMLElement,
+      });
+      client.destroy();
+      await expect(client.getPublicKey()).rejects.toThrow(/has been destroyed/);
+    });
+  });
 });

--- a/packages/nosskey-iframe/src/host.spec.ts
+++ b/packages/nosskey-iframe/src/host.spec.ts
@@ -362,6 +362,45 @@ describe('NosskeyIframeHost', () => {
     host.stop();
   });
 
+  it('wraps a non-Error manager rejection as INTERNAL and still hides the iframe', async () => {
+    const win = createFakeWindow() as DispatchableWindow;
+    const parent = { postMessage: vi.fn() } as unknown as Window;
+    Object.defineProperty(win, 'parent', { value: parent, configurable: true });
+    const manager = makeManager({
+      // Reject with a plain string rather than an Error to exercise String(err).
+      signEvent: vi.fn(() => Promise.reject('manager-non-error-failure')),
+    });
+    const host = new NosskeyIframeHost({
+      manager,
+      allowedOrigins: ['https://parent.example'],
+      onConsent: async () => true,
+      window: win as unknown as Window,
+    });
+    host.start();
+
+    await win.dispatchMessage(
+      {
+        type: 'nosskey:request',
+        id: 'i2',
+        method: 'signEvent',
+        params: { event: { kind: 1, content: '' } },
+      },
+      'https://parent.example'
+    );
+
+    const err = (win.sent[0].data as { error: { code: string; message: string } }).error;
+    expect(err.code).toBe('INTERNAL');
+    expect(err.message).toBe('manager-non-error-failure');
+    // The finally block must still hide the iframe after the operation fails.
+    const visibilityMessages = (
+      parent.postMessage as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls
+      .map((c) => c[0])
+      .filter(isNosskeyVisibility);
+    expect(visibilityMessages.map((m) => m.visible)).toEqual([true, false]);
+    host.stop();
+  });
+
   it('returns INTERNAL when requireUserConsent is true but onConsent is missing', async () => {
     const win = createFakeWindow() as DispatchableWindow;
     const host = new NosskeyIframeHost({
@@ -522,6 +561,34 @@ describe('NosskeyIframeHost', () => {
     expect(win.sent).toHaveLength(0);
   });
 
+  it('throws when no Window is available', () => {
+    vi.stubGlobal('window', undefined);
+    try {
+      expect(() => new NosskeyIframeHost({ manager: makeManager() })).toThrow(/requires a Window/);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('drops the reply when event.source is null', async () => {
+    const win = createFakeWindow() as DispatchableWindow;
+    const manager = makeManager({ getPublicKey: vi.fn(async () => 'deadbeef') });
+    const host = new NosskeyIframeHost({
+      manager,
+      allowedOrigins: ['https://parent.example'],
+      window: win as unknown as Window,
+    });
+    host.start();
+    await win.dispatchMessage(
+      { type: 'nosskey:request', id: 's1', method: 'getPublicKey' },
+      'https://parent.example',
+      null
+    );
+    // Without a source Window there is nowhere to post the response.
+    expect(win.sent).toHaveLength(0);
+    host.stop();
+  });
+
   describe('nip44 / nip04 encrypt / decrypt', () => {
     const peerPub = 'a'.repeat(64);
 
@@ -672,6 +739,71 @@ describe('NosskeyIframeHost', () => {
         'https://parent.example'
       );
       expect((win.sent[0].data as { error: { code: string } }).error.code).toBe('INVALID_REQUEST');
+      host.stop();
+    });
+
+    it('returns INVALID_REQUEST when nip44_decrypt params are missing', async () => {
+      const win = createFakeWindow() as DispatchableWindow;
+      const host = new NosskeyIframeHost({
+        manager: makeManager(),
+        allowedOrigins: ['https://parent.example'],
+        onConsent: async () => true,
+        window: win as unknown as Window,
+      });
+      host.start();
+      await win.dispatchMessage(
+        { type: 'nosskey:request', id: 'n7', method: 'nip44_decrypt' },
+        'https://parent.example'
+      );
+      expect((win.sent[0].data as { error: { code: string } }).error.code).toBe('INVALID_REQUEST');
+      host.stop();
+    });
+
+    it('returns NO_KEY for nip44_decrypt when no key is configured', async () => {
+      const win = createFakeWindow() as DispatchableWindow;
+      const manager = makeManager({ hasKeyInfo: () => false });
+      const host = new NosskeyIframeHost({
+        manager,
+        allowedOrigins: ['https://parent.example'],
+        onConsent: async () => true,
+        window: win as unknown as Window,
+      });
+      host.start();
+      await win.dispatchMessage(
+        {
+          type: 'nosskey:request',
+          id: 'd1',
+          method: 'nip44_decrypt',
+          params: { pubkey: peerPub, ciphertext: 'cipher' },
+        },
+        'https://parent.example'
+      );
+      expect((win.sent[0].data as { error: { code: string } }).error.code).toBe('NO_KEY');
+      expect(manager.nip44Decrypt).not.toHaveBeenCalled();
+      host.stop();
+    });
+
+    it('returns NO_KEY for nip04_decrypt when no key is configured', async () => {
+      const win = createFakeWindow() as DispatchableWindow;
+      const manager = makeManager({ hasKeyInfo: () => false });
+      const host = new NosskeyIframeHost({
+        manager,
+        allowedOrigins: ['https://parent.example'],
+        onConsent: async () => true,
+        window: win as unknown as Window,
+      });
+      host.start();
+      await win.dispatchMessage(
+        {
+          type: 'nosskey:request',
+          id: 'd2',
+          method: 'nip04_decrypt',
+          params: { pubkey: peerPub, ciphertext: 'cbc?iv=zz' },
+        },
+        'https://parent.example'
+      );
+      expect((win.sent[0].data as { error: { code: string } }).error.code).toBe('NO_KEY');
+      expect(manager.nip04Decrypt).not.toHaveBeenCalled();
       host.stop();
     });
   });

--- a/packages/nosskey-iframe/src/protocol.spec.ts
+++ b/packages/nosskey-iframe/src/protocol.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   NOSSKEY_ERROR_CODES,
   type NosskeyErrorCode,
+  isDecryptMethod,
+  isEncryptMethod,
   isNosskeyReady,
   isNosskeyRequest,
   isNosskeyResponse,
@@ -134,6 +136,20 @@ describe('protocol: isNosskeyResponse', () => {
   it('rejects missing id', () => {
     expect(isNosskeyResponse({ type: 'nosskey:response', result: 1 })).toBe(false);
   });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['array', []],
+    ['string', 'x'],
+    ['number', 7],
+  ])('rejects non-object-shaped value: %s', (_label, value) => {
+    expect(isNosskeyResponse(value)).toBe(false);
+  });
+
+  it('rejects a response whose error is not an object', () => {
+    expect(isNosskeyResponse({ type: 'nosskey:response', id: 'r1', error: 'boom' })).toBe(false);
+  });
 });
 
 describe('protocol: isNosskeyReady', () => {
@@ -174,6 +190,32 @@ describe('protocol: isNosskeyVisibility', () => {
   it.each([null, undefined, 'nosskey:visibility', 0, []])('rejects %s', (value) => {
     expect(isNosskeyVisibility(value)).toBe(false);
   });
+});
+
+describe('protocol: isEncryptMethod', () => {
+  it.each(['nip44_encrypt', 'nip04_encrypt'] as const)('returns true for %s', (method) => {
+    expect(isEncryptMethod(method)).toBe(true);
+  });
+
+  it.each(['getPublicKey', 'signEvent', 'getRelays', 'nip44_decrypt', 'nip04_decrypt'] as const)(
+    'returns false for %s',
+    (method) => {
+      expect(isEncryptMethod(method)).toBe(false);
+    }
+  );
+});
+
+describe('protocol: isDecryptMethod', () => {
+  it.each(['nip44_decrypt', 'nip04_decrypt'] as const)('returns true for %s', (method) => {
+    expect(isDecryptMethod(method)).toBe(true);
+  });
+
+  it.each(['getPublicKey', 'signEvent', 'getRelays', 'nip44_encrypt', 'nip04_encrypt'] as const)(
+    'returns false for %s',
+    (method) => {
+      expect(isDecryptMethod(method)).toBe(false);
+    }
+  );
 });
 
 describe('protocol: NOSSKEY_ERROR_CODES', () => {

--- a/packages/nosskey-sdk/src/nip04.spec.ts
+++ b/packages/nosskey-sdk/src/nip04.spec.ts
@@ -1,7 +1,7 @@
 import { schnorr } from '@noble/curves/secp256k1.js';
 import { describe, expect, it } from 'vitest';
 import { __nip04Internal, nip04Decrypt, nip04Encrypt } from './nip04.js';
-import { bytesToHex, hexToBytes } from './utils.js';
+import { bytesToBase64, bytesToHex, hexToBytes } from './utils.js';
 
 describe('NIP-04', () => {
   const aliceSec = hexToBytes('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
@@ -41,6 +41,17 @@ describe('NIP-04', () => {
   it('rejects IV of wrong length', () => {
     const iv = new Uint8Array(8);
     expect(() => nip04Encrypt('x', aliceSec, bobPub, iv)).toThrow();
+  });
+
+  it('rejects a decoded IV that is not 16 bytes', () => {
+    // 'AAAA' decodes to 3 bytes, far short of the required 16-byte IV.
+    expect(() => nip04Decrypt('AAAA?iv=AAAA', aliceSec, bobPub)).toThrow(/IV must be 16 bytes/);
+  });
+
+  it('rejects a ciphertext whose length is not a multiple of the AES block size', () => {
+    const iv = bytesToBase64(new Uint8Array(16));
+    // 'AAAA' decodes to 3 bytes — not a multiple of the 16-byte CBC block.
+    expect(() => nip04Decrypt(`AAAA?iv=${iv}`, bobSec, alicePub)).toThrow();
   });
 
   it('rejects 64-char-mismatch peer pubkey', () => {

--- a/packages/nosskey-sdk/src/nip44.spec.ts
+++ b/packages/nosskey-sdk/src/nip44.spec.ts
@@ -2,7 +2,7 @@ import { schnorr } from '@noble/curves/secp256k1.js';
 import { describe, expect, it } from 'vitest';
 import vectors from './__fixtures__/nip44-vectors.json' with { type: 'json' };
 import { __nip44Internal, nip44Decrypt, nip44Encrypt } from './nip44.js';
-import { bytesToHex, hexToBytes } from './utils.js';
+import { base64ToBytes, bytesToBase64, bytesToHex, hexToBytes } from './utils.js';
 
 interface ConversationKeyVector {
   sec1: string;
@@ -159,5 +159,56 @@ describe('NIP-44 v2: roundtrip with random nonce', () => {
 
     const payload = nip44Encrypt('hello, world! こんにちは 🌍', aliceSec, bobPub);
     expect(nip44Decrypt(payload, bobSec, alicePub)).toBe('hello, world! こんにちは 🌍');
+  });
+});
+
+describe('NIP-44 v2: nonce override validation', () => {
+  const aliceSec = hexToBytes('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  const bobPub = bytesToHex(
+    schnorr.getPublicKey(
+      hexToBytes('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
+    )
+  );
+
+  it('rejects a nonce override that is not 32 bytes', () => {
+    expect(() => nip44Encrypt('hi', aliceSec, bobPub, new Uint8Array(16))).toThrow(
+      'NIP-44: nonce override must be 32 bytes.'
+    );
+  });
+});
+
+describe('NIP-44 v2: plaintext length boundaries', () => {
+  const aliceSec = hexToBytes('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  const bobSec = hexToBytes('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+  const alicePub = bytesToHex(schnorr.getPublicKey(aliceSec));
+  const bobPub = bytesToHex(schnorr.getPublicKey(bobSec));
+
+  // 1 and 65535 are the inclusive plaintext-length bounds; 32/33 straddle the
+  // first calc_padded_len bucket boundary.
+  it.each([1, 32, 33, 65535])('roundtrips a %d-byte plaintext', (len) => {
+    const text = 'a'.repeat(len);
+    const payload = nip44Encrypt(text, aliceSec, bobPub);
+    expect(nip44Decrypt(payload, bobSec, alicePub)).toBe(text);
+  });
+});
+
+describe('NIP-44 v2: tampered payload rejection', () => {
+  const aliceSec = hexToBytes('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  const bobSec = hexToBytes('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+  const alicePub = bytesToHex(schnorr.getPublicKey(aliceSec));
+  const bobPub = bytesToHex(schnorr.getPublicKey(bobSec));
+
+  it('rejects a payload with an unsupported version byte', () => {
+    const bytes = base64ToBytes(nip44Encrypt('hello', aliceSec, bobPub));
+    bytes[0] = 0x01; // canonical version is 0x02
+    expect(() => nip44Decrypt(bytesToBase64(bytes), bobSec, alicePub)).toThrow(
+      /unsupported version/
+    );
+  });
+
+  it('rejects a payload whose MAC has been altered', () => {
+    const bytes = base64ToBytes(nip44Encrypt('hello', aliceSec, bobPub));
+    bytes[bytes.length - 1] ^= 0xff; // flip the final MAC byte
+    expect(() => nip44Decrypt(bytesToBase64(bytes), bobSec, alicePub)).toThrow(/invalid MAC/);
   });
 });

--- a/packages/nosskey-sdk/src/nosskey.spec.ts
+++ b/packages/nosskey-sdk/src/nosskey.spec.ts
@@ -910,6 +910,39 @@ describe('NosskeyManager', () => {
       expect(customStorage.getItem).toHaveBeenCalledWith('nosskey_keyinfo');
       expect(nosskey.getCurrentKeyInfo()?.pubkey).toBe('from-custom-storage');
     });
+
+    it('storage.setItem が例外を投げても unhandled rejection を起こさずエラーをログする', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const rejections: unknown[] = [];
+      const onRejection = (reason: unknown) => rejections.push(reason);
+      process.on('unhandledRejection', onRejection);
+      try {
+        const customStorage = createMockStorage();
+        (customStorage.setItem as ReturnType<typeof vi.fn>).mockImplementation(() => {
+          throw new Error('QuotaExceededError');
+        });
+        const nosskey = new NosskeyManager({
+          storageOptions: { enabled: true, storage: customStorage },
+        });
+        const keyInfo: NostrKeyInfo = {
+          credentialId: bytesToHex(mockCredentialId),
+          pubkey: 'persist-failure',
+          salt: '6e6f7374722d70776b',
+        };
+
+        expect(() => nosskey.setCurrentKeyInfo(keyInfo)).not.toThrow();
+        // 書き込みに失敗しても in-memory の NostrKeyInfo は保持される
+        expect(nosskey.getCurrentKeyInfo()?.pubkey).toBe('persist-failure');
+        expect(errorSpy).toHaveBeenCalled();
+        // #saveKeyInfoToStorage は async。catch を外すと void 呼び出しで
+        // unhandled rejection になるため、マイクロタスク消化後も発生しないことを確認。
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(rejections).toEqual([]);
+      } finally {
+        process.off('unhandledRejection', onRejection);
+        errorSpy.mockRestore();
+      }
+    });
   });
 
   describe('createNostrKey with username オプション', () => {

--- a/packages/nosskey-sdk/src/nosskey.ts
+++ b/packages/nosskey-sdk/src/nosskey.ts
@@ -175,7 +175,13 @@ export class NosskeyManager implements NosskeyManagerLike {
     if (!storage) return;
 
     const key = this.#storageOptions.storageKey || 'nosskey_keyinfo';
-    storage.setItem(key, JSON.stringify(keyInfo));
+    try {
+      storage.setItem(key, JSON.stringify(keyInfo));
+    } catch (e) {
+      // 書き込み失敗（容量超過など）は致命的ではないため、ログのみで握り潰す。
+      // async メソッドのため、握り潰さないと void 呼び出し側で unhandled rejection になる。
+      console.error('Failed to persist NostrKeyInfo', e);
+    }
   }
 
   /**

--- a/packages/nosskey-sdk/src/secp-utils.spec.ts
+++ b/packages/nosskey-sdk/src/secp-utils.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { ecdhSharedX, liftEvenXOnly } from './secp-utils.js';
+
+// secp256k1 ジェネレータ点 G の x 座標。0x02 プレフィックスを付けると曲線上の有効な点になる。
+const VALID_PUBKEY_X = '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+
+describe('secp-utils', () => {
+  describe('liftEvenXOnly', () => {
+    it('64文字の hex を 33バイトの圧縮形式に変換し、偶数パリティ(0x02)を付与すること', () => {
+      const result = liftEvenXOnly(VALID_PUBKEY_X, 'test');
+      expect(result.length).toBe(33);
+      expect(result[0]).toBe(0x02);
+    });
+
+    it('大文字の hex も受け付けること', () => {
+      const result = liftEvenXOnly(VALID_PUBKEY_X.toUpperCase(), 'test');
+      expect(result.length).toBe(33);
+    });
+
+    it('非hex文字を含む64文字でエラーを投げること', () => {
+      expect(() => liftEvenXOnly('g'.repeat(64), 'test')).toThrow(
+        'test: peer public key must be 64 hex characters.'
+      );
+    });
+
+    it('64文字未満でエラーを投げること', () => {
+      expect(() => liftEvenXOnly('ab', 'test')).toThrow(
+        'peer public key must be 64 hex characters.'
+      );
+    });
+
+    it('64文字超でエラーを投げること', () => {
+      expect(() => liftEvenXOnly(`${VALID_PUBKEY_X}00`, 'test')).toThrow(
+        'peer public key must be 64 hex characters.'
+      );
+    });
+  });
+
+  describe('ecdhSharedX', () => {
+    it('有効な秘密鍵と公開鍵で 32バイトの shared_x を返すこと', () => {
+      const secretKey = new Uint8Array(32).fill(1);
+      const result = ecdhSharedX(secretKey, VALID_PUBKEY_X, 'test');
+      expect(result instanceof Uint8Array).toBe(true);
+      expect(result.length).toBe(32);
+    });
+
+    it('同じ入力に対して決定的な結果を返すこと', () => {
+      const secretKey = new Uint8Array(32).fill(1);
+      const a = ecdhSharedX(secretKey, VALID_PUBKEY_X, 'test');
+      const b = ecdhSharedX(secretKey, VALID_PUBKEY_X, 'test');
+      expect(Array.from(a)).toEqual(Array.from(b));
+    });
+
+    it('秘密鍵が32バイトでない場合にエラーを投げること', () => {
+      expect(() => ecdhSharedX(new Uint8Array(31), VALID_PUBKEY_X, 'test')).toThrow(
+        'test: secret key must be 32 bytes.'
+      );
+      expect(() => ecdhSharedX(new Uint8Array(33), VALID_PUBKEY_X, 'test')).toThrow(
+        'secret key must be 32 bytes.'
+      );
+    });
+
+    it('公開鍵が不正な場合に liftEvenXOnly 経由でエラーを投げること', () => {
+      const secretKey = new Uint8Array(32).fill(1);
+      expect(() => ecdhSharedX(secretKey, 'g'.repeat(64), 'test')).toThrow(
+        'peer public key must be 64 hex characters.'
+      );
+    });
+  });
+});

--- a/packages/nosskey-sdk/src/utils.spec.ts
+++ b/packages/nosskey-sdk/src/utils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { bytesToHex, hexToBytes } from './utils.js';
+import { base64ToBytes, bytesToBase64, bytesToHex, hexToBytes } from './utils.js';
 
 describe('バイト変換ユーティリティ', () => {
   describe('bytesToHex', () => {
@@ -65,6 +65,47 @@ describe('バイト変換ユーティリティ', () => {
       for (let i = 0; i < result.length; i++) {
         expect(result[i]).toBe(expected[i]);
       }
+    });
+  });
+
+  describe('bytesToBase64', () => {
+    it('Uint8Array を base64 文字列に変換できること', () => {
+      // 'hello' をASCIIコードで表すと [104, 101, 108, 108, 111]
+      const input = new Uint8Array([104, 101, 108, 108, 111]);
+      expect(bytesToBase64(input)).toBe('aGVsbG8=');
+    });
+
+    it('空のバイト配列を空の文字列に変換できること', () => {
+      expect(bytesToBase64(new Uint8Array([]))).toBe('');
+    });
+
+    it('非ASCIIのバイト値も変換できること', () => {
+      const input = new Uint8Array([0, 15, 16, 128, 255]);
+      expect(bytesToBase64(input)).toBe('AA8QgP8=');
+    });
+  });
+
+  describe('base64ToBytes', () => {
+    it('base64 文字列を Uint8Array に変換できること', () => {
+      const result = base64ToBytes('aGVsbG8=');
+      expect(result instanceof Uint8Array).toBe(true);
+      expect(Array.from(result)).toEqual([104, 101, 108, 108, 111]);
+    });
+
+    it('空の文字列を空のバイト配列に変換できること', () => {
+      expect(base64ToBytes('').length).toBe(0);
+    });
+  });
+
+  describe('bytesToBase64 / base64ToBytes ラウンドトリップ', () => {
+    it('ASCII データを往復変換しても一致すること', () => {
+      const input = new Uint8Array([104, 101, 108, 108, 111]);
+      expect(Array.from(base64ToBytes(bytesToBase64(input)))).toEqual(Array.from(input));
+    });
+
+    it('バイナリ（非ASCII）データを往復変換しても一致すること', () => {
+      const input = new Uint8Array([0, 15, 16, 128, 200, 255]);
+      expect(Array.from(base64ToBytes(bytesToBase64(input)))).toEqual(Array.from(input));
     });
   });
 });


### PR DESCRIPTION
未テストの公開関数とエラーパスを全4ワークスペースに補完し、
docs/todo.md のテスト関連2項目に対応する。

- nosskey-sdk: base64 変換・secp-utils・NIP-44 境界/改竄・NIP-04
  IV/ブロック整列・ストレージ書き込み失敗のテストを追加
- nosskey-iframe: protocol 判定関数、client の結果型検証/
  ライフサイクル、host の Window 欠落/source null/decrypt 系
  NO_KEY/非Error 例外のテストを追加
- parent-sample: nip04Decrypt 成功パスと publish 失敗パスを追加
- svelte-app: vitest 設定が無く未実行だった既存 spec を有効化
  (vitest.config.ts・test スクリプト・依存追加)、
  event-kind-labels のテストを新規追加

あわせて #saveKeyInfoToStorage が書き込み失敗時に unhandled
rejection を起こす不具合を、読み込み側と同じ catch+log で修正。

https://claude.ai/code/session_01RtvdTSEKWyP72vV9BiTxKq