### PR TITLE
improve sample app UX: unify settings feedback and card styling

### DIFF
--- a/examples/svelte-app/src/components/screens/AccountScreen.svelte
+++ b/examples/svelte-app/src/components/screens/AccountScreen.svelte
@@ -4,7 +4,6 @@ import { i18n } from '../../i18n/i18n-store.js';
 import { getNosskeyManager } from '../../services/nosskey-manager.service.js';
 import { isLoggedIn, publicKey } from '../../store/app-state.js';
 import PublicKeyDisplay from '../PublicKeyDisplay.svelte';
-import CardSection from '../ui/CardSection.svelte';
 import AuthScreen from './AuthScreen.svelte';
 
 const login = $derived($isLoggedIn);
@@ -30,9 +29,10 @@ onMount(async () => {
 </script>
 
 <div class="account-screen">
-  <CardSection title={$i18n.t.appWarning.title} compact>
-    <p class="warning-text">{$i18n.t.appWarning.prfCompatibility}</p>
-  </CardSection>
+  <div class="warning-bar" role="note">
+    <strong class="warning-bar__title">{$i18n.t.appWarning.title}</strong>
+    <span class="warning-bar__text">{$i18n.t.appWarning.prfCompatibility}</span>
+  </div>
 
   {#if !login}
     <AuthScreen />
@@ -54,10 +54,27 @@ onMount(async () => {
     gap: 20px;
   }
 
-  .warning-text {
+  .warning-bar {
+    background-color: var(--color-warning-bg);
+    border: 1px solid var(--color-warning-border);
+    border-left: 4px solid var(--color-warning);
+    border-radius: 8px;
+    padding: 10px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
     font-size: 0.8rem;
-    color: var(--color-text-secondary);
-    margin: 0;
+    transition:
+      background-color 0.3s ease,
+      border-color 0.3s ease;
+  }
+
+  .warning-bar__title {
+    color: var(--color-warning);
+  }
+
+  .warning-bar__text {
+    color: var(--color-text);
   }
 
   .account-info {

--- a/examples/svelte-app/src/components/screens/SettingsScreen.svelte
+++ b/examples/svelte-app/src/components/screens/SettingsScreen.svelte
@@ -9,11 +9,11 @@ import ThemeSettings from '../settings/theme-settings.svelte';
 </script>
 
 <div class="settings-container">
-  <LanguageSettings />
-  <ThemeSettings />
   <RelaySettings />
   <ConsentPolicySettings />
   <TrustedOriginsSettings />
+  <LanguageSettings />
+  <ThemeSettings />
   <AppInfo />
 </div>
 

--- a/examples/svelte-app/src/components/settings/ConsentPolicySettings.svelte
+++ b/examples/svelte-app/src/components/settings/ConsentPolicySettings.svelte
@@ -11,6 +11,7 @@ import {
   storageCorruption,
 } from '../../store/app-state.js';
 import CardSection from '../ui/CardSection.svelte';
+import SettingMessage from '../ui/SettingMessage.svelte';
 import Button from '../ui/button/Button.svelte';
 
 const OPTIONS: ConsentDecision[] = ['ask', 'always', 'deny'];
@@ -81,9 +82,7 @@ function optionLabel(option: ConsentDecision): string {
     </div>
   {/if}
 
-  {#if savedMessage}
-    <div class="saved-message" aria-live="polite">{savedMessage}</div>
-  {/if}
+  <SettingMessage message={savedMessage} />
 </CardSection>
 
 <style>
@@ -150,15 +149,5 @@ function optionLabel(option: ConsentDecision): string {
     margin-top: 12px;
     display: flex;
     justify-content: flex-end;
-  }
-
-  .saved-message {
-    margin-top: 12px;
-    padding: 8px 12px;
-    background-color: var(--color-success-bg);
-    border: 1px solid var(--color-success-border);
-    border-radius: 8px;
-    color: var(--color-success);
-    font-size: 0.9rem;
   }
 </style>

--- a/examples/svelte-app/src/components/settings/LanguageSettings.svelte
+++ b/examples/svelte-app/src/components/settings/LanguageSettings.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { changeLanguage, i18n } from '../../i18n/i18n-store.js';
 import CardSection from '../ui/CardSection.svelte';
+import SettingMessage from '../ui/SettingMessage.svelte';
 
 // 状態変数
 let languageMessage = $state('');
@@ -41,11 +42,7 @@ function updateLanguage(lang: 'ja' | 'en') {
       </label>
     </div>
 
-    {#if languageMessage}
-      <div class="result-message">
-        {languageMessage}
-      </div>
-    {/if}
+    <SettingMessage message={languageMessage} />
   </div>
 </CardSection>
 
@@ -75,19 +72,5 @@ function updateLanguage(lang: 'ja' | 'en') {
 
   .radio-group input[type="radio"] {
     margin-right: 10px;
-  }
-
-  .result-message {
-    margin-top: 15px;
-    padding: 10px;
-    background-color: var(--color-success-bg);
-    border: 1px solid var(--color-success-border);
-    border-radius: 8px;
-    font-weight: bold;
-    color: var(--color-success);
-    transition:
-      background-color 0.3s ease,
-      border-color 0.3s ease,
-      color 0.3s ease;
   }
 </style>

--- a/examples/svelte-app/src/components/settings/SecretCacheSettings.svelte
+++ b/examples/svelte-app/src/components/settings/SecretCacheSettings.svelte
@@ -8,6 +8,7 @@ import Button from '../ui/button/Button.svelte';
 
 // 状態変数
 let cacheSettingMessage = $state('');
+let cacheMessageType = $state<'success' | 'error'>('success');
 let isCaching = $state(true);
 let timeoutSeconds = $state(300); // デフォルト5分（300秒）
 
@@ -28,6 +29,7 @@ function updateCacheSetting(value: boolean) {
   // storeを更新（keyManager.serviceがサブスクライブして自動的に反映）
   cacheSecrets.set(value);
 
+  cacheMessageType = 'success';
   cacheSettingMessage = $i18n.t.settings.cacheSettings.saved;
   setTimeout(() => {
     cacheSettingMessage = '';
@@ -43,6 +45,7 @@ function updateTimeoutSetting(event: Event) {
     timeoutSeconds = value;
     cacheTimeout.set(value); // keyManager.serviceがサブスクライブして自動的に反映
 
+    cacheMessageType = 'success';
     cacheSettingMessage = $i18n.t.settings.cacheSettings.saved;
     setTimeout(() => {
       cacheSettingMessage = '';
@@ -55,8 +58,10 @@ function clearCache() {
   const success = clearSecretCache();
 
   if (success) {
+    cacheMessageType = 'success';
     cacheSettingMessage = $i18n.t.settings.cacheSettings.clearSuccess;
   } else {
+    cacheMessageType = 'error';
     cacheSettingMessage = $i18n.t.settings.cacheSettings.clearError;
   }
 
@@ -120,7 +125,7 @@ function clearCache() {
       </Button>
     </div>
 
-    <SettingMessage message={cacheSettingMessage} />
+    <SettingMessage message={cacheSettingMessage} type={cacheMessageType} />
   </div>
 </CardSection>
 

--- a/examples/svelte-app/src/components/settings/SecretCacheSettings.svelte
+++ b/examples/svelte-app/src/components/settings/SecretCacheSettings.svelte
@@ -3,6 +3,7 @@ import { i18n } from '../../i18n/i18n-store.js';
 import { clearSecretCache, getNosskeyManager } from '../../services/nosskey-manager.service.js';
 import { cacheSecrets, cacheTimeout } from '../../store/secret-cache-settings.js';
 import CardSection from '../ui/CardSection.svelte';
+import SettingMessage from '../ui/SettingMessage.svelte';
 import Button from '../ui/button/Button.svelte';
 
 // 状態変数
@@ -119,11 +120,7 @@ function clearCache() {
       </Button>
     </div>
 
-    {#if cacheSettingMessage}
-      <div class="result-message">
-        {cacheSettingMessage}
-      </div>
-    {/if}
+    <SettingMessage message={cacheSettingMessage} />
   </div>
 </CardSection>
 
@@ -177,19 +174,5 @@ function clearCache() {
 
   .cache-clear {
     margin-top: 20px;
-  }
-
-  .result-message {
-    margin-top: 15px;
-    padding: 10px;
-    background-color: var(--color-success-bg);
-    border: 1px solid var(--color-success-border);
-    border-radius: 8px;
-    font-weight: bold;
-    color: var(--color-success);
-    transition:
-      background-color 0.3s ease,
-      border-color 0.3s ease,
-      color 0.3s ease;
   }
 </style>

--- a/examples/svelte-app/src/components/settings/theme-settings.svelte
+++ b/examples/svelte-app/src/components/settings/theme-settings.svelte
@@ -2,8 +2,10 @@
 import { i18n } from '../../i18n/i18n-store.js';
 import { type ThemeMode, currentTheme } from '../../store/app-state.js';
 import CardSection from '../ui/CardSection.svelte';
+import SettingMessage from '../ui/SettingMessage.svelte';
 
 let selectedTheme: ThemeMode = 'auto';
+let themeMessage = $state('');
 
 // 現在の設定を読み込み
 currentTheme.subscribe((value) => {
@@ -16,29 +18,9 @@ const handleThemeChange = (event: Event) => {
   selectedTheme = newTheme;
   currentTheme.set(newTheme);
 
-  // テーマ変更のフィードバック
-  const message = document.createElement('div');
-  message.textContent = $i18n.t.settings.theme.changed;
-  message.style.cssText = `
-      position: fixed;
-      top: 20px;
-      right: 20px;
-      background: var(--color-primary);
-      color: var(--color-text-on-primary);
-      padding: 12px 20px;
-      border-radius: 8px;
-      font-size: 14px;
-      font-weight: 500;
-      z-index: 1000;
-      box-shadow: 0 4px 12px var(--color-shadow-strong);
-      animation: fadeInOut 3s ease-in-out;
-    `;
-
-  document.body.appendChild(message);
+  themeMessage = $i18n.t.settings.theme.changed;
   setTimeout(() => {
-    if (message.parentNode) {
-      message.parentNode.removeChild(message);
-    }
+    themeMessage = '';
   }, 3000);
 };
 </script>
@@ -59,6 +41,8 @@ const handleThemeChange = (event: Event) => {
       <option value="dark">{$i18n.t.settings.theme.dark}</option>
     </select>
   </div>
+
+  <SettingMessage message={themeMessage} />
 </CardSection>
 
 <style>

--- a/examples/svelte-app/src/components/ui/CardSection.svelte
+++ b/examples/svelte-app/src/components/ui/CardSection.svelte
@@ -19,7 +19,7 @@ const { title, compact = false, children }: Props = $props();
 <style>
   .card-section {
     background-color: var(--color-card);
-    padding: 20px 60px;
+    padding: 12px 60px;
     border-radius: 12px;
     border: 1px solid var(--color-border);
     box-shadow: 0 2px 4px var(--color-shadow);
@@ -31,7 +31,7 @@ const { title, compact = false, children }: Props = $props();
 
   @media (max-width: 900px) {
     .card-section {
-      padding: 20px;
+      padding: 12px 20px;
     }
   }
 
@@ -47,14 +47,17 @@ const { title, compact = false, children }: Props = $props();
   }
 
   h2 {
-    margin-bottom: 15px;
-    color: var(--color-titles);
+    margin-bottom: 10px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--color-text-secondary);
     text-align: left;
     transition: color 0.3s ease;
   }
 
   .card-section.compact h2 {
-    font-size: 0.95rem;
     margin-bottom: 8px;
   }
 </style>

--- a/examples/svelte-app/src/components/ui/SettingMessage.svelte
+++ b/examples/svelte-app/src/components/ui/SettingMessage.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+// 設定変更時のフィードバックメッセージ（コントロール直下に表示）
+interface Props {
+  message: string;
+}
+
+const { message }: Props = $props();
+</script>
+
+{#if message}
+  <div class="setting-message" aria-live="polite">
+    {message}
+  </div>
+{/if}
+
+<style>
+  .setting-message {
+    margin-top: 12px;
+    padding: 10px 12px;
+    background-color: var(--color-success-bg);
+    border: 1px solid var(--color-success-border);
+    border-radius: 8px;
+    color: var(--color-success);
+    font-size: 0.9rem;
+    transition:
+      background-color 0.3s ease,
+      border-color 0.3s ease,
+      color 0.3s ease;
+  }
+</style>

--- a/examples/svelte-app/src/components/ui/SettingMessage.svelte
+++ b/examples/svelte-app/src/components/ui/SettingMessage.svelte
@@ -2,13 +2,14 @@
 // 設定変更時のフィードバックメッセージ（コントロール直下に表示）
 interface Props {
   message: string;
+  type?: 'success' | 'error';
 }
 
-const { message }: Props = $props();
+const { message, type = 'success' }: Props = $props();
 </script>
 
 {#if message}
-  <div class="setting-message" aria-live="polite">
+  <div class="setting-message" class:error={type === 'error'} aria-live="polite">
     {message}
   </div>
 {/if}
@@ -26,5 +27,11 @@ const { message }: Props = $props();
       background-color 0.3s ease,
       border-color 0.3s ease,
       color 0.3s ease;
+  }
+
+  .setting-message.error {
+    background-color: var(--color-warning-bg);
+    border-color: var(--color-warning-border);
+    color: var(--color-warning);
   }
 </style>

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -424,8 +424,8 @@ export const ja: TranslationData = {
       description:
         '同意ダイアログで「このサイトを常に許可」を選んだサイトとメソッドの一覧です。許可はメソッドごとに記録され、他のメソッドは別途確認されます。削除すると次回から再度確認が表示されます。',
       empty: '信頼済みサイトはまだありません。',
-      removeButton: 'このメソッドを削除',
-      removeAllButton: 'すべて削除',
+      removeButton: '削除',
+      removeAllButton: '削除',
       confirmRemove: 'このメソッドの自動許可を解除しますか？',
       confirmRemoveAll: 'このサイトの自動許可をすべて解除しますか？',
     },
@@ -699,8 +699,8 @@ export const en: TranslationData = {
       description:
         'Sites and methods you marked as "always allow" in the consent dialog. Trust is recorded per method; other methods are confirmed separately. Removing an entry will make the dialog reappear on the next request.',
       empty: 'No trusted sites yet.',
-      removeButton: 'Remove this method',
-      removeAllButton: 'Remove all',
+      removeButton: 'Remove',
+      removeAllButton: 'Remove',
       confirmRemove: 'Remove auto-approval for this method?',
       confirmRemoveAll: 'Remove auto-approval for this site entirely?',
     },


### PR DESCRIPTION
- Replace theme settings' floating toast with an inline message shown
  directly below the control, via a shared SettingMessage component used
  by language, theme, consent policy and cache settings
- Move language and theme sections below trusted sites in the settings screen
- Reduce CardSection vertical padding and restyle card titles as
  low-contrast monospace labels
- Render the account screen warning as an orange bar instead of a card
- Shorten trusted sites delete button labels to just "削除" / "Remove"

https://claude.ai/code/session_01USkho3LigJDAGQKU6rLo3d