### PR TITLE
feat(parent-sample): accept npub format in peer public key inputs

### DIFF
--- a/examples/parent-sample/index.html
+++ b/examples/parent-sample/index.html
@@ -78,9 +78,9 @@
           from this iframe — both encrypt and decrypt will use the same key,
           so you can verify the round trip without a second account.
         </p>
-        <label for="nip44-peer">Peer public key (hex, 64 chars)</label>
+        <label for="nip44-peer">Peer public key (hex or npub)</label>
         <div class="row">
-          <input id="nip44-peer" type="text" placeholder="64 hex characters" />
+          <input id="nip44-peer" type="text" placeholder="64 hex characters or npub1…" />
           <button id="nip44-use-self" class="secondary" disabled>Use my pubkey</button>
         </div>
         <label for="nip44-plaintext" style="margin-top:12px;">Plaintext</label>
@@ -102,9 +102,9 @@
           spec itself. Use NIP-44 for new messages. This section is provided
           only to verify interop with older clients.
         </p>
-        <label for="nip04-peer">Peer public key (hex, 64 chars)</label>
+        <label for="nip04-peer">Peer public key (hex or npub)</label>
         <div class="row">
-          <input id="nip04-peer" type="text" placeholder="64 hex characters" />
+          <input id="nip04-peer" type="text" placeholder="64 hex characters or npub1…" />
           <button id="nip04-use-self" class="secondary" disabled>Use my pubkey</button>
         </div>
         <label for="nip04-plaintext" style="margin-top:12px;">Plaintext</label>
@@ -138,9 +138,9 @@
           Two consent dialogs appear (NIP-44 encrypt for the seal, then sign
           kind:13). The Relay URL is shared with section 4.
         </p>
-        <label for="nip17-peer">Peer public key (hex, 64 chars)</label>
+        <label for="nip17-peer">Peer public key (hex or npub)</label>
         <div class="row">
-          <input id="nip17-peer" type="text" placeholder="64 hex characters" />
+          <input id="nip17-peer" type="text" placeholder="64 hex characters or npub1…" />
           <button id="nip17-use-self" class="secondary" disabled>Use my pubkey</button>
         </div>
         <label for="nip17-plaintext" style="margin-top:12px;">Message</label>

--- a/examples/parent-sample/src/validation.spec.ts
+++ b/examples/parent-sample/src/validation.spec.ts
@@ -15,11 +15,20 @@ describe('parsePeerPubkey', () => {
     expect(parsePeerPubkey(`  ${hex}  `)).toEqual({ ok: true, value: hex });
   });
 
-  it('does not validate the pubkey format (matches current behavior)', () => {
-    // Intentional: the existing sample does not pre-validate the pubkey shape —
-    // a malformed key surfaces as an error from the iframe instead. This test
-    // pins that behavior.
-    expect(parsePeerPubkey('npub1example')).toEqual({ ok: true, value: 'npub1example' });
+  it('accepts a valid npub and converts it to hex', () => {
+    // NIP-19 test vector from the spec
+    const npub = 'npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6';
+    const hex = '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+    expect(parsePeerPubkey(npub)).toEqual({ ok: true, value: hex });
+  });
+
+  it('rejects an npub-prefixed string that is not a valid npub', () => {
+    expect(parsePeerPubkey('npub1example')).toEqual({ ok: false, reason: 'invalid npub format' });
+  });
+
+  it('accepts a non-npub non-empty value as-is (no format validation)', () => {
+    // Non-npub inputs pass through unchanged; format errors surface from the iframe.
+    expect(parsePeerPubkey('notanpub')).toEqual({ ok: true, value: 'notanpub' });
   });
 });
 

--- a/examples/parent-sample/src/validation.spec.ts
+++ b/examples/parent-sample/src/validation.spec.ts
@@ -22,8 +22,28 @@ describe('parsePeerPubkey', () => {
     expect(parsePeerPubkey(npub)).toEqual({ ok: true, value: hex });
   });
 
-  it('rejects an npub-prefixed string that is not a valid npub', () => {
+  it('accepts an uppercase NPUB and converts it to hex', () => {
+    const npub = 'NPUB180CVV07TJDRRGPA0J7J7TMNYL2YR6YR7L8J4S3EVF6U64TH6GKWSYJH6W6';
+    const hex = '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+    expect(parsePeerPubkey(npub)).toEqual({ ok: true, value: hex });
+  });
+
+  it('rejects an npub-prefixed string that is too short to be a valid npub', () => {
     expect(parsePeerPubkey('npub1example')).toEqual({ ok: false, reason: 'invalid npub format' });
+  });
+
+  it('rejects an npub containing characters outside the bech32 charset', () => {
+    // 'b', 'i', 'o' are not in the bech32 charset
+    const badChar = `npub1${'b'.repeat(58)}`;
+    expect(parsePeerPubkey(badChar)).toEqual({ ok: false, reason: 'invalid npub format' });
+  });
+
+  it('rejects an npub whose last data symbol encodes non-zero padding bits', () => {
+    // The valid last DATA symbol is 's' (=16=0b10000, lower 4 padding bits = 0).
+    // Replacing it with 'l' (=31=0b11111, lower 4 bits = 0b1111 ≠ 0) must be rejected.
+    // Note: last 6 chars are the checksum — the tampered symbol is at position 56.
+    const tampered = 'npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwlyjh6w6';
+    expect(parsePeerPubkey(tampered)).toEqual({ ok: false, reason: 'invalid npub format' });
   });
 
   it('accepts a non-npub non-empty value as-is (no format validation)', () => {

--- a/examples/parent-sample/src/validation.ts
+++ b/examples/parent-sample/src/validation.ts
@@ -6,9 +6,49 @@
 
 export type ParseResult<T> = { ok: true; value: T } | { ok: false; reason: string };
 
+const BECH32_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+
+function npubToHex(npub: string): string | null {
+  try {
+    const lower = npub.toLowerCase();
+    const sep = lower.lastIndexOf('1');
+    if (sep < 0 || lower.slice(0, sep) !== 'npub') return null;
+    // data portion: everything after the separator, minus the 6-char checksum
+    const dataStr = lower.slice(sep + 1, lower.length - 6);
+    if (dataStr.length === 0) return null;
+    const data5: number[] = [];
+    for (const ch of dataStr) {
+      const idx = BECH32_CHARSET.indexOf(ch);
+      if (idx === -1) return null;
+      data5.push(idx);
+    }
+    // convert 5-bit groups to 8-bit bytes
+    let acc = 0;
+    let bits = 0;
+    const bytes: number[] = [];
+    for (const val of data5) {
+      acc = (acc << 5) | val;
+      bits += 5;
+      while (bits >= 8) {
+        bits -= 8;
+        bytes.push((acc >> bits) & 0xff);
+      }
+    }
+    if (bytes.length !== 32) return null;
+    return bytes.map((b) => b.toString(16).padStart(2, '0')).join('');
+  } catch {
+    return null;
+  }
+}
+
 export function parsePeerPubkey(raw: string): ParseResult<string> {
   const trimmed = raw.trim();
   if (!trimmed) return { ok: false, reason: 'peer pubkey is empty' };
+  if (trimmed.toLowerCase().startsWith('npub1')) {
+    const hex = npubToHex(trimmed);
+    if (!hex) return { ok: false, reason: 'invalid npub format' };
+    return { ok: true, value: hex };
+  }
   return { ok: true, value: trimmed };
 }
 

--- a/examples/parent-sample/src/validation.ts
+++ b/examples/parent-sample/src/validation.ts
@@ -8,6 +8,12 @@ export type ParseResult<T> = { ok: true; value: T } | { ok: false; reason: strin
 
 const BECH32_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
 
+/**
+ * Decodes an npub bech32 string to a 64-character lowercase hex pubkey.
+ * Checksum is not verified (acceptable for a sample app); padding bits are
+ * validated to reject npub strings that differ only in their trailing symbol.
+ * Returns null for any malformed input.
+ */
 function npubToHex(npub: string): string | null {
   try {
     const lower = npub.toLowerCase();
@@ -34,6 +40,8 @@ function npubToHex(npub: string): string | null {
         bytes.push((acc >> bits) & 0xff);
       }
     }
+    // leftover padding bits must be zero per bech32 spec
+    if (bits > 0 && (acc & ((1 << bits) - 1)) !== 0) return null;
     if (bytes.length !== 32) return null;
     return bytes.map((b) => b.toString(16).padStart(2, '0')).join('');
   } catch {


### PR DESCRIPTION
parsePeerPubkey now detects the npub1 prefix and converts it to hex
using an inline bech32 decoder, so users can paste npub addresses
directly into the NIP-44/04/17 peer pubkey fields.

https://claude.ai/code/session_01K68r1G5kWuogxYFMCTVAEs