### PR TITLE
feat(parent-sample): add snackbar notifications for action feedback

### DIFF
--- a/examples/parent-sample/index.html
+++ b/examples/parent-sample/index.html
@@ -164,6 +164,7 @@
         aria-label="Nosskey signing"
       ></div>
     </div>
+    <div id="toast-container" class="toast-container" aria-live="polite"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/examples/parent-sample/src/main.ts
+++ b/examples/parent-sample/src/main.ts
@@ -100,7 +100,10 @@ async function connect(): Promise<void> {
     const error = formatError(err);
     log(`Connect failed: ${error}`);
     next?.destroy();
-    // Only reset shared UI state if this connect() still owns the client slot.
+    // Only reset shared UI state — and surface the failure toast — if this
+    // connect() still owns the client slot. A concurrent re-mount may have
+    // already replaced us with a fresh, possibly-successful connect; we must
+    // not overwrite its toast with our stale error.
     if (next === null || client === next) {
       client = null;
       window.nostr = undefined;
@@ -108,8 +111,10 @@ async function connect(): Promise<void> {
       setModalVisible(modal, false);
       clearParentTheme();
       setStatus(ui.status, 'connect failed', 'err');
+      progress.settle(`Connect failed: ${error}`, 'error');
+    } else {
+      progress.dismiss();
     }
-    progress.settle(`Connect failed: ${error}`, 'error');
   }
 }
 

--- a/examples/parent-sample/src/main.ts
+++ b/examples/parent-sample/src/main.ts
@@ -12,6 +12,7 @@ import {
   signAndPublishNote,
 } from './nips.js';
 import { publishEvent } from './relay.js';
+import { createToaster } from './toast.js';
 import {
   type LangChoice,
   type ThemeChoice,
@@ -37,9 +38,11 @@ declare global {
 const app = requireEl<HTMLDivElement>(document, '#app');
 const modal = requireEl<HTMLDivElement>(document, '#iframe-modal');
 const modalCard = requireEl<HTMLDivElement>(modal, '.iframe-modal__card');
+const toastContainer = requireEl<HTMLDivElement>(document, '#toast-container');
 
 const ui = queryUiElements(app);
 const log = createLogger(ui.log);
+const toaster = createToaster(toastContainer);
 
 installModalVisibilityListener(modal);
 
@@ -53,6 +56,7 @@ async function connect(): Promise<void> {
   const iframeUrl = ui.iframeUrl.value.trim();
   if (!iframeUrl) {
     log('Connect aborted: iframe URL is empty.');
+    toaster.show('Connect aborted: iframe URL is empty.', 'error');
     return;
   }
   setStatus(ui.status, 'connecting…');
@@ -60,6 +64,7 @@ async function connect(): Promise<void> {
   const langChoice = ui.parentLang.value as LangChoice;
   log(`Mounting iframe ${iframeUrl} with theme=${themeChoice}, lang=${langChoice}`);
   applyParentTheme(resolveTheme(themeChoice));
+  const progress = toaster.show('Connecting to iframe…', 'progress');
   let next: NosskeyIframeClient | null = null;
   try {
     next = new NosskeyIframeClient({ iframeUrl, theme: themeChoice, lang: langChoice });
@@ -71,6 +76,7 @@ async function connect(): Promise<void> {
     // the newer connect() owns the `client` slot now.
     if (client !== next) {
       next.destroy();
+      progress.dismiss();
       return;
     }
     window.nostr = {
@@ -89,8 +95,10 @@ async function connect(): Promise<void> {
     setConnectedUI(ui, true);
     setStatus(ui.status, 'connected', 'ok');
     log('Received nosskey:ready. window.nostr is now available.');
+    progress.settle('Connected. window.nostr is available.', 'success');
   } catch (err) {
-    log(`Connect failed: ${formatError(err)}`);
+    const error = formatError(err);
+    log(`Connect failed: ${error}`);
     next?.destroy();
     // Only reset shared UI state if this connect() still owns the client slot.
     if (next === null || client === next) {
@@ -101,6 +109,7 @@ async function connect(): Promise<void> {
       clearParentTheme();
       setStatus(ui.status, 'connect failed', 'err');
     }
+    progress.settle(`Connect failed: ${error}`, 'error');
   }
 }
 
@@ -114,16 +123,20 @@ function disconnect(): void {
   clearParentTheme();
   setStatus(ui.status, 'disconnected');
   log('Iframe destroyed; window.nostr removed.');
+  toaster.show('Disconnected.', 'info');
 }
 
 async function getPubkey(): Promise<void> {
   if (!window.nostr) return;
   log('Requesting window.nostr.getPublicKey()…');
+  const progress = toaster.show('Fetching public key…', 'progress');
   try {
     const pubkey = await window.nostr.getPublicKey();
     log(`pubkey: ${pubkey}`);
+    progress.settle(`Public key: ${pubkey.slice(0, 8)}…${pubkey.slice(-4)}`, 'success');
   } catch (err) {
-    log(`getPublicKey failed: ${formatError(err)}`);
+    const error = formatError(err);
+    log(`getPublicKey failed: ${error}`);
     if (err instanceof NosskeyIframeError && err.code === 'NO_KEY') {
       log(
         'Hint: browser storage may be partitioned for this cross-origin iframe. ' +
@@ -132,22 +145,26 @@ async function getPubkey(): Promise<void> {
           'tab, create a passkey, and try again.'
       );
     }
+    progress.settle(`getPublicKey failed: ${error}`, 'error');
   }
 }
 
 async function getRelays(): Promise<void> {
   if (!window.nostr) return;
   log('Requesting window.nostr.getRelays()…');
+  const progress = toaster.show('Fetching relays…', 'progress');
   try {
     const relays = await window.nostr.getRelays();
     const count = Object.keys(relays).length;
     const formatted = count === 0 ? '{}' : JSON.stringify(relays, null, 2);
     ui.relaysOutput.textContent = formatted;
     log(`getRelays: ${count} relay(s) returned`);
+    progress.settle(`getRelays: ${count} relay(s) returned`, 'success');
   } catch (err) {
     const message = formatError(err);
     log(`getRelays failed: ${message}`);
     ui.relaysOutput.textContent = `Error: ${message}`;
+    progress.settle(`getRelays failed: ${message}`, 'error');
   }
 }
 
@@ -156,15 +173,22 @@ async function signAndPublish(): Promise<void> {
   const relay = parseRelayUrl(ui.relayUrl.value);
   if (!relay.ok) {
     log(`Sign aborted: ${relay.reason}.`);
+    toaster.show(`Sign aborted: ${relay.reason}`, 'error');
     return;
   }
-  await signAndPublishNote({
+  const progress = toaster.show('Signing & publishing…', 'progress');
+  const result = await signAndPublishNote({
     nostr: window.nostr,
     content: ui.note.value,
     relayUrl: relay.value,
     log,
     publish: (event) => publish(relay.value, event),
   });
+  if (result.ok) {
+    progress.settle(`Note published to ${relay.value}.`, 'success');
+  } else {
+    progress.settle(`Sign & publish failed: ${result.error}`, 'error');
+  }
 }
 
 async function fillSelfPubkey(target: HTMLInputElement, label: string): Promise<void> {
@@ -173,8 +197,11 @@ async function fillSelfPubkey(target: HTMLInputElement, label: string): Promise<
   try {
     target.value = await window.nostr.getPublicKey();
     log(`${label}: peer pubkey set to own pubkey.`);
+    toaster.show(`${label}: peer set to your pubkey.`, 'info');
   } catch (err) {
-    log(`${label}: getPublicKey failed: ${formatError(err)}`);
+    const error = formatError(err);
+    log(`${label}: getPublicKey failed: ${error}`);
+    toaster.show(`${label}: getPublicKey failed: ${error}`, 'error');
   }
 }
 
@@ -183,8 +210,10 @@ async function runNip44Encrypt(): Promise<void> {
   const peer = parsePeerPubkey(ui.nip44Peer.value);
   if (!peer.ok) {
     log(`NIP-44 encrypt aborted: ${peer.reason}.`);
+    toaster.show(`NIP-44 encrypt aborted: ${peer.reason}`, 'error');
     return;
   }
+  const progress = toaster.show('NIP-44 encrypting…', 'progress');
   const ciphertext = await nip44Encrypt({
     nostr: window.nostr,
     peer: peer.value,
@@ -193,6 +222,9 @@ async function runNip44Encrypt(): Promise<void> {
   });
   if (ciphertext !== null) {
     ui.nip44Ciphertext.value = ciphertext;
+    progress.settle('NIP-44 encrypt OK.', 'success');
+  } else {
+    progress.settle('NIP-44 encrypt failed.', 'error');
   }
 }
 
@@ -202,8 +234,10 @@ async function runNip44Decrypt(): Promise<void> {
   const ciphertext = ui.nip44Ciphertext.value.trim();
   if (!peer.ok || !ciphertext) {
     log('NIP-44 decrypt aborted: peer pubkey or ciphertext is empty.');
+    toaster.show('NIP-44 decrypt aborted: peer pubkey or ciphertext is empty.', 'error');
     return;
   }
+  const progress = toaster.show('NIP-44 decrypting…', 'progress');
   const result = await nip44Decrypt({
     nostr: window.nostr,
     peer: peer.value,
@@ -211,6 +245,11 @@ async function runNip44Decrypt(): Promise<void> {
     log,
   });
   ui.nip44Decrypted.textContent = result.ok ? result.plaintext : `Error: ${result.message}`;
+  if (result.ok) {
+    progress.settle('NIP-44 decrypt OK.', 'success');
+  } else {
+    progress.settle(`NIP-44 decrypt failed: ${result.message}`, 'error');
+  }
 }
 
 async function runNip04Encrypt(): Promise<void> {
@@ -218,8 +257,10 @@ async function runNip04Encrypt(): Promise<void> {
   const peer = parsePeerPubkey(ui.nip04Peer.value);
   if (!peer.ok) {
     log(`NIP-04 encrypt aborted: ${peer.reason}.`);
+    toaster.show(`NIP-04 encrypt aborted: ${peer.reason}`, 'error');
     return;
   }
+  const progress = toaster.show('NIP-04 encrypting…', 'progress');
   const ciphertext = await nip04Encrypt({
     nostr: window.nostr,
     peer: peer.value,
@@ -228,6 +269,9 @@ async function runNip04Encrypt(): Promise<void> {
   });
   if (ciphertext !== null) {
     ui.nip04Ciphertext.value = ciphertext;
+    progress.settle('NIP-04 encrypt OK.', 'success');
+  } else {
+    progress.settle('NIP-04 encrypt failed.', 'error');
   }
 }
 
@@ -237,8 +281,10 @@ async function runNip04Decrypt(): Promise<void> {
   const ciphertext = ui.nip04Ciphertext.value.trim();
   if (!peer.ok || !ciphertext) {
     log('NIP-04 decrypt aborted: peer pubkey or ciphertext is empty.');
+    toaster.show('NIP-04 decrypt aborted: peer pubkey or ciphertext is empty.', 'error');
     return;
   }
+  const progress = toaster.show('NIP-04 decrypting…', 'progress');
   const result = await nip04Decrypt({
     nostr: window.nostr,
     peer: peer.value,
@@ -246,6 +292,11 @@ async function runNip04Decrypt(): Promise<void> {
     log,
   });
   ui.nip04Decrypted.textContent = result.ok ? result.plaintext : `Error: ${result.message}`;
+  if (result.ok) {
+    progress.settle('NIP-04 decrypt OK.', 'success');
+  } else {
+    progress.settle(`NIP-04 decrypt failed: ${result.message}`, 'error');
+  }
 }
 
 async function runNip04SendDm(): Promise<void> {
@@ -253,14 +304,17 @@ async function runNip04SendDm(): Promise<void> {
   const peer = parsePeerPubkey(ui.nip04Peer.value);
   if (!peer.ok) {
     log(`NIP-04 DM aborted: ${peer.reason}.`);
+    toaster.show(`NIP-04 DM aborted: ${peer.reason}`, 'error');
     return;
   }
   const relay = parseRelayUrl(ui.relayUrl.value);
   if (!relay.ok) {
     log('NIP-04 DM aborted: relay URL (section 4) is empty.');
+    toaster.show('NIP-04 DM aborted: relay URL (section 4) is empty.', 'error');
     return;
   }
-  await nip04SendDm({
+  const progress = toaster.show('NIP-04 DM: encrypting, signing & publishing…', 'progress');
+  const result = await nip04SendDm({
     nostr: window.nostr,
     peer: peer.value,
     plaintext: ui.nip04Plaintext.value,
@@ -270,6 +324,11 @@ async function runNip04SendDm(): Promise<void> {
       ui.nip04Ciphertext.value = ciphertext;
     },
   });
+  if (result.ok) {
+    progress.settle(`NIP-04 DM published to ${relay.value}.`, 'success');
+  } else {
+    progress.settle(`NIP-04 DM failed: ${result.error}`, 'error');
+  }
 }
 
 async function runNip17SendDm(): Promise<void> {
@@ -278,20 +337,25 @@ async function runNip17SendDm(): Promise<void> {
   const peer = parsePeerPubkey(ui.nip17Peer.value);
   if (!peer.ok) {
     log(`NIP-17 DM aborted: ${peer.reason}.`);
+    toaster.show(`NIP-17 DM aborted: ${peer.reason}`, 'error');
     return;
   }
   const relay = parseRelayUrl(ui.relayUrl.value);
   if (!relay.ok) {
     log('NIP-17 DM aborted: relay URL (section 4) is empty.');
+    toaster.show('NIP-17 DM aborted: relay URL (section 4) is empty.', 'error');
     return;
   }
 
+  const progress = toaster.show('NIP-17 DM: sealing & publishing…', 'progress');
   log('NIP-17 DM: resolving sender pubkey…');
   let senderPubkey: string;
   try {
     senderPubkey = await nostr.getPublicKey();
   } catch (err) {
-    log(`NIP-17 DM getPublicKey failed: ${formatError(err)}`);
+    const error = formatError(err);
+    log(`NIP-17 DM getPublicKey failed: ${error}`);
+    progress.settle(`NIP-17 DM failed: ${error}`, 'error');
     return;
   }
 
@@ -307,8 +371,11 @@ async function runNip17SendDm(): Promise<void> {
     });
     log(`NIP-17 DM: gift wrap id ${result.giftWrap.id ?? '(missing id)'}`);
     log(`NIP-17 DM: ephemeral pubkey ${result.ephemeralPubkey}`);
+    progress.settle(`NIP-17 DM published to ${relay.value}.`, 'success');
   } catch (err) {
-    log(`NIP-17 DM failed: ${formatError(err)}`);
+    const error = formatError(err);
+    log(`NIP-17 DM failed: ${error}`);
+    progress.settle(`NIP-17 DM failed: ${error}`, 'error');
   }
 }
 

--- a/examples/parent-sample/src/nips.spec.ts
+++ b/examples/parent-sample/src/nips.spec.ts
@@ -137,7 +137,7 @@ describe('signAndPublishNote', () => {
     vi.mocked(nostr.signEvent).mockResolvedValue(signed);
     const publish = vi.fn().mockResolvedValue(undefined);
     const log = vi.fn();
-    await signAndPublishNote({
+    const result = await signAndPublishNote({
       nostr,
       content: 'hi',
       relayUrl: 'wss://example',
@@ -148,13 +148,14 @@ describe('signAndPublishNote', () => {
       expect.objectContaining({ kind: 1, content: 'hi', tags: [] })
     );
     expect(publish).toHaveBeenCalledWith(signed);
+    expect(result).toEqual({ ok: true });
   });
 
   it('does not publish when signEvent rejects', async () => {
     const nostr = createNostrMock();
     vi.mocked(nostr.signEvent).mockRejectedValue(new Error('user rejected'));
     const publish = vi.fn();
-    await signAndPublishNote({
+    const result = await signAndPublishNote({
       nostr,
       content: 'hi',
       relayUrl: 'wss://example',
@@ -162,6 +163,7 @@ describe('signAndPublishNote', () => {
       publish,
     });
     expect(publish).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: false, error: expect.stringContaining('user rejected') });
   });
 
   it('logs a publish failure when publish rejects', async () => {
@@ -178,7 +180,7 @@ describe('signAndPublishNote', () => {
     vi.mocked(nostr.signEvent).mockResolvedValue(signed);
     const publish = vi.fn().mockRejectedValue(new Error('relay down'));
     const log = vi.fn();
-    await signAndPublishNote({
+    const result = await signAndPublishNote({
       nostr,
       content: 'hi',
       relayUrl: 'wss://example',
@@ -187,6 +189,7 @@ describe('signAndPublishNote', () => {
     });
     expect(publish).toHaveBeenCalledWith(signed);
     expect(log).toHaveBeenCalledWith(expect.stringContaining('Publish failed'));
+    expect(result).toEqual({ ok: false, error: expect.stringContaining('relay down') });
   });
 });
 
@@ -209,7 +212,7 @@ describe('nip04SendDm', () => {
     vi.mocked(nostr.signEvent).mockResolvedValue(buildSignedKind4('cipher04'));
     const publish = vi.fn().mockResolvedValue(undefined);
     const onCiphertext = vi.fn();
-    await nip04SendDm({
+    const result = await nip04SendDm({
       nostr,
       peer: PEER,
       plaintext: 'hello',
@@ -223,6 +226,7 @@ describe('nip04SendDm', () => {
       expect.objectContaining({ kind: 4, content: 'cipher04', tags: [['p', PEER]] })
     );
     expect(publish).toHaveBeenCalled();
+    expect(result).toEqual({ ok: true });
   });
 
   it('aborts without signing or publishing if encrypt fails', async () => {
@@ -230,7 +234,7 @@ describe('nip04SendDm', () => {
     vi.mocked(nostr.nip04.encrypt).mockRejectedValue(new Error('encrypt failed'));
     const publish = vi.fn();
     const onCiphertext = vi.fn();
-    await nip04SendDm({
+    const result = await nip04SendDm({
       nostr,
       peer: PEER,
       plaintext: 'hi',
@@ -241,6 +245,7 @@ describe('nip04SendDm', () => {
     expect(nostr.signEvent).not.toHaveBeenCalled();
     expect(publish).not.toHaveBeenCalled();
     expect(onCiphertext).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
   });
 
   it('does not publish when signEvent fails', async () => {
@@ -248,7 +253,7 @@ describe('nip04SendDm', () => {
     vi.mocked(nostr.nip04.encrypt).mockResolvedValue('cipher04');
     vi.mocked(nostr.signEvent).mockRejectedValue(new Error('user rejected'));
     const publish = vi.fn();
-    await nip04SendDm({
+    const result = await nip04SendDm({
       nostr,
       peer: PEER,
       plaintext: 'hi',
@@ -256,6 +261,7 @@ describe('nip04SendDm', () => {
       publish,
     });
     expect(publish).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: false, error: expect.stringContaining('user rejected') });
   });
 
   it('works without onCiphertext callback', async () => {
@@ -263,7 +269,7 @@ describe('nip04SendDm', () => {
     vi.mocked(nostr.nip04.encrypt).mockResolvedValue('cipher04');
     vi.mocked(nostr.signEvent).mockResolvedValue(buildSignedKind4('cipher04'));
     const publish = vi.fn().mockResolvedValue(undefined);
-    await nip04SendDm({
+    const result = await nip04SendDm({
       nostr,
       peer: PEER,
       plaintext: 'hi',
@@ -271,6 +277,7 @@ describe('nip04SendDm', () => {
       publish,
     });
     expect(publish).toHaveBeenCalled();
+    expect(result).toEqual({ ok: true });
   });
 
   it('logs a publish failure when publish rejects', async () => {
@@ -279,7 +286,7 @@ describe('nip04SendDm', () => {
     vi.mocked(nostr.signEvent).mockResolvedValue(buildSignedKind4('cipher04'));
     const publish = vi.fn().mockRejectedValue(new Error('relay down'));
     const log = vi.fn();
-    await nip04SendDm({
+    const result = await nip04SendDm({
       nostr,
       peer: PEER,
       plaintext: 'hi',
@@ -288,5 +295,6 @@ describe('nip04SendDm', () => {
     });
     expect(publish).toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith(expect.stringContaining('NIP-04 DM publish failed'));
+    expect(result).toEqual({ ok: false, error: expect.stringContaining('relay down') });
   });
 });

--- a/examples/parent-sample/src/nips.ts
+++ b/examples/parent-sample/src/nips.ts
@@ -36,6 +36,9 @@ export function formatError(err: unknown): string {
 
 export type DecryptResult = { ok: true; plaintext: string } | { ok: false; message: string };
 
+/** Generic outcome for multi-step actions whose callers want to surface a single success/failure summary. */
+export type ActionResult = { ok: true } | { ok: false; error: string };
+
 export interface EncryptInputs {
   nostr: NostrProvider;
   peer: string;
@@ -112,7 +115,7 @@ export interface SignAndPublishInputs {
   publish: (event: NostrEvent) => Promise<void>;
 }
 
-export async function signAndPublishNote(inputs: SignAndPublishInputs): Promise<void> {
+export async function signAndPublishNote(inputs: SignAndPublishInputs): Promise<ActionResult> {
   const { nostr, content, log, publish } = inputs;
   const draft: NostrEvent = {
     kind: 1,
@@ -126,16 +129,20 @@ export async function signAndPublishNote(inputs: SignAndPublishInputs): Promise<
   try {
     signed = await nostr.signEvent(draft);
   } catch (err) {
-    log(`signEvent failed: ${formatError(err)}`);
-    return;
+    const error = formatError(err);
+    log(`signEvent failed: ${error}`);
+    return { ok: false, error };
   }
   log(`Signed event: ${JSON.stringify(signed, null, 2)}`);
 
   try {
     await publish(signed);
   } catch (err) {
-    log(`Publish failed: ${formatError(err)}`);
+    const error = formatError(err);
+    log(`Publish failed: ${error}`);
+    return { ok: false, error };
   }
+  return { ok: true };
 }
 
 export interface Nip04SendDmInputs {
@@ -148,12 +155,14 @@ export interface Nip04SendDmInputs {
   onCiphertext?: (ciphertext: string) => void;
 }
 
-export async function nip04SendDm(inputs: Nip04SendDmInputs): Promise<void> {
+export async function nip04SendDm(inputs: Nip04SendDmInputs): Promise<ActionResult> {
   const { nostr, peer, plaintext, log, publish, onCiphertext } = inputs;
 
   log(`NIP-04 DM: encrypting to ${peer.slice(0, 8)}…`);
   const ciphertext = await nip04Encrypt({ nostr, peer, plaintext, log });
-  if (ciphertext === null) return;
+  if (ciphertext === null) {
+    return { ok: false, error: 'NIP-04 encrypt failed' };
+  }
   onCiphertext?.(ciphertext);
 
   const draft: NostrEvent = {
@@ -167,14 +176,18 @@ export async function nip04SendDm(inputs: Nip04SendDmInputs): Promise<void> {
   try {
     signed = await nostr.signEvent(draft);
   } catch (err) {
-    log(`NIP-04 DM signEvent failed: ${formatError(err)}`);
-    return;
+    const error = formatError(err);
+    log(`NIP-04 DM signEvent failed: ${error}`);
+    return { ok: false, error };
   }
   log(`NIP-04 DM: signed event id ${signed.id ?? '(missing id)'}.`);
 
   try {
     await publish(signed);
   } catch (err) {
-    log(`NIP-04 DM publish failed: ${formatError(err)}`);
+    const error = formatError(err);
+    log(`NIP-04 DM publish failed: ${error}`);
+    return { ok: false, error };
   }
+  return { ok: true };
 }

--- a/examples/parent-sample/src/style.css
+++ b/examples/parent-sample/src/style.css
@@ -213,3 +213,120 @@ body.parent-theme-dark .iframe-modal__card {
 body.parent-theme-light .iframe-modal__card {
   background: #ffffff;
 }
+
+.toast-container {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 3000;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  width: 100%;
+  max-width: min(560px, calc(100vw - 32px));
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: #1f2329;
+  color: #f5f6f8;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+  border-left: 4px solid rgba(255, 255, 255, 0.4);
+  max-width: 100%;
+  min-width: 240px;
+  word-break: break-word;
+  animation: toast-enter 0.2s ease forwards;
+}
+
+.toast--leaving {
+  animation: toast-leave 0.2s ease forwards;
+}
+
+.toast--info {
+  border-left-color: #4c6ef5;
+}
+
+.toast--success {
+  border-left-color: #2f9e44;
+}
+
+.toast--error {
+  border-left-color: #e03131;
+}
+
+.toast--progress {
+  border-left-color: #adb5bd;
+}
+
+.toast__message {
+  flex: 1;
+}
+
+.toast__close {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  opacity: 0.7;
+}
+
+.toast__close:hover {
+  opacity: 1;
+}
+
+.toast__spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  border-top-color: #f5f6f8;
+  border-radius: 50%;
+  display: none;
+  flex-shrink: 0;
+}
+
+.toast--progress .toast__spinner {
+  display: inline-block;
+  animation: toast-spin 0.8s linear infinite;
+}
+
+@keyframes toast-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes toast-leave {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+}
+
+@keyframes toast-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/examples/parent-sample/src/toast.ts
+++ b/examples/parent-sample/src/toast.ts
@@ -1,0 +1,98 @@
+/**
+ * Snackbar/toast notifier for the parent-sample app. Renders short-lived
+ * messages into a fixed container so user actions get visible feedback
+ * without scrolling the log. Pure DOM glue — no business logic.
+ */
+
+export type ToastVariant = 'info' | 'success' | 'error' | 'progress';
+
+export interface ToastHandle {
+  /** Re-render the same toast node with a final variant/message and start auto-dismiss. */
+  settle(message: string, variant: ToastVariant): void;
+  dismiss(): void;
+}
+
+export interface Toaster {
+  show(message: string, variant?: ToastVariant): ToastHandle;
+}
+
+const AUTO_DISMISS_MS: Record<ToastVariant, number | null> = {
+  info: 4000,
+  success: 4000,
+  error: 6000,
+  progress: null,
+};
+
+export function createToaster(container: HTMLElement): Toaster {
+  return {
+    show(message: string, variant: ToastVariant = 'info'): ToastHandle {
+      const toast = document.createElement('div');
+      const spinner = document.createElement('span');
+      spinner.className = 'toast__spinner';
+      spinner.setAttribute('aria-hidden', 'true');
+
+      const messageEl = document.createElement('span');
+      messageEl.className = 'toast__message';
+      messageEl.textContent = message;
+
+      const closeBtn = document.createElement('button');
+      closeBtn.type = 'button';
+      closeBtn.className = 'toast__close';
+      closeBtn.setAttribute('aria-label', 'Dismiss');
+      closeBtn.textContent = '×';
+
+      toast.appendChild(spinner);
+      toast.appendChild(messageEl);
+      toast.appendChild(closeBtn);
+      container.appendChild(toast);
+
+      let dismissed = false;
+      let timer: ReturnType<typeof setTimeout> | null = null;
+
+      function applyVariant(v: ToastVariant): void {
+        toast.className = `toast toast--${v}`;
+        toast.setAttribute('role', v === 'error' ? 'alert' : 'status');
+      }
+
+      function startAutoDismiss(v: ToastVariant): void {
+        const ms = AUTO_DISMISS_MS[v];
+        if (ms === null) return;
+        timer = setTimeout(dismiss, ms);
+      }
+
+      function clearTimer(): void {
+        if (timer !== null) {
+          clearTimeout(timer);
+          timer = null;
+        }
+      }
+
+      function dismiss(): void {
+        if (dismissed) return;
+        dismissed = true;
+        clearTimer();
+        toast.classList.add('toast--leaving');
+        // Removal time matches the CSS exit animation duration.
+        setTimeout(() => {
+          if (toast.parentNode) toast.parentNode.removeChild(toast);
+        }, 200);
+      }
+
+      closeBtn.addEventListener('click', dismiss);
+
+      applyVariant(variant);
+      startAutoDismiss(variant);
+
+      return {
+        settle(nextMessage, nextVariant) {
+          if (dismissed) return;
+          clearTimer();
+          applyVariant(nextVariant);
+          messageEl.textContent = nextMessage;
+          startAutoDismiss(nextVariant);
+        },
+        dismiss,
+      };
+    },
+  };
+}


### PR DESCRIPTION
The only action feedback was a scrolling log at the bottom of the page,
so users could not easily tell whether Sign & publish (and other
actions) were in progress, succeeded, or failed. Add a fixed
bottom-center snackbar that shows progress/success/error toasts for
every action and persists through the signing consent dialog.

https://claude.ai/code/session_01AxgH3cR2stdhuiUSt638xw