### PR TITLE
feat(svelte-app): default auth tab based on prior-login history

### DIFF
--- a/examples/svelte-app/src/components/screens/AuthScreen.svelte
+++ b/examples/svelte-app/src/components/screens/AuthScreen.svelte
@@ -17,7 +17,7 @@ let errorMessage = $state('');
 let username = $state('');
 let createdCredentialId = $state('');
 let isPasskeyCreated = $state(false);
-let activeTab = $state<AuthTab>('login');
+let activeTab = $state<AuthTab>(appState.hasLoggedInBefore() ? 'login' : 'register');
 
 const keyManager = getNosskeyManager();
 
@@ -74,6 +74,7 @@ async function login(credentialId?: string) {
     const pubKey = await keyManager.getPublicKey();
     appState.publicKey.set(pubKey);
     appState.isLoggedIn.set(true);
+    appState.markLoggedInBefore();
 
     appState.currentScreen.set('account');
   } catch (error) {

--- a/examples/svelte-app/src/store/app-state.ts
+++ b/examples/svelte-app/src/store/app-state.ts
@@ -311,6 +311,23 @@ export function reloadSettings(): void {
   }
 }
 
+const HAS_LOGGED_IN_BEFORE_KEY = 'nosskey_has_logged_in_before';
+
+/**
+ * ログアウトを跨いで残る「過去ログイン履歴」フラグ。
+ * 鍵情報 (`nosskey_pwk`) と独立しているため `clearStoredKeyInfo` の影響を受けない。
+ * 認証画面のデフォルトタブ判定 (新規 → register / 再訪 → login) に使う。
+ */
+export function hasLoggedInBefore(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.localStorage.getItem(HAS_LOGGED_IN_BEFORE_KEY) === 'true';
+}
+
+export function markLoggedInBefore(): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(HAS_LOGGED_IN_BEFORE_KEY, 'true');
+}
+
 // リセット関数
 export const resetState = () => {
   currentScreen.set('account');


### PR DESCRIPTION
新規ユーザーには「新規登録」、過去にログイン経験があるユーザー（ログアウト後の
再訪）には「ログイン」をデフォルトタブとして表示する。`nosskey_pwk` はログアウト
時にクリアされるため、それと独立した `nosskey_has_logged_in_before` フラグを
localStorage に持たせて履歴を保持する。

https://claude.ai/code/session_01NErfD2hj5XvVAXmECi6LYy