### PR TITLE
improve sample app UI: sticky header, compact cards and buttons

### DIFF
--- a/examples/svelte-app/src/App.svelte
+++ b/examples/svelte-app/src/App.svelte
@@ -339,6 +339,7 @@ onMount(() => {
   .app-container {
     max-width: 800px;
     margin: 0 auto;
+    padding-top: 56px; /* 固定ヘッダーの高さ分の余白を追加 */
     padding-bottom: 64px; /* フッターの高さ分の余白を追加 */
   }
 

--- a/examples/svelte-app/src/components/HeaderBar.svelte
+++ b/examples/svelte-app/src/components/HeaderBar.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
-import { onMount } from 'svelte';
 import { i18n } from '../i18n/i18n-store.js';
 import { currentScreen } from '../store/app-state.js';
 
 // 現在の画面を監視
 let screen = $state('account');
-let isVisible = $state(false);
 
 currentScreen.subscribe((value) => {
   screen = value;
@@ -24,54 +22,9 @@ function getPageTitle(screenName: string): string {
       return 'Nosskey';
   }
 }
-
-// h1タイトルの可視性を監視
-onMount(() => {
-  const observer = new IntersectionObserver(
-    (entries) => {
-      for (const entry of entries) {
-        // h1が画面外に出た時にヘッダーバーを表示
-        isVisible = !entry.isIntersecting;
-      }
-    },
-    {
-      root: null,
-      rootMargin: '0px',
-      threshold: 0,
-    }
-  );
-
-  // 画面変更時にh1要素を再監視
-  const observeH1 = () => {
-    // 既存の監視を停止
-    observer.disconnect();
-
-    // 少し遅延してからh1を探す（DOM更新を待つ）
-    setTimeout(() => {
-      const h1Elements = document.querySelectorAll('.screen-title');
-      for (const h1 of h1Elements) {
-        observer.observe(h1);
-      }
-    }, 100);
-  };
-
-  // 初回監視開始
-  observeH1();
-
-  // 画面変更時に監視対象を更新
-  const unsubscribe = currentScreen.subscribe(() => {
-    observeH1();
-  });
-
-  // クリーンアップ
-  return () => {
-    observer.disconnect();
-    unsubscribe();
-  };
-});
 </script>
 
-<header class="header-bar" class:visible={isVisible}>
+<header class="header-bar">
   <div class="header-content">
     <div class="header-left">
       <h1 class="app-title">Nosskey</h1>
@@ -95,15 +48,9 @@ onMount(() => {
     box-shadow: 0 2px 10px var(--color-shadow);
     z-index: 100;
     border-bottom: 1px solid var(--color-border);
-    transform: translateY(-100%);
     transition:
-      transform 0.3s ease-in-out,
       background-color 0.3s ease,
       border-color 0.3s ease;
-  }
-
-  .header-bar.visible {
-    transform: translateY(0);
   }
 
   .header-content {

--- a/examples/svelte-app/src/components/screens/AccountScreen.svelte
+++ b/examples/svelte-app/src/components/screens/AccountScreen.svelte
@@ -30,12 +30,8 @@ onMount(async () => {
 </script>
 
 <div class="account-screen">
-  <h1 class="screen-title">{$i18n.t.navigation.account}</h1>
-
-  <CardSection title={$i18n.t.appWarning.title}>
-    <ul>
-      <li>{$i18n.t.appWarning.prfCompatibility}</li>
-    </ul>
+  <CardSection title={$i18n.t.appWarning.title} compact>
+    <p class="warning-text">{$i18n.t.appWarning.prfCompatibility}</p>
   </CardSection>
 
   {#if !login}
@@ -58,7 +54,9 @@ onMount(async () => {
     gap: 20px;
   }
 
-  h1 {
+  .warning-text {
+    font-size: 0.8rem;
+    color: var(--color-text-secondary);
     margin: 0;
   }
 

--- a/examples/svelte-app/src/components/screens/KeyManagement.svelte
+++ b/examples/svelte-app/src/components/screens/KeyManagement.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { i18n } from '../../i18n/i18n-store.js';
 import ExportKeyInfoComponent from '../settings/ExportKeyInfoComponent.svelte';
 import ExportSecretKey from '../settings/ExportSecretKey.svelte';
 import LocalStorageSection from '../settings/LocalStorageSection.svelte';
@@ -8,8 +7,6 @@ import SecretCacheSettings from '../settings/SecretCacheSettings.svelte';
 </script>
 
 <div class="settings-container">
-  <h1 class="screen-title">{$i18n.t.key.title}</h1>
-
   <SecretCacheSettings />
   <ExportKeyInfoComponent />
   <ExportSecretKey />
@@ -22,9 +19,5 @@ import SecretCacheSettings from '../settings/SecretCacheSettings.svelte';
     max-width: 700px;
     margin: 0 auto;
     padding: 20px;
-  }
-
-  h1 {
-    margin-bottom: 20px;
   }
 </style>

--- a/examples/svelte-app/src/components/screens/SettingsScreen.svelte
+++ b/examples/svelte-app/src/components/screens/SettingsScreen.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { i18n } from '../../i18n/i18n-store.js';
 import AppInfo from '../settings/AppInfo.svelte';
 import ConsentPolicySettings from '../settings/ConsentPolicySettings.svelte';
 import LanguageSettings from '../settings/LanguageSettings.svelte';
@@ -10,8 +9,6 @@ import ThemeSettings from '../settings/theme-settings.svelte';
 </script>
 
 <div class="settings-container">
-  <h1 class="screen-title">{$i18n.t.settings.title}</h1>
-
   <LanguageSettings />
   <ThemeSettings />
   <RelaySettings />
@@ -25,9 +22,5 @@ import ThemeSettings from '../settings/theme-settings.svelte';
     max-width: 700px;
     margin: 0 auto;
     padding: 20px;
-  }
-
-  h1 {
-    margin-bottom: 20px;
   }
 </style>

--- a/examples/svelte-app/src/components/settings/RelaySettings.svelte
+++ b/examples/svelte-app/src/components/settings/RelaySettings.svelte
@@ -89,6 +89,7 @@ function relayEntries(map: RelayMap): Array<[string, { read: boolean; write: boo
           <Button
             variant="danger"
             size="small"
+            fullWidth={false}
             onclick={() => removeRelay(url)}
           >
             {$i18n.t.settings.relays.removeButton}

--- a/examples/svelte-app/src/components/settings/TrustedOriginsSettings.svelte
+++ b/examples/svelte-app/src/components/settings/TrustedOriginsSettings.svelte
@@ -39,7 +39,12 @@ function methodLabel(method: PolicyKey): string {
         <li class="origin-item">
           <div class="origin-header">
             <code class="origin-url" title={entry.origin}>{entry.origin}</code>
-            <Button variant="danger" size="small" onclick={() => removeAll(entry.origin)}>
+            <Button
+              variant="danger"
+              size="small"
+              fullWidth={false}
+              onclick={() => removeAll(entry.origin)}
+            >
               {$i18n.t.settings.trustedOrigins.removeAllButton}
             </Button>
           </div>
@@ -50,6 +55,7 @@ function methodLabel(method: PolicyKey): string {
                 <Button
                   variant="secondary"
                   size="small"
+                  fullWidth={false}
                   onclick={() => removeMethod(entry.origin, method)}
                 >
                   {$i18n.t.settings.trustedOrigins.removeButton}

--- a/examples/svelte-app/src/components/ui/CardSection.svelte
+++ b/examples/svelte-app/src/components/ui/CardSection.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
+import type { Snippet } from 'svelte';
+
 // 共通のカードセクションコンポーネント
-export let title: string;
+interface Props {
+  title: string;
+  compact?: boolean;
+  children?: Snippet;
+}
+
+const { title, compact = false, children }: Props = $props();
 </script>
 
-<div class="card-section">
+<div class="card-section" class:compact>
   <h2>{title}</h2>
-  <slot />
+  {@render children?.()}
 </div>
 
 <style>
@@ -27,10 +35,26 @@ export let title: string;
     }
   }
 
+  .card-section.compact {
+    padding: 12px 16px;
+    margin-bottom: 16px;
+  }
+
+  @media (max-width: 900px) {
+    .card-section.compact {
+      padding: 12px;
+    }
+  }
+
   h2 {
     margin-bottom: 15px;
     color: var(--color-titles);
     text-align: left;
     transition: color 0.3s ease;
+  }
+
+  .card-section.compact h2 {
+    font-size: 0.95rem;
+    margin-bottom: 8px;
   }
 </style>

--- a/examples/svelte-app/src/components/ui/button/Button.svelte
+++ b/examples/svelte-app/src/components/ui/button/Button.svelte
@@ -6,6 +6,7 @@ const {
   disabled = false,
   size = 'medium' as ButtonSize,
   variant = 'primary' as ButtonVariant,
+  fullWidth = true,
   onclick = undefined,
   buttonType = 'button' as 'button' | 'submit' | 'reset',
   title = undefined,
@@ -24,7 +25,7 @@ function handleClick() {
   type={buttonType as "button" | "submit" | "reset"}
   {disabled}
   {title}
-  class={`btn btn-${variant} btn-${size} ${className}`}
+  class={`btn btn-${variant} btn-${size} ${fullWidth ? '' : 'btn-auto-width'} ${className}`}
   onclick={handleClick}
 >
   {@render children?.()}
@@ -55,6 +56,11 @@ function handleClick() {
   .btn:disabled {
     cursor: not-allowed;
     opacity: 0.6;
+  }
+
+  .btn-auto-width {
+    width: auto;
+    max-width: none;
   }
 
   /* Primary Button */

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -402,9 +402,9 @@ export const ja: TranslationData = {
     theme: {
       title: 'テーマ設定',
       description: 'アプリケーションの外観を変更できます。',
-      light: 'ライトモード',
-      dark: 'ダークモード',
-      auto: 'システム設定に従う',
+      light: 'ライト',
+      dark: 'ダーク',
+      auto: '自動',
       changed: 'テーマを変更しました',
     },
     relays: {
@@ -677,9 +677,9 @@ export const en: TranslationData = {
     theme: {
       title: 'Theme Settings',
       description: 'Change the appearance of the application.',
-      light: 'Light Mode',
-      dark: 'Dark Mode',
-      auto: 'Follow System Setting',
+      light: 'Light',
+      dark: 'Dark',
+      auto: 'Auto',
       changed: 'Theme changed',
     },
     relays: {


### PR DESCRIPTION
- HeaderBar を常時表示にし、各画面の冗長な h1 見出しを削除
- アカウント画面の「注意事項」をコンパクトカード・小さい文字に変更
- 設定画面の削除系ボタンを内容幅に（Button に fullWidth prop 追加）
- テーマ設定の選択肢ラベルを簡潔化（自動/ライト/ダーク, Auto/Light/Dark）

https://claude.ai/code/session_011YT4ah61o4khPQ1pw7hCWL