### PR TITLE
chore: add snapshot skill and require it for UI-changing tasks

### DIFF
--- a/.claude/skills/snapshot/SKILL.md
+++ b/.claude/skills/snapshot/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: snapshot
+description: >
+  examples/svelte-app の dev サーバーを起動し、playwright で PC とモバイル両 viewport の
+  スクリーンショットを撮影してユーザーに送る。UI 変更後の見た目確認や、
+  before/after の証跡が必要なときに使う。
+  オプションでルート以外のパス指定や、特定セレクタの computed style 検査も可能。
+  「スクショ撮って」「見た目確認したい」「ヒーロー画像どう見える？」等で起動。
+---
+
+# UI Snapshot Skill
+
+## 用途
+
+examples/svelte-app の UI 変更を視覚的に確認する。test/build がグリーンでも
+レイアウト崩れは検出できないため、レイアウト・スタイル変更時は本スキルで実画を確認する。
+
+## 手順
+
+### 1. dev サーバーを起動
+
+```bash
+cd /home/user/nosskey-sdk && npm run dev -w svelte-app
+```
+
+`run_in_background: true` で起動し、出力ファイルパスを記録。
+
+### 2. ready を待つ
+
+```bash
+until grep -q "Local:" <output_file>; do sleep 0.5; done
+```
+
+Vite が `Local: http://localhost:5173/` を出したら準備完了。
+
+### 3. playwright スクリプトを実行
+
+playwright は `/opt/node22/lib/node_modules/playwright` にグローバル配置されているため、
+CommonJS で絶対パス require する必要がある。スクリプトは `/tmp/snapshot.cjs` に書く:
+
+```javascript
+const { chromium } = require('/opt/node22/lib/node_modules/playwright');
+(async () => {
+  const browser = await chromium.launch();
+  const url = process.env.SNAP_URL || 'http://localhost:5173/';
+  const viewports = [
+    { name: 'pc', width: 1280, height: 900 },
+    { name: 'mobile', width: 375, height: 800 },
+  ];
+  for (const vp of viewports) {
+    const page = await browser.newPage({ viewport: { width: vp.width, height: vp.height } });
+    await page.goto(url);
+    await page.waitForLoadState('networkidle');
+    await page.screenshot({ path: `/tmp/snap-${vp.name}.png`, fullPage: true });
+    await page.close();
+  }
+  await browser.close();
+  console.log('done');
+})();
+```
+
+実行:
+
+```bash
+node /tmp/snapshot.cjs
+```
+
+### 4. ユーザーに送る
+
+`SendUserFile` で `/tmp/snap-pc.png` と `/tmp/snap-mobile.png` を送る。
+caption に「PC (1280px) / モバイル (375px)」のように viewport を明記。
+
+### 5. dev サーバーを停止
+
+```bash
+kill %1 2>/dev/null  # または ps + kill <pid>
+```
+
+バックグラウンドプロセスの ID は Bash 起動時に表示される。
+
+## オプション: computed style 検査
+
+レイアウト崩れの原因調査時は viewport ごとに対象セレクタの bounding box と
+computed style を dump すると有効。`/tmp/inspect.cjs` を以下のテンプレートで:
+
+```javascript
+const { chromium } = require('/opt/node22/lib/node_modules/playwright');
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await page.goto('http://localhost:5173/');
+  await page.waitForLoadState('networkidle');
+  const dump = async (sel, label) => {
+    const r = await page.evaluate((s) => {
+      const el = document.querySelector(s);
+      if (!el) return null;
+      const rect = el.getBoundingClientRect();
+      const cs = getComputedStyle(el);
+      return {
+        width: Math.round(rect.width),
+        left: Math.round(rect.left),
+        maxWidth: cs.maxWidth,
+        display: cs.display,
+        padding: cs.padding,
+        margin: cs.margin,
+        alignItems: cs.alignItems,
+        flexDirection: cs.flexDirection,
+        textAlign: cs.textAlign,
+      };
+    }, sel);
+    console.log(label + ':', JSON.stringify(r));
+  };
+  // 調査対象セレクタを並べる
+  await dump('#app', '#app');
+  await dump('.account-screen', 'account-screen');
+  await dump('.auth-container', 'auth-container');
+  await browser.close();
+})();
+```
+
+`width: 364` のように期待と乖離した値が出れば、margin/display/parent の
+flex 設定など複合要因を疑う。本リポジトリでは過去に flex column 親内の
+`margin: 0 auto` が auto margin として作用し shrink-to-fit に転倒した実例あり
+(PR #86)。
+
+## 注意
+
+- `npm run dev -w svelte-app` の代わりに `cd examples/svelte-app && npm run dev` も可。
+- 既に dev サーバーが起動中なら起動をスキップ (`curl -s http://localhost:5173/` で確認)。
+- スクショは `fullPage: true` 推奨。スクロール下のレイアウトも捕捉できる。
+- 認証や特定状態が必要なら `page.evaluate` で localStorage を設定するか
+  `page.click` で UI 経由でセットアップしてから screenshot を撮る。
+- 撮影後は必ず dev サーバーを停止。長時間放置するとポート 5173 を占有し続ける。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,3 +12,7 @@ npm run check -w svelte-app
 ## タスク完了前レビュー
 
 実装・修正系タスクの完了報告前に、必ず `skeptical-reviewer` サブエージェントを Task ツールで呼び出すこと。レビュー結果の 🔴 要対応 が 0 件になるまで完了報告しない。
+
+## UI 変更時のスクリーンショット確認
+
+`examples/svelte-app/` 配下の Svelte / CSS / 画像アセットを変更したタスクの完了報告前に、必ず `snapshot` スキルを呼び出して PC とモバイル両 viewport の実画を撮影し、ユーザーに送ること。test / build / svelte-check がグリーンでもレイアウト崩れ・はみ出し・余白の異常は検出できないため、視覚確認を必須とする。


### PR DESCRIPTION
## Summary

dev サーバー起動 → playwright で PC / モバイル両 viewport のスクリーンショット撮影 → ユーザー送付、という一連の UI 確認フローを再利用可能なスキル (`.claude/skills/snapshot/SKILL.md`) として登録。あわせて `CLAUDE.md` に「UI 変更を伴うタスクの完了報告前に必ず本スキルを呼ぶ」ルールを追記。

PR #86 のレイアウト調査で使った手順をそのままテンプレートとして保存しています。

## 内容

### `.claude/skills/snapshot/SKILL.md`

- dev サーバー起動（`npm run dev -w svelte-app`）と ready 検知（`grep -q "Local:"` ループ）
- playwright スクリプト（CommonJS、`/opt/node22/lib/node_modules/playwright` 絶対パス require）
- 複数 viewport（PC 1280px / モバイル 375px）の full page screenshot
- オプション: 対象セレクタの bounding box + computed style dump（レイアウト崩れ調査用）
- 撤収時の dev サーバー停止手順

### `CLAUDE.md` に追記

「UI 変更時のスクリーンショット確認」セクション。`examples/svelte-app/` 配下の Svelte / CSS / 画像を変更したタスクの完了報告前に snapshot スキル呼び出しを必須化。`skeptical-reviewer` ルールと同列の扱い。

## 起動

「スクショ撮って」「見た目確認したい」等の自然言語、または skills の自動マッチで起動。

## Test plan

- [x] `SKILL.md` が `available-skills` リストに反映されることをセッション再ロードで確認済み
- [ ] 次回 UI 変更タスクで実際に呼び出して動作確認
