### PR TITLE
fix(svelte-app): prevent mobile horizontal scroll caused by HelpTip bubble

### DIFF
--- a/examples/svelte-app/src/App.svelte
+++ b/examples/svelte-app/src/App.svelte
@@ -351,6 +351,13 @@ onMount(() => {
     background-color: var(--color-background);
     margin: 0;
     padding: 0;
+    /*
+     * モバイルでは内部要素（ツールチップやはみ出した要素）が原因で
+     * 横スクロールが発生しないよう、body レベルで横方向の overflow を抑止する。
+     * `clip` は新しいスクロールコンテナを作らないため、`position: fixed` の
+     * ヘッダ／フッタやモーダルの挙動に影響しない。
+     */
+    overflow-x: clip;
     transition:
       color 0.3s ease,
       background-color 0.3s ease;

--- a/examples/svelte-app/src/components/screens/AuthScreen.svelte
+++ b/examples/svelte-app/src/components/screens/AuthScreen.svelte
@@ -128,7 +128,7 @@ $effect(() => {
       <CardSection title={$i18n.t.auth.tabLogin}>
         <div class="tab-panel">
           <div class="panel-help">
-            <HelpTip text={$i18n.t.auth.loginTip} />
+            <HelpTip text={$i18n.t.auth.loginTip} placement="end" />
           </div>
 
           <Button onclick={() => login()} disabled={isLoading} size="large">
@@ -140,13 +140,13 @@ $effect(() => {
       <CardSection title={$i18n.t.auth.tabRegister}>
         <div class="tab-panel">
           <div class="panel-help">
-            <HelpTip text={$i18n.t.auth.registerTip} />
+            <HelpTip text={$i18n.t.auth.registerTip} placement="end" />
           </div>
 
           <div class="username-input">
             <div class="username-label-row">
               <label for="username">{$i18n.t.auth.username}</label>
-              <HelpTip text={$i18n.t.auth.usernameTip} />
+              <HelpTip text={$i18n.t.auth.usernameTip} placement="start" />
             </div>
             <input
               id="username"

--- a/examples/svelte-app/src/components/ui/HelpTip.svelte
+++ b/examples/svelte-app/src/components/ui/HelpTip.svelte
@@ -1,11 +1,21 @@
 <script lang="ts">
 import { i18n } from '../../i18n/i18n-store.js';
 
+type Placement = 'center' | 'start' | 'end';
+
 interface Props {
   text: string;
+  /**
+   * バブルをトリガに対してどう揃えるか。
+   * `center` はトリガ中央寄せ（デフォルト）。
+   * `start` はトリガの左端にバブル左端を揃え、右方向へ伸ばす。
+   * `end`   はトリガの右端にバブル右端を揃え、左方向へ伸ばす。
+   * 画面端付近のトリガでビューポート外にはみ出さないよう、呼び出し側で指定する。
+   */
+  placement?: Placement;
 }
 
-const { text }: Props = $props();
+const { text, placement = 'center' }: Props = $props();
 
 // 1コンポーネントインスタンスごとに一意の id を発番し aria-describedby と紐付ける。
 // `crypto.randomUUID()` は古い jsdom テスト環境などで存在しないことがあるため
@@ -20,7 +30,11 @@ const tipId = `help-tip-${globalThis.crypto?.randomUUID?.() ?? Math.random().toS
     aria-describedby={tipId}
     aria-label={$i18n.t.common.help}
   >?</button>
-  <span role="tooltip" id={tipId} class="help-tip__bubble">{text}</span>
+  <span
+    role="tooltip"
+    id={tipId}
+    class="help-tip__bubble help-tip__bubble--{placement}"
+  >{text}</span>
 </span>
 
 <style>
@@ -60,11 +74,15 @@ const tipId = `help-tip-${globalThis.crypto?.randomUUID?.() ?? Math.random().toS
     outline: none;
   }
 
+  /*
+   * 非表示時は `display: none` で layout から完全に外す。
+   * `visibility: hidden` だと scrollable overflow に参加してしまい、
+   * トリガがビューポート右端付近にあるとき横スクロールが発生する。
+   */
   .help-tip__bubble {
+    display: none;
     position: absolute;
     bottom: calc(100% + 6px);
-    left: 50%;
-    transform: translateX(-50%);
     width: max-content;
     max-width: min(240px, calc(100vw - 32px));
     padding: 8px 10px;
@@ -78,18 +96,24 @@ const tipId = `help-tip-${globalThis.crypto?.randomUUID?.() ?? Math.random().toS
     line-height: 1.4;
     text-align: left;
     white-space: normal;
-    opacity: 0;
-    visibility: hidden;
-    pointer-events: none;
-    transition:
-      opacity 0.15s ease,
-      visibility 0.15s ease;
     z-index: 10;
+  }
+
+  .help-tip__bubble--center {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  .help-tip__bubble--start {
+    left: 0;
+  }
+
+  .help-tip__bubble--end {
+    right: 0;
   }
 
   .help-tip:hover .help-tip__bubble,
   .help-tip:focus-within .help-tip__bubble {
-    opacity: 1;
-    visibility: visible;
+    display: block;
   }
 </style>


### PR DESCRIPTION
## Summary

`HelpTip` のツールチップバブルが非表示状態でも layout に参加し続け、モバイル幅でバブルがビューポート外まで張り出すことで Account 画面に横スクロールが発生していました。

### 原因

`HelpTip.svelte` の `.help-tip__bubble` は `position: absolute` + `visibility: hidden` で初期化されていましたが、`visibility: hidden` は scrollable overflow に参加します。トリガが画面右端付近 (`.panel-help` は `justify-content: flex-end`) に来るとバブル (`max-width: 240px`, `translateX(-50%)`) がビューポート右端を超え、body が横スクロール可能になっていました。

## 変更内容

- **`display: none` 切替に変更**：非表示時は layout から完全に除外。表示は `:hover` / `:focus-within` で `display: block`。フェードは失うがネイティブ tooltip と同じ即時切替挙動。
- **`placement` prop を追加** (`center` | `start` | `end`)：トリガ位置に応じてバブルの水平アンカーを切替。
  - `.panel-help` (右端揃え) → `placement="end"`（右端を揃え、左へ伸ばす）
  - `.username-label-row` (左寄り) → `placement="start"`（左端を揃え、右へ伸ばす）
  これでバブル表示時もビューポートを越えません。
- **`:global(body) { overflow-x: clip; }` を追加**：将来のリグレッションでもう横スクロールが出ない安全網。`clip` は新スクロールコンテナを作らないため `position: fixed` の HeaderBar / FooterMenu に影響しません。

## Test plan

- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm run test:coverage` (627 tests pass)
- [x] `npm run check -w svelte-app` (0 errors)
- [ ] 実機 (モバイル幅) で `#/account` 未ログイン状態を開き、横スクロールが発生しないこと
- [ ] ログイン／新規登録タブ両方で `?` をタップしてツールチップが画面内に収まること
- [ ] ライト／ダーク両テーマで色崩れがないこと

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoneLbFDeUSk7NuujjZogu)_