### PR TITLE
fix(svelte-app): align auth card tooltip to title row

### DIFF
--- a/examples/svelte-app/src/components/screens/AuthScreen.svelte
+++ b/examples/svelte-app/src/components/screens/AuthScreen.svelte
@@ -199,6 +199,10 @@ $effect(() => {
     margin-bottom: 32px;
   }
 
+  .hero-section img {
+    border-radius: 16px;
+  }
+
   .screen-title {
     font-size: 2.2rem;
     font-weight: 700;

--- a/examples/svelte-app/src/components/screens/AuthScreen.svelte
+++ b/examples/svelte-app/src/components/screens/AuthScreen.svelte
@@ -189,10 +189,16 @@ $effect(() => {
 
 <style>
   .auth-container {
-    max-width: 640px;
+    max-width: 700px;
     margin: 0 auto;
     padding: 20px;
     text-align: center;
+  }
+
+  @media (max-width: 600px) {
+    .auth-container {
+      padding: 12px 8px;
+    }
   }
 
   .hero-section {
@@ -251,7 +257,6 @@ $effect(() => {
     border: 1px solid var(--color-border);
     border-radius: 10px;
     margin: 0 auto 20px;
-    max-width: 360px;
   }
 
   .auth-tabs :global(.auth-tab) {
@@ -259,7 +264,7 @@ $effect(() => {
   }
 
   .tab-panel {
-    text-align: left;
+    text-align: center;
   }
 
   .username-input {
@@ -342,10 +347,6 @@ $effect(() => {
   }
 
   @media (max-width: 480px) {
-    .auth-container {
-      padding: 15px 10px;
-    }
-
     .screen-title {
       font-size: 1.8rem;
     }

--- a/examples/svelte-app/src/components/screens/AuthScreen.svelte
+++ b/examples/svelte-app/src/components/screens/AuthScreen.svelte
@@ -126,11 +126,10 @@ $effect(() => {
 
     {#if activeTab === "login"}
       <CardSection title={$i18n.t.auth.tabLogin}>
+        {#snippet titleAside()}
+          <HelpTip text={$i18n.t.auth.loginTip} placement="end" />
+        {/snippet}
         <div class="tab-panel">
-          <div class="panel-help">
-            <HelpTip text={$i18n.t.auth.loginTip} placement="end" />
-          </div>
-
           <Button onclick={() => login()} disabled={isLoading} size="large">
             {$i18n.t.auth.loginWith}
           </Button>
@@ -138,11 +137,10 @@ $effect(() => {
       </CardSection>
     {:else}
       <CardSection title={$i18n.t.auth.tabRegister}>
+        {#snippet titleAside()}
+          <HelpTip text={$i18n.t.auth.registerTip} placement="end" />
+        {/snippet}
         <div class="tab-panel">
-          <div class="panel-help">
-            <HelpTip text={$i18n.t.auth.registerTip} placement="end" />
-          </div>
-
           <div class="username-input">
             <div class="username-label-row">
               <label for="username">{$i18n.t.auth.username}</label>
@@ -258,12 +256,6 @@ $effect(() => {
 
   .tab-panel {
     text-align: left;
-  }
-
-  .panel-help {
-    display: flex;
-    justify-content: flex-end;
-    margin: 0 0 8px 0;
   }
 
   .username-input {

--- a/examples/svelte-app/src/components/ui/CardSection.svelte
+++ b/examples/svelte-app/src/components/ui/CardSection.svelte
@@ -6,13 +6,19 @@ interface Props {
   title: string;
   compact?: boolean;
   children?: Snippet;
+  titleAside?: Snippet;
 }
 
-const { title, compact = false, children }: Props = $props();
+const { title, compact = false, children, titleAside }: Props = $props();
 </script>
 
 <div class="card-section" class:compact>
-  <h2>{title}</h2>
+  <div class="card-section__header">
+    <h2>{title}</h2>
+    {#if titleAside}
+      <span class="card-section__aside">{@render titleAside()}</span>
+    {/if}
+  </div>
   {@render children?.()}
 </div>
 
@@ -46,8 +52,27 @@ const { title, compact = false, children }: Props = $props();
     }
   }
 
-  h2 {
+  .card-section__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
     margin-bottom: 10px;
+  }
+
+  .card-section.compact .card-section__header {
+    margin-bottom: 8px;
+  }
+
+  .card-section__aside {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  h2 {
+    margin: 0;
+    min-width: 0;
     font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     font-size: 0.8rem;
     font-weight: 600;
@@ -55,9 +80,5 @@ const { title, compact = false, children }: Props = $props();
     color: var(--color-text-secondary);
     text-align: left;
     transition: color 0.3s ease;
-  }
-
-  .card-section.compact h2 {
-    margin-bottom: 8px;
   }
 </style>

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -276,8 +276,8 @@ export const ja: TranslationData = {
     prfCompatibility: '一部の端末・環境はサポートされていません。',
   },
   auth: {
-    title: 'Nosskey デモ',
-    subtitle: 'パスキーで保管するNostr秘密鍵を活用したクライアント',
+    title: 'Nosskey',
+    subtitle: 'Nostrアカウントをパスキーで',
     createNew: '新規作成',
     loginWith: 'パスキーでログイン',
     firstLogin: '初回ログイン',
@@ -288,8 +288,7 @@ export const ja: TranslationData = {
     usernamePlaceholder: 'ユーザー名を入力',
     tabLogin: 'ログイン',
     tabRegister: '新規登録',
-    loginTip:
-      '以前作成したパスキーで再度ログインします。インポートしたNostr鍵の復元は"まだ"サポートされていません。',
+    loginTip: '以前作成したパスキーで再度ログインします',
     registerTip:
       'パスキーは生体認証や端末のセキュリティ機能を使った安全な認証方法です。お使いの端末が直接対応していなくても、QRコードや通知を使ってスマートフォンなどを認証器として利用できます。',
     usernameTip: 'パスキーの表示名として使われます。任意項目で、未入力でも問題ありません。',
@@ -537,8 +536,8 @@ export const en: TranslationData = {
     prfCompatibility: 'Some devices and environments are not supported.',
   },
   auth: {
-    title: 'Nosskey Demo',
-    subtitle: 'Client using Nosskey',
+    title: 'Nosskey',
+    subtitle: 'Your Nostr account, with a passkey',
     createNew: 'Create New',
     loginWith: 'Login with Passkey',
     loading: 'Loading...',
@@ -549,8 +548,7 @@ export const en: TranslationData = {
     proceedWithLogin: 'Proceed with Login',
     tabLogin: 'Login',
     tabRegister: 'Sign Up',
-    loginTip:
-      'Sign in again with a previously created passkey. Recovery of imported Nostr keys is not "yet" supported.',
+    loginTip: 'Sign in again with a previously created passkey',
     registerTip:
       "Passkeys are a secure authentication method using biometrics or your device's security features. Even if your device doesn't directly support it, you can use your smartphone as an authenticator via QR code or browser notification.",
     usernameTip: 'Used as the display name for your passkey. Optional — you can leave it blank.',


### PR DESCRIPTION
ログイン/新規登録カードの右上 HelpTip がタイトル直下の別行に
配置されていたため、タイトル下に不自然な空白ができ、何の説明か
分かりにくかった。CardSection に titleAside Snippet スロットを
追加し、タイトル行に flex で並べるよう変更。AuthScreen 側は
.panel-help ラッパを廃止して titleAside snippet 経由で渡す。