### PR TITLE
feat(svelte-app): split auth screen into login/register tabs and add help tooltips

### DIFF
--- a/examples/svelte-app/src/components/screens/AuthScreen.svelte
+++ b/examples/svelte-app/src/components/screens/AuthScreen.svelte
@@ -5,49 +5,30 @@ import { i18n } from '../../i18n/i18n-store.js';
 import { getNosskeyManager } from '../../services/nosskey-manager.service.js';
 import * as appState from '../../store/app-state.js';
 import CardSection from '../ui/CardSection.svelte';
+import HelpTip from '../ui/HelpTip.svelte';
 import Button from '../ui/button/Button.svelte';
-import FileInputButton from '../ui/button/FileInputButton.svelte';
-import ToggleButton from '../ui/button/ToggleButton.svelte';
+import TabButton from '../ui/button/TabButton.svelte';
 
-// 状態変数
-let isSupported = $state(false);
+type AuthTab = 'login' | 'register';
+
 let isLoading = $state(false);
 let errorMessage = $state('');
-let isPrfChecked = $state(false);
 // biome-ignore lint: svelte
 let username = $state('');
-let createdCredentialId = $state(''); // 新規作成したパスキーのID
-let isPasskeyCreated = $state(false); // パスキーが作成済みかどうか
+let createdCredentialId = $state('');
+let isPasskeyCreated = $state(false);
+let activeTab = $state<AuthTab>('login');
 
-// UI表示制御
-// biome-ignore lint: svelte
-let showAdvancedOptions = $state(false);
-// biome-ignore lint: svelte
-let showDeveloperSection = $state(false);
-// biome-ignore lint: svelte
-let showKeyInfoTextarea = $state(false);
-
-// KeyInfoインポート関連の状態変数
-// biome-ignore lint: svelte
-let keyInfoTextInput = $state('');
-let keyInfoImportError = $state('');
-
-// NosskeyManagerのシングルトンインスタンスを取得
 const keyManager = getNosskeyManager();
 
-// 初期化関数
 async function initialize() {
   isLoading = true;
   try {
-    // 鍵情報が存在するか確認
     if (keyManager.hasKeyInfo()) {
-      // 公開鍵を取得して状態を更新
       const pubKey = await keyManager.getPublicKey();
       appState.publicKey.set(pubKey);
       appState.isLoggedIn.set(true);
-
-      // PRF拡張対応確認をスキップして認証済み状態に
-      return; // 初期化処理を終了
+      return;
     }
   } catch (error) {
     console.error('初期化エラー:', error);
@@ -57,29 +38,11 @@ async function initialize() {
   }
 }
 
-// PRF対応確認
-async function checkPrfSupport() {
-  isLoading = true;
-  errorMessage = '';
-  try {
-    // PRF拡張がサポートされているか確認
-    isSupported = await keyManager.isPrfSupported();
-    isPrfChecked = true;
-  } catch (error) {
-    console.error('PRF対応確認エラー:', error);
-    errorMessage = `${$i18n.t.common.errorMessages.prfCheck} ${error instanceof Error ? error.message : String(error)}`;
-  } finally {
-    isLoading = false;
-  }
-}
-
-// 新規パスキー作成
 async function createNew() {
   isLoading = true;
   errorMessage = '';
 
   try {
-    // 新しいパスキーを作成
     const newCredentialId = await keyManager.createPasskey({
       user: {
         name: username || 'user@nosskey',
@@ -97,24 +60,21 @@ async function createNew() {
   }
 }
 
-// 特定のcredentialIdでログイン
-async function login(credentialId: string) {
+async function login(credentialId?: string) {
   isLoading = true;
   errorMessage = '';
 
   try {
-    // PRFを直接Nostrキーとして使用
-    const keyInfo = await keyManager.createNostrKey(hexToBytes(credentialId));
+    const keyInfo = credentialId
+      ? await keyManager.createNostrKey(hexToBytes(credentialId))
+      : await keyManager.createNostrKey();
 
-    // SDKにKeyInfoを設定（内部でストレージにも保存される）
     keyManager.setCurrentKeyInfo(keyInfo);
 
-    // 公開鍵を取得して状態を更新
     const pubKey = await keyManager.getPublicKey();
     appState.publicKey.set(pubKey);
     appState.isLoggedIn.set(true);
 
-    // アカウント画面に遷移
     appState.currentScreen.set('account');
   } catch (error) {
     console.error('ログインエラー:', error);
@@ -124,116 +84,11 @@ async function login(credentialId: string) {
   }
 }
 
-// 既存のパスキーでログイン（credentialIdなし）
-async function loginWithExistingPasskey() {
-  isLoading = true;
+function selectTab(tab: AuthTab) {
+  activeTab = tab;
   errorMessage = '';
-
-  try {
-    // PRFを直接Nostrキーとして使用（credentialIdなしで呼び出し）
-    const keyInfo = await keyManager.createNostrKey();
-
-    // SDKに鍵情報を設定（内部でストレージにも保存される）
-    keyManager.setCurrentKeyInfo(keyInfo);
-
-    // 公開鍵を取得して状態を更新
-    const pubKey = await keyManager.getPublicKey();
-    appState.publicKey.set(pubKey);
-    appState.isLoggedIn.set(true);
-
-    // アカウント画面に遷移
-    appState.currentScreen.set('account');
-  } catch (error) {
-    console.error('ログインエラー:', error);
-    errorMessage = `${$i18n.t.common.errorMessages.login} ${error instanceof Error ? error.message : String(error)}`;
-  } finally {
-    isLoading = false;
-  }
 }
 
-// サポート対象外の場合のメッセージ
-function getUnsupportedMessage() {
-  const isChrome = navigator.userAgent.indexOf('Chrome') > -1;
-  const isFirefox = navigator.userAgent.indexOf('Firefox') > -1;
-
-  if (isChrome) {
-    return 'Chrome では chrome://flags から #enable-webauthn-new-discovery-mechanism と #enable-webauthn-extensions を有効にしてください。';
-  }
-
-  if (isFirefox) {
-    return 'Firefox では about:config から webauthn:enable_prf を true に設定してください。';
-  }
-
-  return 'お使いのブラウザでは WebAuthn PRF 拡張がサポートされていません。Chrome または Firefox の最新版をお試しください。';
-}
-
-// KeyInfoファイルアップロードの処理
-async function handleKeyInfoFileUpload(event: Event) {
-  const input = event.target as HTMLInputElement;
-  if (!input.files || input.files.length === 0) return;
-
-  const file = input.files[0];
-  isLoading = true;
-  keyInfoImportError = '';
-
-  try {
-    const fileContent = await file.text();
-    await loginWithKeyInfoData(fileContent);
-  } catch (error) {
-    console.error('KeyInfoファイル読み込みエラー:', error);
-    keyInfoImportError = `ファイル読み込みエラー: ${error instanceof Error ? error.message : String(error)}`;
-    isLoading = false;
-  }
-}
-
-// KeyInfoテキストでのログイン処理
-async function loginWithKeyInfoText() {
-  if (!keyInfoTextInput) return;
-
-  isLoading = true;
-  keyInfoImportError = '';
-
-  try {
-    await loginWithKeyInfoData(keyInfoTextInput);
-  } catch (error) {
-    console.error('KeyInfoテキスト処理エラー:', error);
-    keyInfoImportError = `KeyInfo処理エラー: ${error instanceof Error ? error.message : String(error)}`;
-    isLoading = false;
-  }
-}
-
-// KeyInfoデータ（JSONテキスト）からのログイン処理
-async function loginWithKeyInfoData(keyInfoJsonText: string) {
-  try {
-    // JSONをパース
-    const keyData = JSON.parse(keyInfoJsonText);
-
-    // KeyInfoが有効かチェック
-    if (!keyData.v || !keyData.alg || !keyData.credentialId || !keyData.pubkey) {
-      throw new Error('有効なKeyInfoデータではありません');
-    }
-
-    // KeyInfoをセット
-    keyManager.setCurrentKeyInfo(keyData);
-
-    // 公開鍵を取得して状態を更新
-    const pubKey = await keyManager.getPublicKey();
-    appState.publicKey.set(pubKey);
-    appState.isLoggedIn.set(true);
-
-    // アカウント画面に遷移
-    appState.currentScreen.set('account');
-  } catch (error) {
-    console.error('KeyInfoログインエラー:', error);
-    throw new Error(
-      `KeyInfoログインエラー: ${error instanceof Error ? error.message : String(error)}`
-    );
-  } finally {
-    isLoading = false;
-  }
-}
-
-// コンポーネントのマウント時に初期化
 $effect(() => {
   initialize();
 });
@@ -252,192 +107,84 @@ $effect(() => {
       <p>{$i18n.t.auth.loading}</p>
     </div>
   {:else}
-    <!-- メインアクションセクション（新規ユーザー向け） -->
-    <CardSection title={$i18n.t.auth.quickStartTitle}>
-      <div class="quick-start-section">
-        <div class="recommendation-badge new-user">
-          {$i18n.t.auth.newUserRecommended}
-        </div>
-
-        <h3>{$i18n.t.auth.passkeySectionTitle}</h3>
-        <p class="section-description">{$i18n.t.auth.passkeySectionDesc}</p>
-
-        <!-- クロスデバイス認証の説明 -->
-        <div class="info-box">
-          <h4>{$i18n.t.auth.crossDeviceTitle}</h4>
-          <p>{$i18n.t.auth.crossDeviceDesc}</p>
-        </div>
-
-        <div class="username-input">
-          <label for="username">{$i18n.t.auth.username}</label>
-          <input
-            id="username"
-            type="text"
-            bind:value={username}
-            placeholder={$i18n.t.auth.usernamePlaceholder}
-            disabled={isLoading}
-          />
-        </div>
-
-        {#if !isPasskeyCreated}
-          <Button onclick={createNew} disabled={isLoading} size="large">
-            {$i18n.t.auth.createNew}
-          </Button>
-        {:else}
-          <div class="success-message">
-            <div class="success-icon">✅</div>
-            <h4>{$i18n.t.auth.passkeyCreated}</h4>
-            <p>{$i18n.t.auth.firstLogin}</p>
-            <Button
-              variant="success"
-              onclick={() => login(createdCredentialId)}
-              disabled={isLoading}
-              className="success-action-button"
-            >
-              {$i18n.t.auth.proceedWithLogin}
-            </Button>
-          </div>
-        {/if}
-      </div>
-    </CardSection>
-
-    <!-- 既存ユーザー向けセクション -->
-    <CardSection title={$i18n.t.auth.existingUserTitle}>
-      <div class="existing-user-section">
-        <div class="recommendation-badge existing-user">
-          {$i18n.t.auth.returningUserRecommended}
-        </div>
-
-        <h3>{$i18n.t.auth.existingPasskeyTitle}</h3>
-        <p class="section-description">{$i18n.t.auth.existingPasskeyDesc}</p>
-
-        <Button
-          variant="secondary"
-          onclick={loginWithExistingPasskey}
-          disabled={isLoading}
-          className="secondary-action-button"
-        >
-          {$i18n.t.auth.loginWith}
-        </Button>
-      </div>
-    </CardSection>
-
-    <!-- 高度なオプション -->
-    <div class="advanced-section">
-      <ToggleButton
-        onclick={() => (showAdvancedOptions = !showAdvancedOptions)}
-        expanded={showAdvancedOptions}
-        className="toggle-section-button"
+    <div
+      class="auth-tabs"
+      role="tablist"
+      aria-label={$i18n.t.auth.title}
+    >
+      <TabButton
+        active={activeTab === "login"}
+        onclick={() => selectTab("login")}
+        className="auth-tab"
       >
-        {$i18n.t.auth.advancedOptionsTitle}
-      </ToggleButton>
-
-      {#if showAdvancedOptions}
-        <div class="advanced-content">
-          <!-- KeyInfoインポートセクション -->
-          <CardSection title={$i18n.t.auth.keyInfoImportTitle}>
-            <div class="key-info-import-section">
-              <p class="section-description">
-                {$i18n.t.auth.keyInfoImportDesc}
-              </p>
-
-              <div class="key-info-input-container">
-                <FileInputButton
-                  onchange={handleKeyInfoFileUpload}
-                  accept="application/json"
-                  disabled={isLoading}
-                  inputId="key-info-file-input"
-                >
-                  {$i18n.t.auth.keyInfoFileSelect}
-                </FileInputButton>
-
-                <div class="divider">
-                  <span>{$i18n.t.auth.orText}</span>
-                </div>
-
-                <ToggleButton
-                  onclick={() => (showKeyInfoTextarea = !showKeyInfoTextarea)}
-                  expanded={showKeyInfoTextarea}
-                  size="small"
-                  className="toggle-text-input-button"
-                >
-                  {$i18n.t.auth.keyDataInput}
-                </ToggleButton>
-              </div>
-
-              {#if showKeyInfoTextarea}
-                <div class="key-info-textarea-container">
-                  <textarea
-                    bind:value={keyInfoTextInput}
-                    placeholder={$i18n.t.auth.keyDataPlaceholder}
-                    class="key-info-textarea"
-                  ></textarea>
-                  <Button
-                    variant="success"
-                    onclick={loginWithKeyInfoText}
-                    disabled={isLoading || !keyInfoTextInput}
-                    className="key-info-login-button"
-                  >
-                    {isLoading
-                      ? $i18n.t.auth.keyInfoLoginProcessing
-                      : $i18n.t.auth.keyInfoLoginButton}
-                  </Button>
-                </div>
-              {/if}
-
-              {#if keyInfoImportError}
-                <div class="error-message">
-                  {keyInfoImportError}
-                </div>
-              {/if}
-            </div>
-          </CardSection>
-
-          <!-- 開発者向けセクション -->
-          <div class="developer-section">
-            <ToggleButton
-              onclick={() => (showDeveloperSection = !showDeveloperSection)}
-              expanded={showDeveloperSection}
-              size="small"
-              className="toggle-section-button small"
-            >
-              {$i18n.t.auth.developerSection}
-            </ToggleButton>
-
-            {#if showDeveloperSection}
-              <CardSection title="">
-                <div class="developer-content">
-                  <p class="developer-description">
-                    {$i18n.t.auth.prfDebugInfo}
-                  </p>
-
-                  {#if !isPrfChecked}
-                    <Button
-                      variant="secondary"
-                      onclick={checkPrfSupport}
-                      size="small"
-                      className="developer-action-button"
-                    >
-                      {$i18n.t.auth.checkPrf}
-                    </Button>
-                  {:else if !isSupported}
-                    <div class="error-message">
-                      <h4>{$i18n.t.auth.unsupportedTitle}</h4>
-                      <p>{getUnsupportedMessage()}</p>
-                    </div>
-                  {:else}
-                    <div class="success-message small">
-                      <span class="success-icon">✅</span>
-                      <p>{$i18n.t.auth.prfSupportedMessage}</p>
-                    </div>
-                  {/if}
-                </div>
-              </CardSection>
-            {/if}
-          </div>
-        </div>
-      {/if}
+        {$i18n.t.auth.tabLogin}
+      </TabButton>
+      <TabButton
+        active={activeTab === "register"}
+        onclick={() => selectTab("register")}
+        className="auth-tab"
+      >
+        {$i18n.t.auth.tabRegister}
+      </TabButton>
     </div>
+
+    {#if activeTab === "login"}
+      <CardSection title={$i18n.t.auth.tabLogin}>
+        <div class="tab-panel">
+          <div class="panel-heading">
+            <h3>{$i18n.t.auth.loginWith}</h3>
+            <HelpTip text={$i18n.t.auth.loginTip} />
+          </div>
+
+          <Button onclick={() => login()} disabled={isLoading} size="large">
+            {$i18n.t.auth.loginWith}
+          </Button>
+        </div>
+      </CardSection>
+    {:else}
+      <CardSection title={$i18n.t.auth.tabRegister}>
+        <div class="tab-panel">
+          <div class="panel-heading">
+            <h3>{$i18n.t.auth.tabRegister}</h3>
+            <HelpTip text={$i18n.t.auth.registerTip} />
+          </div>
+
+          <div class="username-input">
+            <label for="username">
+              {$i18n.t.auth.username}
+              <HelpTip text={$i18n.t.auth.usernameTip} />
+            </label>
+            <input
+              id="username"
+              type="text"
+              bind:value={username}
+              placeholder={$i18n.t.auth.usernamePlaceholder}
+              disabled={isLoading}
+            />
+          </div>
+
+          {#if !isPasskeyCreated}
+            <Button onclick={createNew} disabled={isLoading} size="large">
+              {$i18n.t.auth.createNew}
+            </Button>
+          {:else}
+            <div class="success-message">
+              <div class="success-icon">✅</div>
+              <h4>{$i18n.t.auth.passkeyCreated}</h4>
+              <p>{$i18n.t.auth.firstLogin}</p>
+              <Button
+                variant="success"
+                onclick={() => login(createdCredentialId)}
+                disabled={isLoading}
+                className="success-action-button"
+              >
+                {$i18n.t.auth.proceedWithLogin}
+              </Button>
+            </div>
+          {/if}
+        </div>
+      </CardSection>
+    {/if}
   {/if}
 
   {#if errorMessage}
@@ -456,7 +203,6 @@ $effect(() => {
     text-align: center;
   }
 
-  /* ヒーローセクション */
   .hero-section {
     margin-bottom: 32px;
   }
@@ -475,7 +221,6 @@ $effect(() => {
     line-height: 1.5;
   }
 
-  /* ローディングセクション */
   .loading-section {
     display: flex;
     flex-direction: column;
@@ -502,79 +247,48 @@ $effect(() => {
     }
   }
 
-  /* レコメンデーションバッジ */
-  .recommendation-badge {
-    display: inline-block;
-    padding: 4px 12px;
-    border-radius: 16px;
-    font-size: 0.85rem;
-    font-weight: 600;
-    margin-bottom: 12px;
+  .auth-tabs {
+    display: flex;
+    gap: 4px;
+    padding: 4px;
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+    margin: 0 auto 20px;
+    max-width: 360px;
   }
 
-  .recommendation-badge.new-user {
-    background-color: var(--color-success-bg);
-    color: var(--color-button-success);
-    border: 1px solid var(--color-button-success);
+  .auth-tabs :global(.auth-tab) {
+    flex: 1;
   }
 
-  .recommendation-badge.existing-user {
-    background-color: var(--color-info-bg);
-    color: var(--color-info);
-    border: 1px solid var(--color-info);
-  }
-
-  /* セクション共通 */
-  .section-description {
-    color: var(--color-text-secondary);
-    line-height: 1.6;
-    margin-bottom: 20px;
-  }
-
-  .quick-start-section,
-  .existing-user-section {
+  .tab-panel {
     text-align: left;
   }
 
-  .quick-start-section h3,
-  .existing-user-section h3 {
+  .panel-heading {
+    display: flex;
+    align-items: center;
     margin: 0 0 12px 0;
+  }
+
+  .panel-heading h3 {
+    margin: 0;
     color: var(--color-text-primary);
     font-size: 1.25rem;
   }
 
-  /* 情報ボックス */
-  .info-box {
-    margin: 16px 0;
-    padding: 16px;
-    background-color: var(--color-info-bg);
-    border-left: 4px solid var(--color-info);
-    border-radius: 4px;
-    text-align: left;
-  }
-
-  .info-box h4 {
-    margin: 0 0 8px 0;
-    color: var(--color-info);
-    font-size: 1rem;
-  }
-
-  .info-box p {
-    margin: 0;
-    font-size: 0.9rem;
-    line-height: 1.5;
-  }
-
-  /* ユーザー名入力 */
   .username-input {
     display: flex;
     flex-direction: column;
     gap: 6px;
-    margin: 20px 0;
+    margin: 0 0 20px 0;
     text-align: left;
   }
 
   .username-input label {
+    display: inline-flex;
+    align-items: center;
     font-weight: 500;
     color: var(--color-text-primary);
   }
@@ -592,7 +306,6 @@ $effect(() => {
     border-color: var(--color-button-primary);
   }
 
-  /* 成功メッセージ */
   .success-message {
     padding: 20px;
     background-color: var(--color-success-bg);
@@ -600,14 +313,6 @@ $effect(() => {
     border-radius: 8px;
     text-align: center;
     margin: 16px 0;
-  }
-
-  .success-message.small {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 12px;
-    text-align: left;
   }
 
   .success-message h4 {
@@ -621,92 +326,8 @@ $effect(() => {
     color: var(--color-text-secondary);
   }
 
-  .success-message.small p {
-    margin: 0;
-  }
-
   .success-icon {
     font-size: 1.2rem;
-  }
-
-  /* 高度なオプションセクション */
-  .advanced-section {
-    margin-top: 40px;
-  }
-
-  .advanced-content {
-    margin-top: 16px;
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-  }
-
-  /* KeyInfoインポートセクション */
-  .key-info-import-section {
-    text-align: left;
-  }
-
-  .key-info-input-container {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    margin: 16px 0;
-  }
-
-  .divider {
-    display: flex;
-    align-items: center;
-    gap: 16px;
-    margin: 8px 0;
-  }
-
-  .divider::before,
-  .divider::after {
-    content: "";
-    flex: 1;
-    height: 1px;
-    background-color: var(--color-border-medium);
-  }
-
-  .divider span {
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-  }
-
-  .key-info-textarea-container {
-    margin-top: 16px;
-  }
-
-  .key-info-textarea {
-    width: 100%;
-    height: 120px;
-    padding: 12px;
-    border: 2px solid var(--color-border-medium);
-    border-radius: 6px;
-    font-family: ui-monospace, "Courier New", monospace;
-    font-size: 0.85rem;
-    resize: vertical;
-    margin-bottom: 12px;
-    transition: border-color 0.2s ease;
-  }
-
-  .key-info-textarea:focus {
-    outline: none;
-    border-color: var(--color-button-primary);
-  }
-
-  .developer-section {
-    margin-top: 16px;
-  }
-
-  .developer-content {
-    text-align: left;
-  }
-
-  .developer-description {
-    color: var(--color-text-muted);
-    font-size: 0.9rem;
-    margin-bottom: 16px;
   }
 
   .error-message {
@@ -740,11 +361,6 @@ $effect(() => {
 
     .screen-title {
       font-size: 1.8rem;
-    }
-
-    .recommendation-badge {
-      font-size: 0.8rem;
-      padding: 3px 10px;
     }
   }
 </style>

--- a/examples/svelte-app/src/components/screens/AuthScreen.svelte
+++ b/examples/svelte-app/src/components/screens/AuthScreen.svelte
@@ -107,11 +107,7 @@ $effect(() => {
       <p>{$i18n.t.auth.loading}</p>
     </div>
   {:else}
-    <div
-      class="auth-tabs"
-      role="tablist"
-      aria-label={$i18n.t.auth.title}
-    >
+    <div class="auth-tabs">
       <TabButton
         active={activeTab === "login"}
         onclick={() => selectTab("login")}
@@ -131,8 +127,7 @@ $effect(() => {
     {#if activeTab === "login"}
       <CardSection title={$i18n.t.auth.tabLogin}>
         <div class="tab-panel">
-          <div class="panel-heading">
-            <h3>{$i18n.t.auth.loginWith}</h3>
+          <div class="panel-help">
             <HelpTip text={$i18n.t.auth.loginTip} />
           </div>
 
@@ -144,16 +139,15 @@ $effect(() => {
     {:else}
       <CardSection title={$i18n.t.auth.tabRegister}>
         <div class="tab-panel">
-          <div class="panel-heading">
-            <h3>{$i18n.t.auth.tabRegister}</h3>
+          <div class="panel-help">
             <HelpTip text={$i18n.t.auth.registerTip} />
           </div>
 
           <div class="username-input">
-            <label for="username">
-              {$i18n.t.auth.username}
+            <div class="username-label-row">
+              <label for="username">{$i18n.t.auth.username}</label>
               <HelpTip text={$i18n.t.auth.usernameTip} />
-            </label>
+            </div>
             <input
               id="username"
               type="text"
@@ -266,16 +260,10 @@ $effect(() => {
     text-align: left;
   }
 
-  .panel-heading {
+  .panel-help {
     display: flex;
-    align-items: center;
-    margin: 0 0 12px 0;
-  }
-
-  .panel-heading h3 {
-    margin: 0;
-    color: var(--color-text-primary);
-    font-size: 1.25rem;
+    justify-content: flex-end;
+    margin: 0 0 8px 0;
   }
 
   .username-input {
@@ -286,9 +274,12 @@ $effect(() => {
     text-align: left;
   }
 
-  .username-input label {
-    display: inline-flex;
+  .username-label-row {
+    display: flex;
     align-items: center;
+  }
+
+  .username-label-row label {
     font-weight: 500;
     color: var(--color-text-primary);
   }

--- a/examples/svelte-app/src/components/screens/KeyManagement.svelte
+++ b/examples/svelte-app/src/components/screens/KeyManagement.svelte
@@ -1,17 +1,23 @@
 <script lang="ts">
+import { isLoggedIn } from '../../store/app-state.js';
 import ExportKeyInfoComponent from '../settings/ExportKeyInfoComponent.svelte';
 import ExportSecretKey from '../settings/ExportSecretKey.svelte';
+import ImportKeyInfo from '../settings/ImportKeyInfo.svelte';
 import LocalStorageSection from '../settings/LocalStorageSection.svelte';
 import LogoutSection from '../settings/LogoutSection.svelte';
 import SecretCacheSettings from '../settings/SecretCacheSettings.svelte';
 </script>
 
 <div class="settings-container">
-  <SecretCacheSettings />
-  <ExportKeyInfoComponent />
-  <ExportSecretKey />
-  <LogoutSection />
-  <LocalStorageSection />
+  {#if $isLoggedIn}
+    <SecretCacheSettings />
+    <ExportKeyInfoComponent />
+    <ExportSecretKey />
+    <LogoutSection />
+    <LocalStorageSection />
+  {:else}
+    <ImportKeyInfo />
+  {/if}
 </div>
 
 <style>

--- a/examples/svelte-app/src/components/screens/SettingsScreen.svelte
+++ b/examples/svelte-app/src/components/screens/SettingsScreen.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import AppInfo from '../settings/AppInfo.svelte';
 import ConsentPolicySettings from '../settings/ConsentPolicySettings.svelte';
+import DeveloperSection from '../settings/DeveloperSection.svelte';
 import LanguageSettings from '../settings/LanguageSettings.svelte';
-import LocalStorageSection from '../settings/LocalStorageSection.svelte';
 import RelaySettings from '../settings/RelaySettings.svelte';
 import TrustedOriginsSettings from '../settings/TrustedOriginsSettings.svelte';
 import ThemeSettings from '../settings/theme-settings.svelte';
@@ -15,6 +15,7 @@ import ThemeSettings from '../settings/theme-settings.svelte';
   <LanguageSettings />
   <ThemeSettings />
   <AppInfo />
+  <DeveloperSection />
 </div>
 
 <style>

--- a/examples/svelte-app/src/components/settings/DeveloperSection.svelte
+++ b/examples/svelte-app/src/components/settings/DeveloperSection.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+import { i18n } from '../../i18n/i18n-store.js';
+import { getNosskeyManager } from '../../services/nosskey-manager.service.js';
+import CardSection from '../ui/CardSection.svelte';
+import Button from '../ui/button/Button.svelte';
+import ToggleButton from '../ui/button/ToggleButton.svelte';
+
+let isLoading = $state(false);
+let errorMessage = $state('');
+let isPrfChecked = $state(false);
+let isSupported = $state(false);
+// biome-ignore lint: svelte
+let expanded = $state(false);
+
+const keyManager = getNosskeyManager();
+
+async function checkPrfSupport() {
+  isLoading = true;
+  errorMessage = '';
+  try {
+    isSupported = await keyManager.isPrfSupported();
+    isPrfChecked = true;
+  } catch (error) {
+    console.error('PRF対応確認エラー:', error);
+    errorMessage = `${$i18n.t.common.errorMessages.prfCheck} ${error instanceof Error ? error.message : String(error)}`;
+  } finally {
+    isLoading = false;
+  }
+}
+
+function getUnsupportedMessage() {
+  const isChrome = navigator.userAgent.indexOf('Chrome') > -1;
+  const isFirefox = navigator.userAgent.indexOf('Firefox') > -1;
+
+  if (isChrome) {
+    return 'Chrome では chrome://flags から #enable-webauthn-new-discovery-mechanism と #enable-webauthn-extensions を有効にしてください。';
+  }
+
+  if (isFirefox) {
+    return 'Firefox では about:config から webauthn:enable_prf を true に設定してください。';
+  }
+
+  return 'お使いのブラウザでは WebAuthn PRF 拡張がサポートされていません。Chrome または Firefox の最新版をお試しください。';
+}
+</script>
+
+<div class="developer-section">
+  <ToggleButton
+    onclick={() => (expanded = !expanded)}
+    {expanded}
+    size="small"
+    className="toggle-section-button small"
+  >
+    {$i18n.t.settings.developer.title}
+  </ToggleButton>
+
+  {#if expanded}
+    <CardSection title="">
+      <div class="developer-content">
+        <p class="developer-description">
+          {$i18n.t.settings.developer.description}
+        </p>
+
+        {#if !isPrfChecked}
+          <Button
+            variant="secondary"
+            onclick={checkPrfSupport}
+            disabled={isLoading}
+            size="small"
+            className="developer-action-button"
+          >
+            {$i18n.t.settings.developer.checkPrf}
+          </Button>
+        {:else if !isSupported}
+          <div class="error-message">
+            <h4>{$i18n.t.settings.developer.prfUnsupportedTitle}</h4>
+            <p>{getUnsupportedMessage()}</p>
+          </div>
+        {:else}
+          <div class="success-message small">
+            <span class="success-icon">✅</span>
+            <p>{$i18n.t.settings.developer.prfSupported}</p>
+          </div>
+        {/if}
+
+        {#if errorMessage}
+          <div class="error-message">{errorMessage}</div>
+        {/if}
+      </div>
+    </CardSection>
+  {/if}
+</div>
+
+<style>
+  .developer-section {
+    margin-top: 16px;
+  }
+
+  .developer-content {
+    text-align: left;
+  }
+
+  .developer-description {
+    color: var(--color-text-muted);
+    font-size: 0.9rem;
+    margin-bottom: 16px;
+  }
+
+  .success-message.small {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px;
+    text-align: left;
+    background-color: var(--color-success-bg);
+    border: 2px solid var(--color-button-success);
+    border-radius: 8px;
+    margin: 16px 0;
+  }
+
+  .success-message.small p {
+    margin: 0;
+  }
+
+  .success-icon {
+    font-size: 1.2rem;
+  }
+
+  .error-message {
+    padding: 12px 16px;
+    background-color: var(--color-error-bg);
+    color: var(--color-error);
+    border: 1px solid var(--color-error);
+    border-radius: 6px;
+    margin: 12px 0;
+    font-size: 0.9rem;
+    text-align: left;
+  }
+
+  .error-message h4 {
+    margin: 0 0 8px 0;
+  }
+</style>

--- a/examples/svelte-app/src/components/settings/ImportKeyInfo.svelte
+++ b/examples/svelte-app/src/components/settings/ImportKeyInfo.svelte
@@ -1,0 +1,204 @@
+<script lang="ts">
+import { i18n } from '../../i18n/i18n-store.js';
+import { getNosskeyManager } from '../../services/nosskey-manager.service.js';
+import * as appState from '../../store/app-state.js';
+import CardSection from '../ui/CardSection.svelte';
+import Button from '../ui/button/Button.svelte';
+import FileInputButton from '../ui/button/FileInputButton.svelte';
+import ToggleButton from '../ui/button/ToggleButton.svelte';
+
+let isLoading = $state(false);
+// biome-ignore lint: svelte
+let showKeyInfoTextarea = $state(false);
+// biome-ignore lint: svelte
+let keyInfoTextInput = $state('');
+let keyInfoImportError = $state('');
+
+const keyManager = getNosskeyManager();
+
+async function handleKeyInfoFileUpload(event: Event) {
+  const input = event.target as HTMLInputElement;
+  if (!input.files || input.files.length === 0) return;
+
+  const file = input.files[0];
+  isLoading = true;
+  keyInfoImportError = '';
+
+  try {
+    const fileContent = await file.text();
+    await loginWithKeyInfoData(fileContent);
+  } catch (error) {
+    console.error('KeyInfoファイル読み込みエラー:', error);
+    keyInfoImportError = `ファイル読み込みエラー: ${error instanceof Error ? error.message : String(error)}`;
+    isLoading = false;
+  }
+}
+
+async function loginWithKeyInfoText() {
+  if (!keyInfoTextInput) return;
+
+  isLoading = true;
+  keyInfoImportError = '';
+
+  try {
+    await loginWithKeyInfoData(keyInfoTextInput);
+  } catch (error) {
+    console.error('KeyInfoテキスト処理エラー:', error);
+    keyInfoImportError = `KeyInfo処理エラー: ${error instanceof Error ? error.message : String(error)}`;
+    isLoading = false;
+  }
+}
+
+async function loginWithKeyInfoData(keyInfoJsonText: string) {
+  try {
+    const keyData = JSON.parse(keyInfoJsonText);
+
+    if (!keyData.v || !keyData.alg || !keyData.credentialId || !keyData.pubkey) {
+      throw new Error('有効なKeyInfoデータではありません');
+    }
+
+    keyManager.setCurrentKeyInfo(keyData);
+
+    const pubKey = await keyManager.getPublicKey();
+    appState.publicKey.set(pubKey);
+    appState.isLoggedIn.set(true);
+
+    appState.currentScreen.set('account');
+  } catch (error) {
+    console.error('KeyInfoログインエラー:', error);
+    throw new Error(
+      `KeyInfoログインエラー: ${error instanceof Error ? error.message : String(error)}`
+    );
+  } finally {
+    isLoading = false;
+  }
+}
+</script>
+
+<CardSection title={$i18n.t.settings.import.title}>
+  <div class="key-info-import-section">
+    <p class="section-description">{$i18n.t.settings.import.description}</p>
+
+    <div class="key-info-input-container">
+      <FileInputButton
+        onchange={handleKeyInfoFileUpload}
+        accept="application/json"
+        disabled={isLoading}
+        inputId="key-info-file-input"
+      >
+        {$i18n.t.settings.import.fileSelect}
+      </FileInputButton>
+
+      <div class="divider">
+        <span>{$i18n.t.settings.import.or}</span>
+      </div>
+
+      <ToggleButton
+        onclick={() => (showKeyInfoTextarea = !showKeyInfoTextarea)}
+        expanded={showKeyInfoTextarea}
+        size="small"
+        className="toggle-text-input-button"
+      >
+        {$i18n.t.settings.import.dataInput}
+      </ToggleButton>
+    </div>
+
+    {#if showKeyInfoTextarea}
+      <div class="key-info-textarea-container">
+        <textarea
+          bind:value={keyInfoTextInput}
+          placeholder={$i18n.t.settings.import.dataPlaceholder}
+          class="key-info-textarea"
+        ></textarea>
+        <Button
+          variant="success"
+          onclick={loginWithKeyInfoText}
+          disabled={isLoading || !keyInfoTextInput}
+          className="key-info-login-button"
+        >
+          {isLoading
+            ? $i18n.t.settings.import.processing
+            : $i18n.t.settings.import.loginButton}
+        </Button>
+      </div>
+    {/if}
+
+    {#if keyInfoImportError}
+      <div class="error-message">
+        {keyInfoImportError}
+      </div>
+    {/if}
+  </div>
+</CardSection>
+
+<style>
+  .key-info-import-section {
+    text-align: left;
+  }
+
+  .section-description {
+    color: var(--color-text-secondary);
+    line-height: 1.6;
+    margin-bottom: 20px;
+  }
+
+  .key-info-input-container {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin: 16px 0;
+  }
+
+  .divider {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin: 8px 0;
+  }
+
+  .divider::before,
+  .divider::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background-color: var(--color-border-medium);
+  }
+
+  .divider span {
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
+  }
+
+  .key-info-textarea-container {
+    margin-top: 16px;
+  }
+
+  .key-info-textarea {
+    width: 100%;
+    height: 120px;
+    padding: 12px;
+    border: 2px solid var(--color-border-medium);
+    border-radius: 6px;
+    font-family: ui-monospace, "Courier New", monospace;
+    font-size: 0.85rem;
+    resize: vertical;
+    margin-bottom: 12px;
+    transition: border-color 0.2s ease;
+  }
+
+  .key-info-textarea:focus {
+    outline: none;
+    border-color: var(--color-button-primary);
+  }
+
+  .error-message {
+    padding: 12px 16px;
+    background-color: var(--color-error-bg);
+    color: var(--color-error);
+    border: 1px solid var(--color-error);
+    border-radius: 6px;
+    margin: 12px 0;
+    font-size: 0.9rem;
+    text-align: left;
+  }
+</style>

--- a/examples/svelte-app/src/components/ui/HelpTip.svelte
+++ b/examples/svelte-app/src/components/ui/HelpTip.svelte
@@ -8,7 +8,9 @@ interface Props {
 const { text }: Props = $props();
 
 // 1コンポーネントインスタンスごとに一意の id を発番し aria-describedby と紐付ける。
-const tipId = `help-tip-${crypto.randomUUID()}`;
+// `crypto.randomUUID()` は古い jsdom テスト環境などで存在しないことがあるため
+// Math.random ベースのフォールバックを併用する。
+const tipId = `help-tip-${globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2)}`;
 </script>
 
 <span class="help-tip">

--- a/examples/svelte-app/src/components/ui/HelpTip.svelte
+++ b/examples/svelte-app/src/components/ui/HelpTip.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+import { i18n } from '../../i18n/i18n-store.js';
+
+interface Props {
+  text: string;
+}
+
+const { text }: Props = $props();
+
+// 1コンポーネントインスタンスごとに一意の id を発番し aria-describedby と紐付ける。
+const tipId = `help-tip-${crypto.randomUUID()}`;
+</script>
+
+<span class="help-tip">
+  <button
+    type="button"
+    class="help-tip__trigger"
+    aria-describedby={tipId}
+    aria-label={$i18n.t.common.help}
+  >?</button>
+  <span role="tooltip" id={tipId} class="help-tip__bubble">{text}</span>
+</span>
+
+<style>
+  .help-tip {
+    position: relative;
+    display: inline-flex;
+    vertical-align: middle;
+    margin-left: 6px;
+  }
+
+  .help-tip__trigger {
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    border-radius: 50%;
+    border: 1.5px solid var(--color-border-medium);
+    background: transparent;
+    color: var(--color-text-secondary);
+    font-family: inherit;
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1;
+    cursor: help;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition:
+      border-color 0.2s ease,
+      color 0.2s ease,
+      background-color 0.2s ease;
+  }
+
+  .help-tip__trigger:hover,
+  .help-tip__trigger:focus-visible {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+    outline: none;
+  }
+
+  .help-tip__bubble {
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    width: max-content;
+    max-width: min(240px, calc(100vw - 32px));
+    padding: 8px 10px;
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border-medium);
+    border-radius: 6px;
+    box-shadow: 0 4px 12px var(--color-shadow);
+    font-size: 0.85rem;
+    font-weight: 400;
+    line-height: 1.4;
+    text-align: left;
+    white-space: normal;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition:
+      opacity 0.15s ease,
+      visibility 0.15s ease;
+    z-index: 10;
+  }
+
+  .help-tip:hover .help-tip__bubble,
+  .help-tip:focus-within .help-tip__bubble {
+    opacity: 1;
+    visibility: visible;
+  }
+</style>

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -19,6 +19,7 @@ export interface TranslationData {
     copied: string;
     loading: string;
     edit: string;
+    help: string;
     errorMessages: {
       init: string;
       prfCheck: string;
@@ -33,48 +34,25 @@ export interface TranslationData {
   auth: {
     title: string;
     subtitle: string;
-    checkPrf: string;
-    unsupportedTitle: string;
     createNew: string;
     loginWith: string;
     login: string;
     loading: string;
     username: string;
     usernamePlaceholder: string;
-    importTitle: string;
-    importSubtitle: string;
     secretKey: string;
     secretKeyHelp: string;
     importButton: string;
     accountTitle: string;
     appDescription: string;
-    passkeySectionTitle: string;
-    passkeySectionDesc: string;
-    crossDeviceTitle: string;
-    crossDeviceDesc: string;
-    existingPasskeyTitle: string;
-    existingPasskeyDesc: string;
-    developerSection: string;
-    prfDebugInfo: string;
-    prfSupportedMessage: string;
     firstLogin: string;
     passkeyCreated: string;
     proceedWithLogin: string;
-    keyInfoImportTitle: string;
-    keyInfoImportDesc: string;
-    keyInfoFileSelect: string;
-    keyDataInput: string;
-    keyDataPlaceholder: string;
-    keyInfoLoginButton: string;
-    keyInfoLoginProcessing: string;
-    orText: string;
-    quickStartTitle: string;
-    quickStartDesc: string;
-    existingUserTitle: string;
-    existingUserDesc: string;
-    advancedOptionsTitle: string;
-    newUserRecommended: string;
-    returningUserRecommended: string;
+    tabLogin: string;
+    tabRegister: string;
+    loginTip: string;
+    registerTip: string;
+    usernameTip: string;
   };
   nostr: {
     publicKey: string;
@@ -193,6 +171,23 @@ export interface TranslationData {
       saved: string;
       corruptionWarning: string;
     };
+    developer: {
+      title: string;
+      description: string;
+      checkPrf: string;
+      prfSupported: string;
+      prfUnsupportedTitle: string;
+    };
+    import: {
+      title: string;
+      description: string;
+      fileSelect: string;
+      dataInput: string;
+      dataPlaceholder: string;
+      loginButton: string;
+      processing: string;
+      or: string;
+    };
   };
   navigation: {
     account: string;
@@ -274,6 +269,7 @@ export const ja: TranslationData = {
     copied: 'コピーしました',
     loading: '読み込み中...',
     edit: '編集',
+    help: 'ヘルプ',
     errorMessages: {
       init: '初期化エラー:',
       prfCheck: 'PRF対応確認エラー:',
@@ -288,10 +284,8 @@ export const ja: TranslationData = {
   auth: {
     title: 'Nosskey デモ',
     subtitle: 'パスキーで保管するNostr秘密鍵を活用したクライアント',
-    checkPrf: 'PRF拡張対応確認',
-    unsupportedTitle: 'PRF拡張がサポートされていません',
     createNew: '新規作成',
-    loginWith: '既存のパスキーでログイン',
+    loginWith: 'パスキーでログイン',
     login: 'ログイン',
     firstLogin: '初回ログイン',
     passkeyCreated: 'パスキーが作成されました',
@@ -299,42 +293,19 @@ export const ja: TranslationData = {
     loading: 'ロード中...',
     username: 'ユーザー名',
     usernamePlaceholder: 'ユーザー名を入力',
-    importTitle: '既存のNostr鍵をインポート',
-    importSubtitle:
-      '既存の秘密鍵をパスキーで保護します。PRFを直接秘密鍵として使用せず、秘密鍵の暗号化に使用します',
     secretKey: 'Nostr秘密鍵',
     secretKeyHelp: '秘密鍵は設定後にサーバーに送信されず、ブラウザ内で処理されます',
     importButton: 'インポート',
     accountTitle: 'Nostrアカウント',
     appDescription:
       'このアプリはパスキー認証を使ってNostr鍵を安全に管理します。パスキーはプラットフォームによりクラウドバックアップされるため煩雑な秘密鍵管理が不要となります',
-    passkeySectionTitle: 'パスキーでアカウント作成',
-    passkeySectionDesc:
-      'パスキーは生体認証や端末のセキュリティ機能を使った簡単で安全な認証方法です。',
-    crossDeviceTitle: '幅広い端末で利用可能',
-    crossDeviceDesc:
-      'お使いの端末が直接対応していなくても、ブラウザのQRコードまたは通知を使って、スマートフォンなどを認証器として利用できます。',
-    existingPasskeyTitle: '既存のパスキーでログイン',
-    existingPasskeyDesc:
-      '以前作成したパスキーで再度ログイン。インポートしたNostr Keyの復元は"まだ"サポートされていません',
-    developerSection: '開発者向け',
-    prfDebugInfo: 'PRF拡張確認はデバッグ用途です',
-    prfSupportedMessage: 'PRF拡張がサポートされています',
-    keyInfoImportTitle: 'バックアップした鍵情報でログイン',
-    keyInfoImportDesc: '以前にエクスポートした鍵情報ファイルまたはデータを使用してログインします。',
-    keyInfoFileSelect: '📁鍵情報ファイルを選択',
-    keyDataInput: '鍵情報データを入力',
-    keyDataPlaceholder: '鍵情報データをここに貼り付けてください',
-    keyInfoLoginButton: '鍵情報データでログイン',
-    keyInfoLoginProcessing: '処理中...',
-    orText: 'または',
-    quickStartTitle: 'はじめる',
-    quickStartDesc: '新規ユーザー向けの最も簡単な方法',
-    existingUserTitle: '既存ユーザー',
-    existingUserDesc: '以前に作成したアカウントでログイン',
-    advancedOptionsTitle: '高度なオプション',
-    newUserRecommended: '新規ユーザーにおすすめ',
-    returningUserRecommended: '既存ユーザーにおすすめ',
+    tabLogin: 'ログイン',
+    tabRegister: '新規登録',
+    loginTip:
+      '以前作成したパスキーで再度ログインします。インポートしたNostr鍵の復元は"まだ"サポートされていません。',
+    registerTip:
+      'パスキーは生体認証や端末のセキュリティ機能を使った安全な認証方法です。お使いの端末が直接対応していなくても、QRコードや通知を使ってスマートフォンなどを認証器として利用できます。',
+    usernameTip: 'パスキーの表示名として使われます。任意項目で、未入力でも問題ありません。',
   },
   nostr: {
     publicKey: '公開鍵',
@@ -465,6 +436,23 @@ export const ja: TranslationData = {
       saveFileTitle: 'ファイルに保存',
       noCurrentKeyInfo: '現在の鍵情報が見つかりません。ログイン状態を確認してください。',
     },
+    developer: {
+      title: '開発者向け',
+      description: 'PRF拡張対応の確認はデバッグ用途です。',
+      checkPrf: 'PRF拡張対応確認',
+      prfSupported: 'PRF拡張がサポートされています',
+      prfUnsupportedTitle: 'PRF拡張がサポートされていません',
+    },
+    import: {
+      title: '鍵情報でログイン',
+      description: '以前にエクスポートした鍵情報ファイルまたはデータを使用してログインします。',
+      fileSelect: '📁鍵情報ファイルを選択',
+      dataInput: '鍵情報データを入力',
+      dataPlaceholder: '鍵情報データをここに貼り付けてください',
+      loginButton: '鍵情報データでログイン',
+      processing: '処理中...',
+      or: 'または',
+    },
   },
   navigation: {
     account: 'アカウント',
@@ -549,6 +537,7 @@ export const en: TranslationData = {
     copied: 'Copied',
     loading: 'Loading...',
     edit: 'Edit',
+    help: 'Help',
     errorMessages: {
       init: 'Initialization Error:',
       prfCheck: 'PRF Support Check Error:',
@@ -563,53 +552,28 @@ export const en: TranslationData = {
   auth: {
     title: 'Nosskey Demo',
     subtitle: 'Client using Nosskey',
-    checkPrf: 'Check PRF Extension Support',
-    unsupportedTitle: 'PRF Extension Not Supported',
     createNew: 'Create New',
-    loginWith: 'Login with Existing Passkey',
+    loginWith: 'Login with Passkey',
     login: 'Login',
     loading: 'Loading...',
     username: 'Username (Optional)',
     usernamePlaceholder: 'Enter username',
-    importTitle: 'Import Existing Nostr Key',
-    importSubtitle:
-      'Protect your existing secret key with a passkey. Do not use PRF directly as private key, use PRF for encryption of private key',
     secretKey: 'Nostr Secret Key',
     secretKeyHelp: 'Your secret key is processed locally and never sent to any server',
     importButton: 'Import',
     accountTitle: 'Nostr account',
     appDescription:
       'This app uses passkey authentication to securely manage your Nostr keys. Passkey is cloud-backed by the platform, eliminating the need for cumbersome private key management.',
-    passkeySectionTitle: 'Create Account with Passkey',
-    passkeySectionDesc:
-      'Passkeys are a simple and secure authentication method using biometrics or your device security features.',
-    crossDeviceTitle: 'Available on a wide range of devices',
-    crossDeviceDesc:
-      "Even if your device doesn't directly support it, you can use your smartphone as an authenticator via QR code or browser notification.",
-    existingPasskeyTitle: 'Login with Existing Passkey',
-    existingPasskeyDesc:
-      'Login again with previously created passkey. Recovery of imported Nostr Key is not "yet" supported.',
-    developerSection: 'For Developers',
-    prfDebugInfo: 'PRF extension check is for debugging purposes',
-    prfSupportedMessage: 'PRF extension is supported',
     firstLogin: 'First Login',
     passkeyCreated: 'Passkey Created Successfully',
     proceedWithLogin: 'Proceed with Login',
-    keyInfoImportTitle: 'Login with Backed Up KeyInfo',
-    keyInfoImportDesc: 'Use a previously exported KeyInfo file or data to login.',
-    keyInfoFileSelect: '📁Select KeyInfo File',
-    keyDataInput: 'Enter KeyInfo Data',
-    keyDataPlaceholder: 'Paste your Key data here',
-    keyInfoLoginButton: 'Login with Key Data',
-    keyInfoLoginProcessing: 'Processing...',
-    orText: 'or',
-    quickStartTitle: 'Get Started',
-    quickStartDesc: 'Simplest way for new users',
-    existingUserTitle: 'Returning Users',
-    existingUserDesc: 'Login with previously created account',
-    advancedOptionsTitle: 'Advanced Options',
-    newUserRecommended: 'Recommended for new users',
-    returningUserRecommended: 'Recommended for existing users',
+    tabLogin: 'Login',
+    tabRegister: 'Sign Up',
+    loginTip:
+      'Sign in again with a previously created passkey. Recovery of imported Nostr keys is not "yet" supported.',
+    registerTip:
+      "Passkeys are a secure authentication method using biometrics or your device's security features. Even if your device doesn't directly support it, you can use your smartphone as an authenticator via QR code or browser notification.",
+    usernameTip: 'Used as the display name for your passkey. Optional — you can leave it blank.',
   },
   nostr: {
     publicKey: 'Public Key',
@@ -739,6 +703,23 @@ export const en: TranslationData = {
       saveFile: 'Save',
       saveFileTitle: 'Save to file',
       noCurrentKeyInfo: 'Current KeyInfo not found. Please check your login status.',
+    },
+    developer: {
+      title: 'For Developers',
+      description: 'PRF extension support check is for debugging purposes.',
+      checkPrf: 'Check PRF Extension Support',
+      prfSupported: 'PRF extension is supported',
+      prfUnsupportedTitle: 'PRF Extension Not Supported',
+    },
+    import: {
+      title: 'Login with KeyInfo',
+      description: 'Use a previously exported KeyInfo file or data to login.',
+      fileSelect: '📁Select KeyInfo File',
+      dataInput: 'Enter KeyInfo Data',
+      dataPlaceholder: 'Paste your Key data here',
+      loginButton: 'Login with Key Data',
+      processing: 'Processing...',
+      or: 'or',
     },
   },
   navigation: {

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -36,15 +36,9 @@ export interface TranslationData {
     subtitle: string;
     createNew: string;
     loginWith: string;
-    login: string;
     loading: string;
     username: string;
     usernamePlaceholder: string;
-    secretKey: string;
-    secretKeyHelp: string;
-    importButton: string;
-    accountTitle: string;
-    appDescription: string;
     firstLogin: string;
     passkeyCreated: string;
     proceedWithLogin: string;
@@ -286,19 +280,12 @@ export const ja: TranslationData = {
     subtitle: 'パスキーで保管するNostr秘密鍵を活用したクライアント',
     createNew: '新規作成',
     loginWith: 'パスキーでログイン',
-    login: 'ログイン',
     firstLogin: '初回ログイン',
     passkeyCreated: 'パスキーが作成されました',
     proceedWithLogin: 'ログインして続ける',
     loading: 'ロード中...',
     username: 'ユーザー名',
     usernamePlaceholder: 'ユーザー名を入力',
-    secretKey: 'Nostr秘密鍵',
-    secretKeyHelp: '秘密鍵は設定後にサーバーに送信されず、ブラウザ内で処理されます',
-    importButton: 'インポート',
-    accountTitle: 'Nostrアカウント',
-    appDescription:
-      'このアプリはパスキー認証を使ってNostr鍵を安全に管理します。パスキーはプラットフォームによりクラウドバックアップされるため煩雑な秘密鍵管理が不要となります',
     tabLogin: 'ログイン',
     tabRegister: '新規登録',
     loginTip:
@@ -554,16 +541,9 @@ export const en: TranslationData = {
     subtitle: 'Client using Nosskey',
     createNew: 'Create New',
     loginWith: 'Login with Passkey',
-    login: 'Login',
     loading: 'Loading...',
     username: 'Username (Optional)',
     usernamePlaceholder: 'Enter username',
-    secretKey: 'Nostr Secret Key',
-    secretKeyHelp: 'Your secret key is processed locally and never sent to any server',
-    importButton: 'Import',
-    accountTitle: 'Nostr account',
-    appDescription:
-      'This app uses passkey authentication to securely manage your Nostr keys. Passkey is cloud-backed by the platform, eliminating the need for cumbersome private key management.',
     firstLogin: 'First Login',
     passkeyCreated: 'Passkey Created Successfully',
     proceedWithLogin: 'Proceed with Login',


### PR DESCRIPTION
- Separate the new-registration and login flows into tabs (default: login)
  so first-time visitors see a single primary action.
- Move the rarely-used KeyInfo import to #/key (shown only when logged out)
  and the PRF debug check to #/settings under a developer section.
- Replace long descriptive paragraphs, info-box panels, and recommendation
  badges with a HelpTip component that uses the native ARIA tooltip pattern
  (role="tooltip" + aria-describedby, shown via CSS :hover / :focus-within).
- Reorganize i18n keys: drop unused auth.* keys, add auth.tab*/auth.*Tip,
  common.help, settings.developer.*, settings.import.* in both ja and en.