### PR TITLE
fix(svelte-app): sync consent settings between iframe and settings page

### DIFF
--- a/examples/svelte-app/src/iframe-mode.spec.ts
+++ b/examples/svelte-app/src/iframe-mode.spec.ts
@@ -8,6 +8,7 @@ import {
   pendingConsent,
   rejectConsent,
 } from './iframe-mode.js';
+import { getNosskeyManager, resetNosskeyManager } from './services/nosskey-manager.service.js';
 import { consentPolicy, denyCounts, resetDenyCounts, trustedOrigins } from './store/app-state.js';
 
 const origin = 'https://parent.example';
@@ -33,6 +34,10 @@ const nip04Request: ConsentRequest = {
 };
 
 beforeEach(() => {
+  // 各テストを独立させる: SDK マネージャのハンドル / ストレージ残留を持ち越さない。
+  resetNosskeyManager();
+  localStorage.clear();
+  sessionStorage.clear();
   trustedOrigins.set([]);
   consentPolicy.set({ signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
   resetDenyCounts();
@@ -159,5 +164,25 @@ describe('onConsentWithFreshSettings', () => {
     expect(get(pendingConsent)).not.toBeNull();
     rejectConsent();
     expect(await promise).toBe(false);
+  });
+
+  it('reads through the granted SDK storage handle (SAA first-party path)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // in-memory ストアは古い「always 許可」のまま（localStorage に書かれる）。
+    consentPolicy.set({ signEvent: 'always', nip44: 'ask', nip04: 'ask' });
+    // SAA グラント後の first-party ストレージハンドルを sessionStorage で代用し、
+    // 設定画面が deny を書き込んだ状態を模す。reloadSettings は
+    // resolveSettingsStorage() 経由でこのハンドルを優先して読む。
+    sessionStorage.setItem(
+      'nosskey_consent_policy',
+      JSON.stringify({ signEvent: 'deny', nip44: 'ask', nip04: 'ask' })
+    );
+    getNosskeyManager().setStorageOptions({ storage: sessionStorage });
+
+    const result = await onConsentWithFreshSettings(signRequest);
+
+    expect(result).toBe(false);
+    expect(get(denyCounts).signEvent).toBe(1);
+    expect(warn).toHaveBeenCalledOnce();
   });
 });

--- a/examples/svelte-app/src/iframe-mode.spec.ts
+++ b/examples/svelte-app/src/iframe-mode.spec.ts
@@ -1,7 +1,13 @@
 import type { ConsentRequest } from 'nosskey-iframe';
 import { get } from 'svelte/store';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { approveConsent, onConsent, pendingConsent, rejectConsent } from './iframe-mode.js';
+import {
+  approveConsent,
+  onConsent,
+  onConsentWithFreshSettings,
+  pendingConsent,
+  rejectConsent,
+} from './iframe-mode.js';
 import { consentPolicy, denyCounts, resetDenyCounts, trustedOrigins } from './store/app-state.js';
 
 const origin = 'https://parent.example';
@@ -119,5 +125,39 @@ describe('onConsent', () => {
     const result = await onConsent(signRequest);
     expect(result).toBe(false);
     expect(get(denyCounts).signEvent).toBe(1);
+  });
+});
+
+describe('onConsentWithFreshSettings', () => {
+  it('re-reads persisted settings so a settings-page deny overrides a stale always store', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // iframe の in-memory ストアは古い「always 許可」のまま。
+    consentPolicy.set({ signEvent: 'always', nip44: 'ask', nip04: 'ask' });
+    // 設定画面タブが localStorage を deny に書き換えたことを模す。永続化 subscriber に
+    // 上書きされないよう、ストア set より後にストレージへ直接書き込む。
+    localStorage.setItem(
+      'nosskey_consent_policy',
+      JSON.stringify({ signEvent: 'deny', nip44: 'ask', nip04: 'ask' })
+    );
+
+    const result = await onConsentWithFreshSettings(signRequest);
+
+    expect(result).toBe(false);
+    expect(get(denyCounts).signEvent).toBe(1);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('re-reads persisted settings so a revoked trusted origin falls back to the dialog', async () => {
+    // 古い「常に許可」が in-memory に残っている状態。
+    trustedOrigins.set([{ origin, methods: ['signEvent'] }]);
+    consentPolicy.set({ signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
+    // 設定画面タブが信頼リストを空にした（信頼解除）ことを模す。
+    localStorage.setItem('nosskey_trusted_origins_v2', JSON.stringify([]));
+
+    const promise = onConsentWithFreshSettings(signRequest);
+    // 信頼解除が読み直されたので自動承認されず、同意ダイアログ待ちになる。
+    expect(get(pendingConsent)).not.toBeNull();
+    rejectConsent();
+    expect(await promise).toBe(false);
   });
 });

--- a/examples/svelte-app/src/iframe-mode.ts
+++ b/examples/svelte-app/src/iframe-mode.ts
@@ -3,7 +3,12 @@ import { NosskeyIframeHost } from 'nosskey-iframe';
 import { get, writable } from 'svelte/store';
 import { getNosskeyManager } from './services/nosskey-manager.service.js';
 import { loadRelays } from './services/relays-store.js';
-import { consentPolicy, incrementDenyCount, trustedOrigins } from './store/app-state.js';
+import {
+  consentPolicy,
+  incrementDenyCount,
+  reloadSettings,
+  trustedOrigins,
+} from './store/app-state.js';
 import { evaluateConsent, policyKeyFor } from './utils/consent-gating.js';
 
 export interface ApproveOptions {
@@ -73,6 +78,17 @@ export function onConsent(request: ConsentRequest): Promise<boolean> {
   });
 }
 
+/**
+ * `NosskeyIframeHost` に渡す `onConsent` 実装。判定の直前に永続化設定を読み直す。
+ * 設定画面タブで「拒否 / 信頼解除」されても storage イベントが cross-site iframe に
+ * 届くとは限らないため、署名リクエストごとにストレージから直接読み直して
+ * `onConsent`（純粋判定）に渡し、設定変更を確実に反映する。
+ */
+export function onConsentWithFreshSettings(request: ConsentRequest): Promise<boolean> {
+  reloadSettings();
+  return onConsent(request);
+}
+
 export function approveConsent(options?: ApproveOptions): void {
   pendingConsent.update((current) => {
     current?.resolve(true, options);
@@ -102,7 +118,7 @@ export function startIframeHost(overrides: Partial<NosskeyIframeHostOptions> = {
     // ここで原点フィルタを行うものではない。プロダクション統合時は親オリジンを限定すること。
     allowedOrigins: '*',
     requireUserConsent: true,
-    onConsent,
+    onConsent: onConsentWithFreshSettings,
     // Read through the SDK's storage handle so we hit first-party storage
     // when the user has granted access (Chromium keeps window.localStorage
     // partitioned even after the grant — only the handle points at it).

--- a/examples/svelte-app/src/store/app-state.spec.ts
+++ b/examples/svelte-app/src/store/app-state.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { get } from 'svelte/store';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getNosskeyManager, resetNosskeyManager } from '../services/nosskey-manager.service.js';
 import { consentPolicy, reloadSettings, trustedOrigins } from './app-state.js';
 import { cacheSecrets, cacheTimeout } from './secret-cache-settings.js';
@@ -164,5 +164,25 @@ describe('cross-context sync via storage events', () => {
 
     // 監視外キーなので reloadSettings は呼ばれず、in-memory は always のまま。
     expect(get(consentPolicy).signEvent).toBe('always');
+  });
+
+  it('does not write loaded values back to storage during reloadSettings', () => {
+    const firstParty = grantFirstPartyStorage({
+      nosskey_consent_policy: JSON.stringify({ signEvent: 'always', nip44: 'ask', nip04: 'ask' }),
+    });
+    const setItemSpy = vi.spyOn(firstParty, 'setItem');
+
+    reloadSettings();
+
+    // applyingExternalUpdate ガードにより、読み込んだ値を永続化 subscriber が
+    // 書き戻さない（冗長な setItem と余計な storage イベントを防ぐ）。
+    expect(setItemSpy).not.toHaveBeenCalled();
+
+    // ガードは reloadSettings の外では解除され、通常の変更は永続化される。
+    consentPolicy.set({ signEvent: 'deny', nip44: 'ask', nip04: 'ask' });
+    expect(setItemSpy).toHaveBeenCalledWith(
+      'nosskey_consent_policy',
+      JSON.stringify({ signEvent: 'deny', nip44: 'ask', nip04: 'ask' })
+    );
   });
 });

--- a/examples/svelte-app/src/store/app-state.spec.ts
+++ b/examples/svelte-app/src/store/app-state.spec.ts
@@ -114,3 +114,55 @@ describe('settings persistence after a storage grant', () => {
     });
   });
 });
+
+describe('cross-context sync via storage events', () => {
+  it('reloads settings when another context changes a watched key', () => {
+    const firstParty = grantFirstPartyStorage();
+    firstParty.setItem(
+      'nosskey_consent_policy',
+      JSON.stringify({ signEvent: 'deny', nip44: 'ask', nip04: 'ask' })
+    );
+    firstParty.setItem(
+      'nosskey_trusted_origins_v2',
+      JSON.stringify([{ origin: 'https://parent.example', methods: ['signEvent'] }])
+    );
+
+    // 別タブ / iframe からの書き込み相当。実際のブラウザでは書き込んだ当人には
+    // storage イベントは発火しないが、テストでは経路検証のため明示的に dispatch する。
+    window.dispatchEvent(new StorageEvent('storage', { key: 'nosskey_consent_policy' }));
+
+    expect(get(consentPolicy)).toEqual({ signEvent: 'deny', nip44: 'ask', nip04: 'ask' });
+    expect(get(trustedOrigins)).toEqual([
+      { origin: 'https://parent.example', methods: ['signEvent'] },
+    ]);
+  });
+
+  it('reloads settings when storage is cleared (event.key === null)', () => {
+    const firstParty = grantFirstPartyStorage({
+      nosskey_consent_policy: JSON.stringify({ signEvent: 'always', nip44: 'ask', nip04: 'ask' }),
+    });
+    reloadSettings();
+    expect(get(consentPolicy).signEvent).toBe('always');
+
+    firstParty.clear();
+    window.dispatchEvent(new StorageEvent('storage', { key: null }));
+
+    expect(get(consentPolicy)).toEqual({ signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
+  });
+
+  it('ignores storage events for keys it does not own', () => {
+    const firstParty = grantFirstPartyStorage();
+    reloadSettings();
+    consentPolicy.set({ signEvent: 'always', nip44: 'ask', nip04: 'ask' });
+    // ストレージ側だけ deny に差し替える（in-memory は always のまま）。
+    firstParty.setItem(
+      'nosskey_consent_policy',
+      JSON.stringify({ signEvent: 'deny', nip44: 'ask', nip04: 'ask' })
+    );
+
+    window.dispatchEvent(new StorageEvent('storage', { key: 'unrelated_key' }));
+
+    // 監視外キーなので reloadSettings は呼ばれず、in-memory は always のまま。
+    expect(get(consentPolicy).signEvent).toBe('always');
+  });
+});

--- a/examples/svelte-app/src/store/app-state.ts
+++ b/examples/svelte-app/src/store/app-state.ts
@@ -61,6 +61,11 @@ export const currentTheme = writable<ThemeMode>('dark');
 // localStorage には書き戻さない（次回スタンドアロン起動時にユーザー設定を保つため）。
 let embeddedThemeOverride = false;
 
+// `reloadSettings()` 実行中は true。ストレージ→メモリの一方向ロード中に
+// 永続化 subscriber が同じ値を書き戻す（冗長な setItem と余計な storage
+// イベント発火）のを抑止する。
+let applyingExternalUpdate = false;
+
 /**
  * 設定の永続化先 Storage を解決する。SDK マネージャが Storage Access API
  * グラント後のハンドルを保持していれば、それを使う。これはリレー設定が読む
@@ -232,10 +237,12 @@ try {
 
   // 設定が変更されたら保存
   cacheSecrets.subscribe((value) => {
+    if (applyingExternalUpdate) return;
     resolveSettingsStorage()?.setItem('nosskey_cache_secrets', String(value));
   });
 
   cacheTimeout.subscribe((value) => {
+    if (applyingExternalUpdate) return;
     resolveSettingsStorage()?.setItem('nosskey_cache_timeout', String(value));
   });
 
@@ -250,12 +257,32 @@ try {
   consentPolicy.set(loadConsentPolicy());
 
   trustedOrigins.subscribe((value) => {
+    if (applyingExternalUpdate) return;
     resolveSettingsStorage()?.setItem(TRUSTED_ORIGINS_KEY, JSON.stringify(value));
   });
 
   consentPolicy.subscribe((value) => {
+    if (applyingExternalUpdate) return;
     resolveSettingsStorage()?.setItem(CONSENT_POLICY_KEY, JSON.stringify(value));
   });
+
+  // 別ドキュメント（設定画面タブ / 署名 iframe）が同じ first-party ストレージへ
+  // 設定を書き込んだら storage イベントで通知される。リロード無しで即時同期するため
+  // 監視キーの変更時に reloadSettings() で読み直す。storage イベントは変更を行った
+  // 当人のドキュメントには発火しないため自己トリガはしない。
+  if (typeof window !== 'undefined') {
+    const WATCHED_SETTINGS_KEYS = new Set<string>([
+      TRUSTED_ORIGINS_KEY,
+      CONSENT_POLICY_KEY,
+      'nosskey_cache_secrets',
+      'nosskey_cache_timeout',
+    ]);
+    window.addEventListener('storage', (event) => {
+      // key が null なのは clear() 由来。監視キー以外は無視する。
+      if (event.key !== null && !WATCHED_SETTINGS_KEYS.has(event.key)) return;
+      reloadSettings();
+    });
+  }
 } catch (e) {
   console.error('設定の初期化に失敗しました:', e);
 }
@@ -270,10 +297,18 @@ try {
  * 向かう。テーマは埋め込み時に親オリジンが指定する既存仕様のため対象外。
  */
 export function reloadSettings(): void {
-  cacheSecrets.set(loadCacheSecretsSetting());
-  cacheTimeout.set(loadCacheTimeoutSetting());
-  trustedOrigins.set(loadTrustedOrigins());
-  consentPolicy.set(loadConsentPolicy());
+  // ロードした値を永続化 subscriber が即座に書き戻さないよう抑止する。
+  // Svelte writable の subscriber は set() 内で同期実行されるため、
+  // try/finally のスコープで全 set() の通知を覆える。
+  applyingExternalUpdate = true;
+  try {
+    cacheSecrets.set(loadCacheSecretsSetting());
+    cacheTimeout.set(loadCacheTimeoutSetting());
+    trustedOrigins.set(loadTrustedOrigins());
+    consentPolicy.set(loadConsentPolicy());
+  } finally {
+    applyingExternalUpdate = false;
+  }
 }
 
 // リセット関数


### PR DESCRIPTION
Consent settings changed in one context (the signing iframe vs. the
settings tab) were not reflected in the other until a full reload, so a
settings-page "deny"/revoke could be bypassed and an iframe "always
allow" did not show up in the settings list.

Add a window storage-event listener so each context re-reads settings
when another context persists a change, and re-read persisted settings
before every consent evaluation in the iframe so a deny/revoke takes
effect on the next signing request without relying on storage events
reaching the cross-site iframe. Guard reloadSettings() against the
persistence subscribers writing the freshly loaded values back.

https://claude.ai/code/session_01RHknnvMDbzuYLNeJYc7vwH