### PR TITLE
fix(svelte-app): stretch auth-container in flex column parent

### DIFF
--- a/examples/svelte-app/src/components/screens/AuthScreen.svelte
+++ b/examples/svelte-app/src/components/screens/AuthScreen.svelte
@@ -190,7 +190,9 @@ $effect(() => {
 <style>
   .auth-container {
     max-width: 700px;
-    margin: 0 auto;
+    /* 親 .account-screen は flex column のため、cross-axis に auto margin を置くと
+       free space を吸収して shrink-to-fit になる。stretch に任せるため 0 にする。 */
+    margin: 0;
     padding: 20px;
     text-align: center;
   }


### PR DESCRIPTION
## Summary

PR #85 でカードを `max-width: 700px` に拡幅したつもりだったが、ユーザー報告で「サブタイトル『Nostrアカウントをパスキーで』の文字幅までカードの幅が狭くなっている」状態が続いていた。

### 原因

`AuthScreen.svelte` の `.auth-container` は親 `AccountScreen.svelte` の `.account-screen` (`display: flex; flex-direction: column`) の中で **flex item** として配置される。この文脈では cross-axis に `margin: 0 auto` を置くと free space を auto margin が吸収し、`align-items: stretch` (デフォルト) が無効化されて **shrink-to-fit** になる（CSS Flexbox Level 1 §8.1 Aligning with auto margins）。結果、`max-width: 700px` は効かず、コンテナはサブタイトル文字幅まで縮退していた。

### 修正

`.auth-container { margin: 0 auto }` → `margin: 0` に変更（1 文字単位）。
`align-items: stretch` (デフォルト) に任せることで親の content-box (660px) まで広がり、自身の `max-width: 700px` で頭打ちになる。

将来 AccountScreen 側を block に戻したり `align-items: center` に変えると再発するため、意図を CSS コメントで明記。

## 検証

playwright で実測（dev server `http://localhost:5173/`）:

| Viewport | `.auth-container` width (before → after) | `.card-section` width (before → after) |
|---|---|---|
| 1280px (PC) | 364px → **700px** | 324px → **660px** |
| 375px (mobile) | 290px → **335px** | 274px → **319px** |

## Test plan

- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm run test:coverage` (148 tests pass)
- [x] `npm run check -w svelte-app` (0 errors)
- [x] playwright で PC/モバイル両 viewport のレイアウトを実測
- [ ] 実機ブラウザでログイン/新規登録両タブの見た目を最終確認

## Follow-up（任意）

`AccountScreen.svelte` の `.account-screen` が flex column で子要素を stretch する暗黙仕様に依存している点は、`align-items: stretch` を明示するか、block + `gap` 相当に置き換える方が設計上は綺麗。本 PR の範囲外として残す。


---
_Generated by [Claude Code](https://claude.ai/code/session_016bjPmhS7kru3TvC63Vjnyx)_