### PR TITLE
fix(sdk): set residentKey on NosskeySDK.createPasskey to surface Google Password Manager

### DIFF
--- a/packages/nosskey-sdk/src/nosskey.spec.ts
+++ b/packages/nosskey-sdk/src/nosskey.spec.ts
@@ -169,6 +169,8 @@ describe('NosskeyManager', () => {
           rpId: 'example.com',
           timeout: 60000,
           userVerification: 'preferred',
+          residentKey: 'required',
+          requireResidentKey: true,
         },
         hexToBytes('6e6f7374722d70776b')
       );
@@ -250,6 +252,8 @@ describe('NosskeyManager', () => {
           rpId: 'example.com',
           timeout: 60000,
           userVerification: 'preferred',
+          residentKey: 'required',
+          requireResidentKey: true,
         },
         hexToBytes('6e6f7374722d70776b')
       );
@@ -313,6 +317,8 @@ describe('NosskeyManager', () => {
           rpId: 'example.com',
           timeout: 60000,
           userVerification: 'preferred',
+          residentKey: 'required',
+          requireResidentKey: true,
         },
         hexToBytes('6e6f7374722d70776b')
       );

--- a/packages/nosskey-sdk/src/nosskey.ts
+++ b/packages/nosskey-sdk/src/nosskey.ts
@@ -69,10 +69,17 @@ export class NosskeyManager implements NosskeyManagerLike {
 
     // 重要なoptionなので外れないようにデフォルト値を設定
     const userVerification = options?.prfOptions?.userVerification ?? 'required';
+    const residentKey = options?.prfOptions?.residentKey ?? 'required';
+    const requireResidentKey = options?.prfOptions?.requireResidentKey ?? true;
     if (options?.prfOptions) {
-      this.#prfOptions = { ...options.prfOptions, userVerification };
+      this.#prfOptions = {
+        ...options.prfOptions,
+        userVerification,
+        residentKey,
+        requireResidentKey,
+      };
     } else {
-      this.#prfOptions = { userVerification };
+      this.#prfOptions = { userVerification, residentKey, requireResidentKey };
     }
 
     // ストレージが有効な場合、NostrKeyInfoの読み込みを試みる
@@ -298,15 +305,12 @@ export class NosskeyManager implements NosskeyManagerLike {
         name: this.#prfOptions.rpId,
       },
       authenticatorSelection: {
-        // residentKey / requireResidentKey を必ず付ける。これが無いと
-        // Android Chrome の Credential Manager は Google パスワード
-        // マネージャーを候補から外し、「この端末」だけが表示される
-        // （passkeys-debugger.io との差分で確認）。prf-handler 側にも
-        // 同名のデフォルトはあるが、ここで authenticatorSelection オブジェクト
-        // を作って渡してしまうとあちらの `||` フォールバックが効かないため、
-        // ラッパ側で揃える必要がある。
-        residentKey: 'required',
-        requireResidentKey: true,
+        // 既定値は #prfOptions 側でコンストラクタ時に解決済み
+        // （residentKey='required' / requireResidentKey=true / userVerification='required'）。
+        // これらは Android Chrome の Credential Manager で Google Password
+        // Manager を候補プロバイダに出すための条件として必須。
+        residentKey: this.#prfOptions.residentKey,
+        requireResidentKey: this.#prfOptions.requireResidentKey,
         userVerification: this.#prfOptions.userVerification,
       },
       ...options,

--- a/packages/nosskey-sdk/src/nosskey.ts
+++ b/packages/nosskey-sdk/src/nosskey.ts
@@ -298,6 +298,15 @@ export class NosskeyManager implements NosskeyManagerLike {
         name: this.#prfOptions.rpId,
       },
       authenticatorSelection: {
+        // residentKey / requireResidentKey を必ず付ける。これが無いと
+        // Android Chrome の Credential Manager は Google パスワード
+        // マネージャーを候補から外し、「この端末」だけが表示される
+        // （passkeys-debugger.io との差分で確認）。prf-handler 側にも
+        // 同名のデフォルトはあるが、ここで authenticatorSelection オブジェクト
+        // を作って渡してしまうとあちらの `||` フォールバックが効かないため、
+        // ラッパ側で揃える必要がある。
+        residentKey: 'required',
+        requireResidentKey: true,
         userVerification: this.#prfOptions.userVerification,
       },
       ...options,

--- a/packages/nosskey-sdk/src/types.ts
+++ b/packages/nosskey-sdk/src/types.ts
@@ -61,6 +61,17 @@ export interface GetPrfSecretOptions {
   timeout?: number;
   /** ユーザー検証要件 */
   userVerification?: UserVerificationRequirement;
+  /**
+   * パスキー作成時の residentKey 要件（createPasskey 時のみ使用）。
+   * Android Chrome の Credential Manager で Google Password Manager を
+   * 候補プロバイダに出すためには 'required' が必須。
+   */
+  residentKey?: ResidentKeyRequirement;
+  /**
+   * パスキー作成時の requireResidentKey 要件（createPasskey 時のみ使用）。
+   * WebAuthn L2 以前の実装は residentKey ではなくこちらを見るため新旧併用。
+   */
+  requireResidentKey?: boolean;
 }
 
 /**


### PR DESCRIPTION
## 概要

Android Chrome のパスキー選択 UI で **Google Password Manager が候補に出てこず、「この端末」しか選択肢にならない**問題の修正。

## 真因

Production のリクエストログを見ると `navigator.credentials.create()` に届く `authenticatorSelection` が `{ userVerification: 'required' }` だけで、`residentKey` / `requireResidentKey` が抜けていた。

`NosskeyManager.createPasskey` (wrapper) が独自に `authenticatorSelection` オブジェクトを組み立てて inner `createPasskey()` に渡していたため、inner 側の `options.authenticatorSelection || {…defaults…}` フォールバックが**truthy なオブジェクト**で短絡され、residentKey 系のデフォルトが完全に消えていた。

passkeys-debugger.io との設定差分を 1 つずつ比較した結果、Google Password Manager を Credential Manager の候補プロバイダに上げる条件は `residentKey: 'required'` + `requireResidentKey: true` を**実際に request まで届ける**こと、と判明。

## 変更

- `NosskeyManager.createPasskey` の `authenticatorSelection` に `residentKey` と `requireResidentKey` を明示
- それらを `userVerification` と同じく `prfOptions` 経由で解決するように整理（デフォルト `'required'` / `true`、呼び出し側から上書き可能）
- `GetPrfSecretOptions` に 2 フィールド追加（create 時のみ使用される旨を JSDoc に明記）
- 既存テスト 3 箇所の `getPrfSecret` expect を新フィールド対応

デフォルト値は production の従来挙動と一致させているので **動作変更なし**。

## Test plan

- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm run test:coverage` (303 passed)
- [x] `npm run check -w svelte-app`
- [ ] Android Chrome 実機で新規登録 → パスキー選択 UI に「Google Password Manager」が出るか確認

https://claude.ai/code/session_01Y6eRajd7BVKHeFhKipBQc4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6eRajd7BVKHeFhKipBQc4)_