### PR TITLE
feat(svelte-app): verify kind:0 signatures and revamp profile display

### DIFF
--- a/examples/svelte-app/package.json
+++ b/examples/svelte-app/package.json
@@ -26,6 +26,8 @@
     "vitest": "^3.1.2"
   },
   "dependencies": {
+    "@noble/curves": "^2.2.0",
+    "@noble/hashes": "^2.2.0",
     "bech32": "^2.0.0",
     "nosskey-iframe": "*",
     "nosskey-sdk": "*"

--- a/examples/svelte-app/src/components/ProfileAvatar.svelte
+++ b/examples/svelte-app/src/components/ProfileAvatar.svelte
@@ -58,8 +58,8 @@ function handlePictureError() {
 <style>
   .avatar {
     flex-shrink: 0;
-    width: 64px;
-    height: 64px;
+    width: 120px;
+    height: 120px;
     border-radius: 50%;
     overflow: hidden;
     background-color: var(--color-card);
@@ -77,7 +77,7 @@ function handlePictureError() {
   }
 
   .avatar-fallback {
-    font-size: 1.4rem;
+    font-size: 2.6rem;
     font-weight: 600;
     color: var(--color-text-muted);
     user-select: none;
@@ -85,12 +85,12 @@ function handlePictureError() {
 
   @media (max-width: 480px) {
     .avatar {
-      width: 52px;
-      height: 52px;
+      width: 96px;
+      height: 96px;
     }
 
     .avatar-fallback {
-      font-size: 1.1rem;
+      font-size: 2rem;
     }
   }
 </style>

--- a/examples/svelte-app/src/components/PublicKeyDisplay.svelte
+++ b/examples/svelte-app/src/components/PublicKeyDisplay.svelte
@@ -2,13 +2,13 @@
 import CopyIcon from '../assets/copy-icon.svg';
 import { i18n } from '../i18n/i18n-store.js';
 import { publicKey } from '../store/app-state.js';
+import { currentProfile } from '../store/profile-store.js';
 import { hexToNpub } from '../utils/bech32-converter.js';
 import ProfileAvatar from './ProfileAvatar.svelte';
 import IconButton from './ui/button/IconButton.svelte';
 
 // 状態変数
 let publicKeyHex = $state('');
-let publicKeyShort = $state('');
 let npubAddress = $state('');
 let showCopiedMessage = $state(false);
 
@@ -19,9 +19,6 @@ publicKey.subscribe((value) => {
   publicKeyHex = value || '';
 
   if (publicKeyHex) {
-    // 公開鍵を表示用に整形
-    publicKeyShort = `${publicKeyHex.slice(0, 8)}...${publicKeyHex.slice(-8)}`;
-
     // npub形式に変換
     try {
       npubAddress = hexToNpub(publicKeyHex);
@@ -30,6 +27,15 @@ publicKey.subscribe((value) => {
       npubAddress = 'Error: Could not convert to npub';
     }
   }
+});
+
+// kind:0 由来の表示名。display_name を優先し、無ければ name。
+const profileName = $derived($currentProfile?.display_name || $currentProfile?.name || '');
+// display_name と name が両方あり別物なら、name を @ハンドルとして補助表示する。
+const profileHandle = $derived.by(() => {
+  const p = $currentProfile;
+  if (p?.display_name && p.name && p.name !== p.display_name) return p.name;
+  return '';
 });
 
 // クリップボードにコピー
@@ -51,58 +57,70 @@ function copyNpubToClipboard() {
 </script>
 
 <div class="pubkey-container">
-  <div class="pubkey-header">
-    <ProfileAvatar pubkey={publicKeyHex} />
-    <div class="pubkey-display">
-      <h3>{$i18n.t.nostr.publicKey}</h3>
-      <p>{publicKeyShort}</p>
-      <div class="npub-container">
-        <div class="npub-wrapper">
-          <p class="npub">
-            {npubAddress.length > 20
-              ? `${npubAddress.slice(0, 12)}...${npubAddress.slice(-8)}`
-              : npubAddress}
-          </p>
-          <IconButton
-            onclick={copyNpubToClipboard}
-            title={$i18n.t.nostr.copyToClipboard}
-          >
-            <img src={CopyIcon} alt="Copy" />
-          </IconButton>
-        </div>
-        {#if showCopiedMessage}
-          <span class="copied-message">{$i18n.t.nostr.copiedToClipboard}</span>
-        {/if}
-      </div>
+  <ProfileAvatar pubkey={publicKeyHex} />
+
+  {#if profileName}
+    <h2 class="display-name">{profileName}</h2>
+  {/if}
+  {#if profileHandle}
+    <p class="handle">@{profileHandle}</p>
+  {/if}
+
+  <div class="npub-section">
+    <h3>{$i18n.t.nostr.publicKey}</h3>
+    <div class="npub-wrapper">
+      <p class="npub">
+        {npubAddress.length > 20
+          ? `${npubAddress.slice(0, 12)}...${npubAddress.slice(-8)}`
+          : npubAddress}
+      </p>
+      <IconButton
+        onclick={copyNpubToClipboard}
+        title={$i18n.t.nostr.copyToClipboard}
+      >
+        <img src={CopyIcon} alt="Copy" />
+      </IconButton>
     </div>
+    {#if showCopiedMessage}
+      <span class="copied-message">{$i18n.t.nostr.copiedToClipboard}</span>
+    {/if}
   </div>
 </div>
 
 <style>
   .pubkey-container {
     background-color: var(--color-surface-alt);
-    padding: 15px;
+    padding: 24px 15px;
     border-radius: 5px;
     margin-bottom: 20px;
-  }
-
-  .pubkey-header {
     display: flex;
+    flex-direction: column;
     align-items: center;
-    gap: 16px;
+    text-align: center;
+    gap: 6px;
   }
 
-  .pubkey-display {
-    flex: 1;
-    min-width: 0;
+  .display-name {
+    margin: 10px 0 0;
+    font-size: 1.3rem;
+    font-weight: 700;
+    word-break: break-word;
+  }
+
+  .handle {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--color-text-muted);
     word-break: break-all;
   }
 
-  .npub-container {
+  .npub-section {
     display: flex;
     flex-direction: column;
-    gap: 5px;
-    margin-top: 5px;
+    align-items: center;
+    gap: 6px;
+    margin-top: 10px;
+    max-width: 100%;
   }
 
   .npub-wrapper {
@@ -115,6 +133,7 @@ function copyNpubToClipboard() {
     font-size: 0.9rem;
     color: var(--color-text-muted);
     margin: 0;
+    word-break: break-all;
   }
 
   .copied-message {
@@ -124,13 +143,7 @@ function copyNpubToClipboard() {
   }
 
   h3 {
-    margin-top: 0;
-    margin-bottom: 10px;
-  }
-
-  @media (max-width: 480px) {
-    .pubkey-header {
-      gap: 12px;
-    }
+    margin: 0;
+    font-size: 1rem;
   }
 </style>

--- a/examples/svelte-app/src/components/PublicKeyDisplay.svelte
+++ b/examples/svelte-app/src/components/PublicKeyDisplay.svelte
@@ -26,6 +26,9 @@ publicKey.subscribe((value) => {
       console.error('npub変換エラー:', error);
       npubAddress = 'Error: Could not convert to npub';
     }
+  } else {
+    // ログアウト等で公開鍵が無くなったら前ユーザの npub を残さない。
+    npubAddress = '';
   }
 });
 

--- a/examples/svelte-app/src/components/screens/AccountScreen.svelte
+++ b/examples/svelte-app/src/components/screens/AccountScreen.svelte
@@ -34,9 +34,7 @@ onMount(async () => {
 
   <CardSection title={$i18n.t.appWarning.title}>
     <ul>
-      <li>{$i18n.t.appWarning.demoDescription}</li>
       <li>{$i18n.t.appWarning.prfCompatibility}</li>
-      <li>{$i18n.t.appWarning.domainChange}</li>
     </ul>
   </CardSection>
 

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -28,8 +28,6 @@ export interface TranslationData {
   };
   appWarning: {
     title: string;
-    domainChange: string;
-    demoDescription: string;
     prfCompatibility: string;
   };
   auth: {
@@ -285,10 +283,6 @@ export const ja: TranslationData = {
   },
   appWarning: {
     title: '注意事項',
-    domainChange:
-      'パスキーは異なるドメインでは使用できないため、ドメインの異なるアプリで使用するにはこれまで通り秘密鍵のエクスポートが必要です。',
-    demoDescription:
-      'このアプリはパスキーのPRF拡張を用いたNostr鍵管理のUXのデモンストレーションです。そのためクライアントとしての機能は限定的です。',
     prfCompatibility:
       '一部の端末・環境ではPRF拡張が**まだ**サポートされていません。Windows HelloやFirefox（デフォルト設定）では利用できません。また、BitwardenなどのソフトウェアパスキーではPRF拡張が対応していない場合があります。',
   },
@@ -565,10 +559,6 @@ export const en: TranslationData = {
   },
   appWarning: {
     title: 'Important Notice',
-    domainChange:
-      'Passkeys cannot be used across different domains, so traditional private key export is still required to use with applications on different domains.',
-    demoDescription:
-      'This application is a UX demonstration of Nostr key management using Passkey PRF extension. Therefore, its functionality as a client is limited.',
     prfCompatibility:
       'PRF extension is not **yet** supported on some devices and environments. It is not available on Windows Hello or Firefox (default settings). Additionally, software passkeys like Bitwarden may not support PRF extension.',
   },

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -283,8 +283,7 @@ export const ja: TranslationData = {
   },
   appWarning: {
     title: '注意事項',
-    prfCompatibility:
-      '一部の端末・環境ではPRF拡張が**まだ**サポートされていません。Windows HelloやFirefox（デフォルト設定）では利用できません。また、BitwardenなどのソフトウェアパスキーではPRF拡張が対応していない場合があります。',
+    prfCompatibility: '一部の端末・環境はサポートされていません。',
   },
   auth: {
     title: 'Nosskey デモ',
@@ -559,8 +558,7 @@ export const en: TranslationData = {
   },
   appWarning: {
     title: 'Important Notice',
-    prfCompatibility:
-      'PRF extension is not **yet** supported on some devices and environments. It is not available on Windows Hello or Firefox (default settings). Additionally, software passkeys like Bitwarden may not support PRF extension.',
+    prfCompatibility: 'Some devices and environments are not supported.',
   },
   auth: {
     title: 'Nosskey Demo',

--- a/examples/svelte-app/src/services/kind0-test-utils.ts
+++ b/examples/svelte-app/src/services/kind0-test-utils.ts
@@ -1,0 +1,54 @@
+/**
+ * テスト用に schnorr 署名付きの kind:0 イベントを生成するヘルパー。
+ *
+ * profile-fetcher に署名検証が入ったため、固定の偽 `sig` を持つモックでは
+ * テストが通らない。`profile-fetcher.spec.ts` と `profile-store.spec.ts` から
+ * 共有して使う。
+ */
+
+import { schnorr } from '@noble/curves/secp256k1.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
+
+export const TEST_SK = new Uint8Array(32).fill(1);
+export const OTHER_SK = new Uint8Array(32).fill(2);
+
+export const TEST_PUBKEY = bytesToHex(schnorr.getPublicKey(TEST_SK));
+export const OTHER_PUBKEY = bytesToHex(schnorr.getPublicKey(OTHER_SK));
+
+export interface SignedKind0 {
+  id: string;
+  kind: number;
+  pubkey: string;
+  created_at: number;
+  content: string;
+  tags: string[][];
+  sig: string;
+}
+
+/**
+ * 与えた秘密鍵で署名した kind:0 イベントを返す。
+ * `content` がオブジェクトなら JSON 化、文字列ならそのまま `content` に使う
+ * （不正な JSON を `content` に持つ署名済みイベントもテストできる）。
+ */
+export function buildSignedKind0(
+  sk: Uint8Array,
+  content: object | string,
+  created_at: number
+): SignedKind0 {
+  const pubkey = bytesToHex(schnorr.getPublicKey(sk));
+  const tags: string[][] = [];
+  const contentStr = typeof content === 'string' ? content : JSON.stringify(content);
+  const serialized = JSON.stringify([0, pubkey, created_at, 0, tags, contentStr]);
+  const idBytes = sha256(new TextEncoder().encode(serialized));
+  const sig = bytesToHex(schnorr.sign(idBytes, sk));
+  return {
+    id: bytesToHex(idBytes),
+    kind: 0,
+    pubkey,
+    created_at,
+    content: contentStr,
+    tags,
+    sig,
+  };
+}

--- a/examples/svelte-app/src/services/profile-fetcher.spec.ts
+++ b/examples/svelte-app/src/services/profile-fetcher.spec.ts
@@ -144,6 +144,43 @@ describe('fetchKind0Profile', () => {
     expect(await promise).toBeNull();
   });
 
+  it('他者の鍵で署名されたなりすまし kind:0 は無視する', async () => {
+    const factory = freshFactory();
+    const promise = fetchKind0Profile(TEST_PUBKEY, ['wss://a'], {
+      wsFactory: factory,
+      timeoutMs: 1000,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    const ws = FakeWebSocket.instances[0];
+    const sub = JSON.parse(ws.sent[0])[1];
+    // 攻撃者が他者鍵(OTHER_SK)で署名したイベントの pubkey フィールドだけを
+    // 被害者(TEST_PUBKEY)にすり替えても、署名はその pubkey の id に対して
+    // 成立しないため署名検証で弾かれる（なりすまし耐性の核心ケース）。
+    const spoofed = buildSignedKind0(OTHER_SK, { picture: 'https://evil/x.png' }, 1000);
+    spoofed.pubkey = TEST_PUBKEY;
+    ws.emit(['EVENT', sub, spoofed]);
+    ws.emit(['EOSE', sub]);
+    expect(await promise).toBeNull();
+  });
+
+  it('sig が不正な hex の kind:0 は無視する', async () => {
+    const factory = freshFactory();
+    const promise = fetchKind0Profile(TEST_PUBKEY, ['wss://a'], {
+      wsFactory: factory,
+      timeoutMs: 1000,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    const ws = FakeWebSocket.instances[0];
+    const sub = JSON.parse(ws.sent[0])[1];
+    const evt = buildSignedKind0(TEST_SK, { picture: 'https://x/a.png' }, 1000);
+    // 不正な hex の sig は検証中の例外（hexToBytes）として握りつぶされ false になる。
+    ws.emit(['EVENT', sub, { ...evt, sig: 'not-hex' }]);
+    ws.emit(['EOSE', sub]);
+    expect(await promise).toBeNull();
+  });
+
   it('content が不正な JSON のイベントは無視する', async () => {
     const factory = freshFactory();
     const promise = fetchKind0Profile(TEST_PUBKEY, ['wss://a'], {

--- a/examples/svelte-app/src/services/profile-fetcher.spec.ts
+++ b/examples/svelte-app/src/services/profile-fetcher.spec.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OTHER_SK, TEST_PUBKEY, TEST_SK, buildSignedKind0 } from './kind0-test-utils.js';
 import { fetchKind0Profile } from './profile-fetcher.js';
 
 /**
@@ -53,31 +54,17 @@ afterEach(() => {
   FakeWebSocket.instances = [];
 });
 
-function buildKind0(pubkey: string, content: object, created_at: number) {
-  return {
-    id: 'fake',
-    kind: 0,
-    pubkey,
-    created_at,
-    content: JSON.stringify(content),
-    tags: [],
-    sig: '',
-  };
-}
-
-const PUBKEY = 'a'.repeat(64);
-
 describe('fetchKind0Profile', () => {
   it('relays が空なら null を返す（接続を試みない）', async () => {
     const factory = freshFactory();
-    const result = await fetchKind0Profile(PUBKEY, [], { wsFactory: factory });
+    const result = await fetchKind0Profile(TEST_PUBKEY, [], { wsFactory: factory });
     expect(result).toBeNull();
     expect(FakeWebSocket.instances.length).toBe(0);
   });
 
   it('EVENT→EOSE で picture を抽出して返す', async () => {
     const factory = freshFactory();
-    const promise = fetchKind0Profile(PUBKEY, ['wss://relay.example'], {
+    const promise = fetchKind0Profile(TEST_PUBKEY, ['wss://relay.example'], {
       wsFactory: factory,
       timeoutMs: 1000,
     });
@@ -92,7 +79,7 @@ describe('fetchKind0Profile', () => {
     ws.emit([
       'EVENT',
       subId,
-      buildKind0(PUBKEY, { picture: 'https://x/a.png', name: 'alice' }, 1000),
+      buildSignedKind0(TEST_SK, { picture: 'https://x/a.png', name: 'alice' }, 1000),
     ]);
     ws.emit(['EOSE', subId]);
     const result = await promise;
@@ -106,7 +93,7 @@ describe('fetchKind0Profile', () => {
 
   it('複数リレーで created_at の最新を採用する', async () => {
     const factory = freshFactory();
-    const promise = fetchKind0Profile(PUBKEY, ['wss://a', 'wss://b'], {
+    const promise = fetchKind0Profile(TEST_PUBKEY, ['wss://a', 'wss://b'], {
       wsFactory: factory,
       timeoutMs: 1000,
     });
@@ -115,9 +102,9 @@ describe('fetchKind0Profile', () => {
     const [wsA, wsB] = FakeWebSocket.instances;
     const subA = JSON.parse(wsA.sent[0])[1];
     const subB = JSON.parse(wsB.sent[0])[1];
-    wsA.emit(['EVENT', subA, buildKind0(PUBKEY, { picture: 'https://a/old.png' }, 100)]);
+    wsA.emit(['EVENT', subA, buildSignedKind0(TEST_SK, { picture: 'https://a/old.png' }, 100)]);
     wsA.emit(['EOSE', subA]);
-    wsB.emit(['EVENT', subB, buildKind0(PUBKEY, { picture: 'https://b/new.png' }, 200)]);
+    wsB.emit(['EVENT', subB, buildSignedKind0(TEST_SK, { picture: 'https://b/new.png' }, 200)]);
     wsB.emit(['EOSE', subB]);
     const result = await promise;
     expect(result?.picture).toBe('https://b/new.png');
@@ -126,7 +113,7 @@ describe('fetchKind0Profile', () => {
 
   it('期待しない pubkey の EVENT は無視する', async () => {
     const factory = freshFactory();
-    const promise = fetchKind0Profile(PUBKEY, ['wss://a'], {
+    const promise = fetchKind0Profile(TEST_PUBKEY, ['wss://a'], {
       wsFactory: factory,
       timeoutMs: 1000,
     });
@@ -134,14 +121,32 @@ describe('fetchKind0Profile', () => {
     await Promise.resolve();
     const ws = FakeWebSocket.instances[0];
     const sub = JSON.parse(ws.sent[0])[1];
-    ws.emit(['EVENT', sub, buildKind0('b'.repeat(64), { picture: 'https://evil/x' }, 999)]);
+    ws.emit(['EVENT', sub, buildSignedKind0(OTHER_SK, { picture: 'https://evil/x' }, 999)]);
+    ws.emit(['EOSE', sub]);
+    expect(await promise).toBeNull();
+  });
+
+  it('署名が一致しない EVENT は無視する', async () => {
+    const factory = freshFactory();
+    const promise = fetchKind0Profile(TEST_PUBKEY, ['wss://a'], {
+      wsFactory: factory,
+      timeoutMs: 1000,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    const ws = FakeWebSocket.instances[0];
+    const sub = JSON.parse(ws.sent[0])[1];
+    // 正しく署名したイベントの content を後から差し替えると sig が一致しなくなる。
+    const tampered = buildSignedKind0(TEST_SK, { picture: 'https://x/a.png' }, 1000);
+    tampered.content = JSON.stringify({ picture: 'https://evil/x.png' });
+    ws.emit(['EVENT', sub, tampered]);
     ws.emit(['EOSE', sub]);
     expect(await promise).toBeNull();
   });
 
   it('content が不正な JSON のイベントは無視する', async () => {
     const factory = freshFactory();
-    const promise = fetchKind0Profile(PUBKEY, ['wss://a'], {
+    const promise = fetchKind0Profile(TEST_PUBKEY, ['wss://a'], {
       wsFactory: factory,
       timeoutMs: 1000,
     });
@@ -149,7 +154,8 @@ describe('fetchKind0Profile', () => {
     await Promise.resolve();
     const ws = FakeWebSocket.instances[0];
     const sub = JSON.parse(ws.sent[0])[1];
-    ws.emit(['EVENT', sub, { kind: 0, pubkey: PUBKEY, created_at: 1, content: '{not-json' }]);
+    // content が不正な JSON でも署名自体は正しい（content 文字列全体に署名）。
+    ws.emit(['EVENT', sub, buildSignedKind0(TEST_SK, '{not-json', 1)]);
     ws.emit(['EOSE', sub]);
     expect(await promise).toBeNull();
   });
@@ -158,7 +164,7 @@ describe('fetchKind0Profile', () => {
     vi.useFakeTimers();
     try {
       const factory = freshFactory();
-      const promise = fetchKind0Profile(PUBKEY, ['wss://a'], {
+      const promise = fetchKind0Profile(TEST_PUBKEY, ['wss://a'], {
         wsFactory: factory,
         timeoutMs: 100,
       });
@@ -178,7 +184,7 @@ describe('fetchKind0Profile', () => {
       throw new Error('boom');
     };
     expect(
-      await fetchKind0Profile(PUBKEY, ['wss://a'], {
+      await fetchKind0Profile(TEST_PUBKEY, ['wss://a'], {
         wsFactory: factory,
         timeoutMs: 100,
       })
@@ -187,7 +193,7 @@ describe('fetchKind0Profile', () => {
 
   it('socket onerror が発火した場合は null を返してクローズする', async () => {
     const factory = freshFactory();
-    const promise = fetchKind0Profile(PUBKEY, ['wss://a'], {
+    const promise = fetchKind0Profile(TEST_PUBKEY, ['wss://a'], {
       wsFactory: factory,
       timeoutMs: 1000,
     });
@@ -201,7 +207,7 @@ describe('fetchKind0Profile', () => {
 
   it('全リレーが応答しないと null を返す（onclose 経由）', async () => {
     const factory = freshFactory();
-    const promise = fetchKind0Profile(PUBKEY, ['wss://a', 'wss://b'], {
+    const promise = fetchKind0Profile(TEST_PUBKEY, ['wss://a', 'wss://b'], {
       wsFactory: factory,
       timeoutMs: 1000,
     });

--- a/examples/svelte-app/src/services/profile-fetcher.ts
+++ b/examples/svelte-app/src/services/profile-fetcher.ts
@@ -8,7 +8,15 @@
  * 複数リレーに並列接続し、得られた EVENT のうち最も新しい (`created_at` 最大)
  * ものの `content` を JSON として解析して返す。タイムアウトと AbortSignal で
  * 必ず全 socket をクローズする。
+ *
+ * 受け取った kind:0 は `verifyEventSignature` で schnorr 署名を検証してから
+ * 採用する。検証しないと、悪意あるリレーが他人になりすました kind:0 を返した
+ * 場合にそれを画像・名前として表示してしまう。
  */
+
+import { schnorr } from '@noble/curves/secp256k1.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { hexToBytes } from '@noble/hashes/utils.js';
 
 export interface Kind0ProfileResult {
   picture?: string;
@@ -30,6 +38,8 @@ interface NostrEventLike {
   pubkey?: unknown;
   created_at?: unknown;
   content?: unknown;
+  tags?: unknown;
+  sig?: unknown;
 }
 
 const DEFAULT_TIMEOUT_MS = 5000;
@@ -152,6 +162,25 @@ function fetchFromOneRelay(
   });
 }
 
+/**
+ * Nostr イベントの schnorr 署名を検証する。NIP-01 のシリアライズ
+ * `[0, pubkey, created_at, kind, tags, content]` から event id を再計算し、
+ * `sig` がその id に対する `pubkey` の署名であることを確認する。
+ * 署名フィールドが無い・壊れている・検証に失敗した場合は false。
+ */
+function verifyEventSignature(e: NostrEventLike): boolean {
+  if (typeof e.sig !== 'string' || typeof e.pubkey !== 'string') return false;
+  if (typeof e.kind !== 'number' || typeof e.created_at !== 'number') return false;
+  if (typeof e.content !== 'string' || !Array.isArray(e.tags)) return false;
+  try {
+    const serialized = JSON.stringify([0, e.pubkey, e.created_at, e.kind, e.tags, e.content]);
+    const id = sha256(new TextEncoder().encode(serialized));
+    return schnorr.verify(hexToBytes(e.sig), id, hexToBytes(e.pubkey));
+  } catch {
+    return false;
+  }
+}
+
 function parseKind0Event(event: unknown, expectedPubkey: string): Kind0ProfileResult | null {
   if (!event || typeof event !== 'object') return null;
   const e = event as NostrEventLike;
@@ -159,6 +188,10 @@ function parseKind0Event(event: unknown, expectedPubkey: string): Kind0ProfileRe
   if (typeof e.pubkey !== 'string' || e.pubkey !== expectedPubkey) return null;
   if (typeof e.created_at !== 'number') return null;
   if (typeof e.content !== 'string') return null;
+  if (!verifyEventSignature(e)) {
+    console.warn('[nosskey] profile fetch: invalid kind:0 signature, dropping event');
+    return null;
+  }
   let metadata: unknown;
   try {
     metadata = JSON.parse(e.content);

--- a/examples/svelte-app/src/store/profile-store.spec.ts
+++ b/examples/svelte-app/src/store/profile-store.spec.ts
@@ -1,12 +1,17 @@
 // @vitest-environment happy-dom
 import { get } from 'svelte/store';
 import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  OTHER_PUBKEY,
+  OTHER_SK,
+  TEST_PUBKEY,
+  TEST_SK,
+  buildSignedKind0,
+} from '../services/kind0-test-utils.js';
 import { PROFILE_CACHE_KEY } from '../services/profile-cache.js';
 import { RELAYS_STORAGE_KEY } from '../services/relays-store.js';
 import { publicKey } from './app-state.js';
 import { clearCurrentProfile, currentProfile, loadProfileForPubkey } from './profile-store.js';
-
-const PUBKEY = 'a'.repeat(64);
 
 beforeEach(() => {
   publicKey.set(null);
@@ -17,7 +22,7 @@ beforeEach(() => {
 describe('loadProfileForPubkey', () => {
   it('リレー未設定なら fetch は呼ばれず loading=false で着地する', async () => {
     let called = false;
-    await loadProfileForPubkey(PUBKEY, {
+    await loadProfileForPubkey(TEST_PUBKEY, {
       relays: [],
       fetcherOptions: {
         wsFactory: () => {
@@ -34,7 +39,7 @@ describe('loadProfileForPubkey', () => {
     localStorage.setItem(
       PROFILE_CACHE_KEY,
       JSON.stringify({
-        [PUBKEY]: {
+        [TEST_PUBKEY]: {
           picture: 'https://cache.example/old.png',
           name: 'cached',
           updatedAt: 100,
@@ -46,7 +51,7 @@ describe('loadProfileForPubkey', () => {
       picture: 'https://new.example/new.png',
       created_at: 500,
     });
-    await loadProfileForPubkey(PUBKEY, {
+    await loadProfileForPubkey(TEST_PUBKEY, {
       relays: ['wss://r'],
       fetcherOptions: { wsFactory: fakeWs, timeoutMs: 1000 },
     });
@@ -57,7 +62,7 @@ describe('loadProfileForPubkey', () => {
 
   it('fetcher が null を返したら loading=false に降格する', async () => {
     const fakeWs = makeImmediateProfileFactory(null);
-    await loadProfileForPubkey(PUBKEY, {
+    await loadProfileForPubkey(TEST_PUBKEY, {
       relays: ['wss://r'],
       fetcherOptions: { wsFactory: fakeWs, timeoutMs: 1000 },
     });
@@ -69,7 +74,7 @@ describe('loadProfileForPubkey', () => {
       picture: 'http://example.com/x.png',
       created_at: 1,
     });
-    await loadProfileForPubkey(PUBKEY, {
+    await loadProfileForPubkey(TEST_PUBKEY, {
       relays: ['wss://r'],
       fetcherOptions: { wsFactory: fakeWs, timeoutMs: 1000 },
     });
@@ -89,7 +94,9 @@ describe('loadProfileForPubkey', () => {
       visited.push(url);
       return immediateProfileSocket(url, { picture: 'https://x/a.png', created_at: 10 });
     };
-    await loadProfileForPubkey(PUBKEY, { fetcherOptions: { wsFactory: fakeWs, timeoutMs: 1000 } });
+    await loadProfileForPubkey(TEST_PUBKEY, {
+      fetcherOptions: { wsFactory: fakeWs, timeoutMs: 1000 },
+    });
     expect(visited).toEqual(['wss://read']);
   });
 
@@ -103,7 +110,7 @@ describe('loadProfileForPubkey', () => {
     const factory = () => {
       throw new Error('boom');
     };
-    await loadProfileForPubkey(PUBKEY, {
+    await loadProfileForPubkey(TEST_PUBKEY, {
       relays: ['wss://r'],
       fetcherOptions: { wsFactory: factory, timeoutMs: 1000 },
     });
@@ -111,10 +118,9 @@ describe('loadProfileForPubkey', () => {
   });
 
   it('pubkey 切替で古い fetch の結果は破棄される', async () => {
-    const OTHER = 'b'.repeat(64);
     // 古い pubkey 向けの fetch をスタートし、応答前に新 pubkey でロードを掛ける
     let releaseOld: (() => void) | null = null;
-    const stallingFactory = (url: string) => {
+    const stallingFactory = (_url: string) => {
       const ws = {
         readyState: 0,
         onopen: null as (() => void) | null,
@@ -137,12 +143,7 @@ describe('loadProfileForPubkey', () => {
             data: JSON.stringify([
               'EVENT',
               'sub-old',
-              {
-                kind: 0,
-                pubkey: PUBKEY,
-                created_at: 1,
-                content: JSON.stringify({ picture: 'https://old.example/p.png' }),
-              },
+              buildSignedKind0(TEST_SK, { picture: 'https://old.example/p.png' }, 1),
             ]),
           });
         };
@@ -151,7 +152,7 @@ describe('loadProfileForPubkey', () => {
       return ws as any;
     };
 
-    const oldPromise = loadProfileForPubkey(PUBKEY, {
+    const oldPromise = loadProfileForPubkey(TEST_PUBKEY, {
       relays: ['wss://old'],
       fetcherOptions: { wsFactory: stallingFactory, timeoutMs: 500 },
     });
@@ -160,11 +161,11 @@ describe('loadProfileForPubkey', () => {
     await Promise.resolve();
 
     // 新 pubkey でリロード（即時 EOSE で settle する factory）
-    const newPromise = loadProfileForPubkey(OTHER, {
+    const newPromise = loadProfileForPubkey(OTHER_PUBKEY, {
       relays: ['wss://new'],
       fetcherOptions: {
         wsFactory: (url: string) =>
-          immediateProfileSocketForPubkey(url, OTHER, {
+          immediateProfileSocketForKey(url, OTHER_SK, {
             picture: 'https://new.example/p.png',
             created_at: 999,
           }),
@@ -182,9 +183,9 @@ describe('loadProfileForPubkey', () => {
   });
 });
 
-function immediateProfileSocketForPubkey(
+function immediateProfileSocketForKey(
   _url: string,
-  pubkey: string,
+  sk: Uint8Array,
   result: { picture?: string; created_at: number }
 ): WebSocket {
   type Listener = ((ev: { data: string }) => void) | (() => void) | null;
@@ -203,12 +204,7 @@ function immediateProfileSocketForPubkey(
           data: JSON.stringify([
             'EVENT',
             subId,
-            {
-              kind: 0,
-              pubkey,
-              created_at: result.created_at,
-              content: JSON.stringify({ picture: result.picture }),
-            },
+            buildSignedKind0(sk, { picture: result.picture }, result.created_at),
           ]),
         });
         this.onmessage?.({ data: JSON.stringify(['EOSE', subId]) });
@@ -250,15 +246,11 @@ function immediateProfileSocket(
             data: JSON.stringify([
               'EVENT',
               subId,
-              {
-                id: 'x',
-                kind: 0,
-                pubkey: PUBKEY,
-                created_at: result.created_at,
-                content: JSON.stringify({ picture: result.picture, name: result.name }),
-                tags: [],
-                sig: '',
-              },
+              buildSignedKind0(
+                TEST_SK,
+                { picture: result.picture, name: result.name },
+                result.created_at
+              ),
             ]),
           });
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,8 @@
     "examples/svelte-app": {
       "version": "0.0.0",
       "dependencies": {
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
         "bech32": "^2.0.0",
         "nosskey-iframe": "*",
         "nosskey-sdk": "*"


### PR DESCRIPTION
Verify schnorr signatures of fetched kind:0 events by recomputing the
NIP-01 event id, dropping events that fail verification so a malicious
relay cannot spoof another user's profile. Enlarge and center the
profile avatar, show the kind:0 display name, drop the hex pubkey in
favor of npub only, and trim the account-screen notice to the PRF
compatibility item.

https://claude.ai/code/session_018CG5w611YpwKLtMasdXCrN