### PR TITLE
style(svelte-app): add Japanese sans-serif fallback to CardSection title

### DIFF
--- a/examples/svelte-app/src/components/ui/CardSection.svelte
+++ b/examples/svelte-app/src/components/ui/CardSection.svelte
@@ -73,7 +73,8 @@ const { title, compact = false, children, titleAside }: Props = $props();
   h2 {
     margin: 0;
     min-width: 0;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Hiragino Sans",
+      "Yu Gothic UI", Meiryo, sans-serif;
     font-size: 0.8rem;
     font-weight: 600;
     letter-spacing: 0.04em;


### PR DESCRIPTION
The h2 stack used only Latin monospace fonts, so Japanese card titles
(「鍵管理」「リレー設定」etc.) fell through to the OS default monospace
and rendered poorly. Append Hiragino Sans / Yu Gothic UI / Meiryo /
sans-serif so per-glyph fallback keeps Latin in monospace while Japanese
picks up the system sans-serif.