### PR TITLE
feat(svelte-app): add setup/settings links for NO_KEY and consent UI

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -50,7 +50,7 @@
 - [x] ダイアログ表示内容の整理 — `kindLabel()` で kind ラベル化、content は 100 文字プレビュー、`<details>` で raw event JSON を折りたたみ表示、nip44/nip04 では `renderPeerPubkey()` で相手 pubkey を短縮表示（`examples/svelte-app/src/components/ConsentDialog.svelte`）
 - [x] スタイル整理 — `--color-card` / `--color-text` 等の CSS variables 化と `@media (max-width: 480px)` レスポンシブ対応（`ConsentDialog.svelte`）
 - [x] テーマ・言語を親から渡す — URL クエリパラメータ (`?theme=dark&lang=en`) 経由。`NosskeyIframeClient` に `theme` / `lang` オプションを追加し `buildIframeUrl()` で URL に自動付与、Svelte アプリ側の受信 (`app-state.ts` / `i18n-store.ts`) も対応済み。PR #52
-- [ ] 設定ページへのリンク遷移 — NO_KEY エラー時のセットアップ誘導
+- [x] 設定ページへのリンク遷移 — NO_KEY エラー時のセットアップ誘導 — `IframeHostScreen` の鍵が使えない4状態(`noKeyExists`/`unsupported` は主ボタン、`partitioned`/`denied` は副リンク)に、別タブで account 画面(`#/account`、パスキー登録・ログイン)を開く「セットアップを開く」導線を追加。あわせて `ConsentDialog` の許可ダイアログにも settings 画面(`#/settings`、信頼済みサイト・同意ポリシー)を開く「同意設定を開く」小リンクを追加。URL 組み立ては純粋関数 `buildScreenUrl`(`utils/app-navigation.ts`)に切り出し単体テスト追加。doc 6-D の protocol メッセージ(`nosskey:setup_required`)追加は「任意」のため見送り
 
 #### Phase 7: フレームワーク導入しやすさの改善（低優先）
 - [ ] `nosskey-elements` パッケージ追加 — `<nosskey-button>` Web Components として提供

--- a/examples/svelte-app/src/components/ConsentDialog.svelte
+++ b/examples/svelte-app/src/components/ConsentDialog.svelte
@@ -68,8 +68,10 @@ function handleReject() {
 }
 
 // Open the standalone app's settings screen in a new tab so the user can
-// review trusted sites and the consent policy. A new tab is required:
-// this dialog runs inside the (often cross-origin) signing iframe.
+// review trusted sites and the consent policy. A new tab (rather than
+// in-place navigation) is used because the consent prompt is shown while
+// the app is acting as the signing iframe — navigating away would tear
+// down the iframe host.
 function openConsentSettings(): void {
   window.open(buildScreenUrl(window.location, 'settings'), '_blank', 'noopener');
 }

--- a/examples/svelte-app/src/components/ConsentDialog.svelte
+++ b/examples/svelte-app/src/components/ConsentDialog.svelte
@@ -2,6 +2,7 @@
 import { type NosskeyMethod, isDecryptMethod, isEncryptMethod } from 'nosskey-iframe';
 import { i18n } from '../i18n/i18n-store.js';
 import { approveConsent, pendingConsent, rejectConsent } from '../iframe-mode.js';
+import { buildScreenUrl } from '../utils/app-navigation.js';
 import { hexToNpub } from '../utils/bech32-converter.js';
 import { kindLabel } from '../utils/event-kind-labels.js';
 import Button from './ui/button/Button.svelte';
@@ -64,6 +65,13 @@ function handleApproveAlways() {
 
 function handleReject() {
   rejectConsent();
+}
+
+// Open the standalone app's settings screen in a new tab so the user can
+// review trusted sites and the consent policy. A new tab is required:
+// this dialog runs inside the (often cross-origin) signing iframe.
+function openConsentSettings(): void {
+  window.open(buildScreenUrl(window.location, 'settings'), '_blank', 'noopener');
 }
 </script>
 
@@ -140,6 +148,12 @@ function handleReject() {
         <Button variant="secondary" size="small" onclick={handleApproveOnce}>
           {$i18n.t.consent.approveOnce}
         </Button>
+      </div>
+
+      <div class="consent-settings-link">
+        <button type="button" class="settings-link" onclick={openConsentSettings}>
+          {$i18n.t.consent.openSettings}
+        </button>
       </div>
     </div>
   </div>
@@ -265,6 +279,32 @@ function handleReject() {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .consent-settings-link {
+    margin-top: 10px;
+    text-align: center;
+  }
+
+  .settings-link {
+    background: none;
+    border: none;
+    padding: 2px 6px;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+  }
+
+  .settings-link:hover {
+    color: var(--color-text-secondary);
+  }
+
+  .settings-link:focus-visible {
+    outline: none;
+    border-radius: 4px;
+    box-shadow: 0 0 0 3px var(--color-primary-alpha-20);
   }
 
   /* Embedded mode: parent modal already provides the backdrop and card frame,

--- a/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
+++ b/examples/svelte-app/src/components/screens/IframeHostScreen.svelte
@@ -4,6 +4,7 @@ import { i18n } from '../../i18n/i18n-store.js';
 import { isEmbeddedIframeMode, pendingConsent, startIframeHost } from '../../iframe-mode.js';
 import { getNosskeyManager } from '../../services/nosskey-manager.service.js';
 import { reloadSettings } from '../../store/app-state.js';
+import { buildScreenUrl } from '../../utils/app-navigation.js';
 import ConsentDialog from '../ConsentDialog.svelte';
 import Button from '../ui/button/Button.svelte';
 
@@ -149,6 +150,14 @@ function handleClose(): void {
   postVisibility(false);
 }
 
+// Open the standalone app's account screen in a new tab so the user can
+// register or sign in with a passkey. A new tab is required: this screen
+// runs inside the (often cross-origin) signing iframe, where in-place
+// navigation would not reach the first-party setup flow.
+function openSetup(): void {
+  window.open(buildScreenUrl(window.location, 'account'), '_blank', 'noopener');
+}
+
 type CardConfig = {
   title: string;
   description: string;
@@ -157,6 +166,10 @@ type CardConfig = {
   action?: {
     label: string;
     variant: ActionVariant;
+    onclick: () => void;
+  };
+  secondaryLink?: {
+    label: string;
     onclick: () => void;
   };
 };
@@ -175,6 +188,7 @@ function cardForState(state: Exclude<UiState, 'running'>): CardConfig {
           variant: 'warning',
           onclick: () => void requestAccess(),
         },
+        secondaryLink: { label: t.openSetup, onclick: openSetup },
       };
     case 'denied':
       return {
@@ -187,6 +201,7 @@ function cardForState(state: Exclude<UiState, 'running'>): CardConfig {
           variant: 'danger',
           onclick: () => void requestAccess(),
         },
+        secondaryLink: { label: t.openSetup, onclick: openSetup },
       };
     case 'granted':
       return {
@@ -201,6 +216,11 @@ function cardForState(state: Exclude<UiState, 'running'>): CardConfig {
         description: t.noKey,
         icon: 'key_off',
         tone: 'warning',
+        action: {
+          label: t.openSetup,
+          variant: 'primary',
+          onclick: openSetup,
+        },
       };
     case 'unsupported':
       return {
@@ -208,6 +228,11 @@ function cardForState(state: Exclude<UiState, 'running'>): CardConfig {
         description: `${t.storageAccessUnsupported} ${t.noKey}`,
         icon: 'info',
         tone: 'warning',
+        action: {
+          label: t.openSetup,
+          variant: 'primary',
+          onclick: openSetup,
+        },
       };
   }
 }
@@ -263,6 +288,18 @@ onDestroy(() => {
           >
             {card.action.label}
           </Button>
+        </div>
+      {/if}
+
+      {#if card.secondaryLink}
+        <div class="card-setup-link">
+          <button
+            type="button"
+            class="setup-link"
+            onclick={card.secondaryLink.onclick}
+          >
+            {card.secondaryLink.label}
+          </button>
         </div>
       {/if}
     </div>
@@ -376,6 +413,32 @@ onDestroy(() => {
   .card-action :global(.btn) {
     width: auto;
     min-width: 160px;
+  }
+
+  .card-setup-link {
+    display: flex;
+    justify-content: center;
+    margin-top: 12px;
+  }
+
+  .setup-link {
+    background: none;
+    border: none;
+    padding: 4px 8px;
+    font-size: 0.8rem;
+    color: var(--color-primary);
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  .setup-link:hover {
+    color: var(--color-button-primary-hover);
+  }
+
+  .setup-link:focus-visible {
+    outline: none;
+    border-radius: 4px;
+    box-shadow: 0 0 0 3px var(--color-primary-alpha-20);
   }
 
   /* Mobile-first: tighter spacing on narrow viewports */

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -240,6 +240,7 @@ export interface TranslationData {
       unknown: string;
     };
     approveAndTrust: string;
+    openSettings: string;
   };
   iframeHost: {
     running: string;
@@ -255,6 +256,7 @@ export interface TranslationData {
     grantedTitle: string;
     noKeyTitle: string;
     unsupportedTitle: string;
+    openSetup: string;
   };
 }
 
@@ -513,10 +515,12 @@ export const ja: TranslationData = {
       unknown: 'その他のイベント',
     },
     approveAndTrust: '常に許可して承認',
+    openSettings: '同意設定を開く',
   },
   iframeHost: {
     running: 'Nosskey iframe が起動中です。親アプリからの署名リクエストを待機します。',
-    noKey: '鍵が設定されていません。別タブで設定画面を開き、パスキーでログインしてください。',
+    noKey:
+      '鍵が設定されていません。下のボタンからセットアップ画面を開き、パスキーで登録またはログインしてください。',
     partitionedWarning:
       'このサイトは別ドメインから埋め込まれています。鍵にアクセスするには、下のボタンを押してストレージアクセスを許可してください。',
     grantStorageAccess: 'ストレージアクセスを許可',
@@ -530,6 +534,7 @@ export const ja: TranslationData = {
     grantedTitle: '許可されました',
     noKeyTitle: '鍵が見つかりません',
     unsupportedTitle: 'このブラウザは未対応です',
+    openSetup: 'セットアップを開く',
   },
 };
 
@@ -788,10 +793,12 @@ export const en: TranslationData = {
       unknown: 'Other event',
     },
     approveAndTrust: 'Approve and always allow',
+    openSettings: 'Open consent settings',
   },
   iframeHost: {
     running: 'Nosskey iframe is running and waiting for signing requests from the parent app.',
-    noKey: 'No key configured. Open the settings page in another tab and sign in with a passkey.',
+    noKey:
+      'No key configured. Use the button below to open the setup page, then register or sign in with a passkey.',
     partitionedWarning:
       'This page is embedded from a different domain. Grant storage access with the button below to reach your key.',
     grantStorageAccess: 'Grant storage access',
@@ -805,6 +812,7 @@ export const en: TranslationData = {
     grantedTitle: 'Access granted',
     noKeyTitle: 'No key found',
     unsupportedTitle: 'Browser not supported',
+    openSetup: 'Open setup',
   },
 };
 

--- a/examples/svelte-app/src/utils/app-navigation.spec.ts
+++ b/examples/svelte-app/src/utils/app-navigation.spec.ts
@@ -17,6 +17,12 @@ describe('buildScreenUrl', () => {
     ).toBe('http://localhost:5173/index.html#/iframe');
   });
 
+  it('appends the hash directly to a pathname without a trailing slash', () => {
+    expect(buildScreenUrl({ origin: 'https://nosskey.app', pathname: '/app' }, 'account')).toBe(
+      'https://nosskey.app/app#/account'
+    );
+  });
+
   it('does not carry over an existing query string', () => {
     // Location.search is intentionally ignored — only origin + pathname are used.
     const loc = { origin: 'https://example.com', pathname: '/' };

--- a/examples/svelte-app/src/utils/app-navigation.spec.ts
+++ b/examples/svelte-app/src/utils/app-navigation.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { buildScreenUrl } from './app-navigation.js';
+
+describe('buildScreenUrl', () => {
+  it('builds a hash route URL from origin and pathname', () => {
+    const loc = { origin: 'https://example.com', pathname: '/' };
+    expect(buildScreenUrl(loc, 'account')).toBe('https://example.com/#/account');
+    expect(buildScreenUrl(loc, 'settings')).toBe('https://example.com/#/settings');
+  });
+
+  it('preserves a sub-path / file in pathname', () => {
+    expect(buildScreenUrl({ origin: 'https://nosskey.app', pathname: '/app/' }, 'key')).toBe(
+      'https://nosskey.app/app/#/key'
+    );
+    expect(
+      buildScreenUrl({ origin: 'http://localhost:5173', pathname: '/index.html' }, 'iframe')
+    ).toBe('http://localhost:5173/index.html#/iframe');
+  });
+
+  it('does not carry over an existing query string', () => {
+    // Location.search is intentionally ignored — only origin + pathname are used.
+    const loc = { origin: 'https://example.com', pathname: '/' };
+    expect(buildScreenUrl(loc, 'account')).not.toContain('?');
+  });
+});

--- a/examples/svelte-app/src/utils/app-navigation.ts
+++ b/examples/svelte-app/src/utils/app-navigation.ts
@@ -1,0 +1,17 @@
+/**
+ * アプリ内のハッシュルートへの遷移ヘルパー。
+ * iframe 埋め込み時は別タブで開く必要があるため、URL 組み立てを純粋関数に切り出す。
+ */
+import type { ScreenName } from '../store/app-state.js';
+
+/**
+ * アプリのハッシュルートへの絶対 URL を組み立てる。
+ * クエリ文字列（`?embedded=1` など）は引き継がず、別タブでは通常の
+ * スタンドアロン版アプリが開くようにする。
+ */
+export function buildScreenUrl(
+  loc: Pick<Location, 'origin' | 'pathname'>,
+  screen: ScreenName
+): string {
+  return `${loc.origin}${loc.pathname}#/${screen}`;
+}


### PR DESCRIPTION
Guide users to set up a passkey when no key is registered, and let them
reach consent settings from the signing dialog. The signing iframe is
often cross-origin, so links open the standalone app in a new tab.

- IframeHostScreen: add a "setup" affordance to all four key-unusable
  states (primary button for noKeyExists/unsupported, secondary link for
  partitioned/denied) opening the account screen
- ConsentDialog: add a small link to the consent settings screen
- Extract buildScreenUrl into utils/app-navigation.ts with unit tests

https://claude.ai/code/session_014vwa48jcvSwcdQ1W9DiDGv