### PR TITLE
chore(svelte-app): TODO 整理（エクスポートバグ修正・ラベル簡潔化・削除ボタンのアイコン統一）

### DIFF
--- a/examples/svelte-app/TODO.md
+++ b/examples/svelte-app/TODO.md
@@ -30,8 +30,6 @@
 
 ## P3: 長期・将来
 
-- [ ] **新規登録タブのラベルを簡潔にする** — 「パスキーを新規作成」「既存 nsec をインポート（ベータ版）」が冗長。「新規作成」「インポート（ベータ版）」程度に短縮する（`AuthScreen.svelte` の `methodNew` / `methodImport` タブ、i18n ja/en）。
-- [ ] **削除ボタンをゴミ箱アイコンに統一する** — PR #94 で保存済みアカウント一覧の削除は Material のゴミ箱アイコン（`IconButton` + `delete-icon.svg`）化済み。他の削除系ボタン（設定の信頼済みオリジン削除・リレー削除等のテキストボタン）も同じゴミ箱アイコンに揃える。
 - [ ] **秘密鍵紛失時の回復方法についての説明を追加する**
 - [ ] **Windows（Edge）での動作をテストする**
 - [ ] **Windows についての注意書きを追加する**
@@ -42,7 +40,11 @@
 ## アーカイブ
 
 ### P2（中期）
-- [x] **「鍵情報をエクスポート」が動作しないバグの修正** — `ExportKeyInfoComponent.svelte:44` で `JSON.stringify(exportKeyInfo, ...)` と **関数 `exportKeyInfo` 自身**を直列化していたのを、32 行目で取得済みの `currentKeyInfo`（`NostrKeyInfo`）を直列化するよう修正。インポート側（`ImportKeyInfo.svelte`）は `JSON.parse` → `isNostrKeyInfo` 検証 → `loginWith` 経路のため往復成立。
+- [x] **「鍵情報をエクスポート」が動作しないバグの修正** — `ExportKeyInfoComponent.svelte:44` で `JSON.stringify(exportKeyInfo, ...)` と **関数 `exportKeyInfo` 自身**を直列化していたのを、32 行目で取得済みの `currentKeyInfo`（`NostrKeyInfo`）を直列化するよう修正。直列化ロジックを純粋関数 `utils/key-info-export.ts`（`serializeKeyInfoForExport`）へ切り出し、`isNostrKeyInfo` との往復検証 spec を追加して回帰防止。インポート側（`ImportKeyInfo.svelte`）は `JSON.parse` → `isNostrKeyInfo` 検証 → `loginWith` 経路のため往復成立。
+
+### P3（長期・将来）
+- [x] **新規登録タブのラベルを簡潔にする** — `methodNew`「パスキーを新規作成」→「新規作成」、`methodImport`「既存nsecをインポート（ベータ版）」→「インポート（ベータ版）」に短縮（ja/en）。
+- [x] **削除ボタンをゴミ箱アイコンに統一する** — 設定のリレー削除（`RelaySettings.svelte`）・信頼済みオリジン削除（`TrustedOriginsSettings.svelte` の origin 全削除／メソッド別削除）のテキストボタンを、`SavedAccounts.svelte` と同じ `IconButton` + `delete-icon.svg` に統一。
 
 ### P1（リリース前推奨）
 - [x] **ログアウト後の wrap モード鍵で再ログインできるようにする** — PR #94 で対応。ログアウトを「current ポインタ（`nosskey_pwk`）＋派生キャッシュのみ消去」に変更し、別キー `nosskey_accounts` のアプリ内マルチアカウント登録簿（`store/accounts.ts`: upsert/remove/list ＋ salt 正規化 ＋ 既存 current 鍵の一度きり移行）は保持するようにした。これにより wrap モード鍵（暗号化 nsec が localStorage にしか無い）も失われず再ログイン可能。`logout()` 後は `hasKeyInfo()` が false になり無言の自動ログインを防止。`loginWith()`（新規作成 / nsec インポート / KeyInfo ファイルインポート / 保存済みアカウント再ログインの共通活性化経路）で復元。`SavedAccounts.svelte` がログインタブ上部に保存済みアカウント一覧（再ログイン＋5秒キャンセル可能な削除）を表示。影響ファイル: `store/accounts.ts`（新規）・`store/app-state.ts`・`components/SavedAccounts.svelte`（新規）・`components/screens/AuthScreen.svelte`・`components/settings/ImportKeyInfo.svelte`。`accounts.spec.ts` 追加。

--- a/examples/svelte-app/TODO.md
+++ b/examples/svelte-app/TODO.md
@@ -22,7 +22,6 @@
 
 ## P2: 中期で取り組む
 
-- [ ] **「鍵情報をエクスポート」が動作しないバグの修正** — 設定画面の鍵情報エクスポートが動作していない。原因は `examples/svelte-app/src/components/settings/ExportKeyInfoComponent.svelte:44` で `JSON.stringify(exportKeyInfo, null, 2)` と **関数 `exportKeyInfo` 自身**を直列化しており、`currentKeyInfo`（32 行目で取得済み）を渡せていないこと。`JSON.stringify(currentKeyInfo, null, 2)` に修正する。修正後はインポート側（`ImportKeyInfo.svelte`）との往復で検証すること。
 - [ ] **新規パスキー作成時にパスキー認証が 2 回要求される問題の調査・修正** — 新規作成タブは `createNew()`（`AuthScreen.svelte` の `createPasskey()` = WebAuthn `create`）でパスキー作成後、成功画面で改めて「ログイン」ボタン → `login(credentialId)`（`createNostrKey()` = WebAuthn `get`/PRF）を押す 2 ステップ。既存 nsec インポート経路（`importExisting()` → `createPasskey()` → `importNostrKey()`）は `createPasskey` 時の PRF が `#pendingPrfByCredId` にキャッシュされ消費されるため UV 1 回・1 ステップで完了する。新規作成側でも create 時の標準 salt PRF を消費して 2 回目の `get` を省けるか（＝ create→createNostrKey を 1 ボタンに統合できるか）を検証する。`createPasskey` が PRF 結果を返さないブラウザがある場合はフォールバックが必要なので、ブラウザ依存の切り分けも行う。
 - [ ] **テーマを 2 種類から 4 種類に増やす** — 現状 `ThemeMode = 'light' | 'dark' | 'auto'`（`app-state.ts:59`。実テーマは light/dark の 2 種、auto は OS 追従）。選択可能なカラーテーマを 4 種類に拡張する。`ThemeMode` 型・`currentTheme` ストア・`loadThemeSetting()`（`app-state.ts:131` の許容値チェック）・テーマ適用ロジック・CSS variables（テーマ別カラーセット）・`theme-settings.svelte` の UI・i18n ラベル・iframe へ渡す `?theme=` クエリパラメータ（`NosskeyIframeClient` / `buildIframeUrl` と受信側 `app-state.ts:222`）の許容値もあわせて更新が必要。
 - [ ] **テストの充実** — Vitest の追加導入は完了済み (`vitest.config.ts` 等)。今後は store / service レイヤと画面遷移のカバレッジ拡充。
@@ -41,6 +40,9 @@
 ---
 
 ## アーカイブ
+
+### P2（中期）
+- [x] **「鍵情報をエクスポート」が動作しないバグの修正** — `ExportKeyInfoComponent.svelte:44` で `JSON.stringify(exportKeyInfo, ...)` と **関数 `exportKeyInfo` 自身**を直列化していたのを、32 行目で取得済みの `currentKeyInfo`（`NostrKeyInfo`）を直列化するよう修正。インポート側（`ImportKeyInfo.svelte`）は `JSON.parse` → `isNostrKeyInfo` 検証 → `loginWith` 経路のため往復成立。
 
 ### P1（リリース前推奨）
 - [x] **ログアウト後の wrap モード鍵で再ログインできるようにする** — PR #94 で対応。ログアウトを「current ポインタ（`nosskey_pwk`）＋派生キャッシュのみ消去」に変更し、別キー `nosskey_accounts` のアプリ内マルチアカウント登録簿（`store/accounts.ts`: upsert/remove/list ＋ salt 正規化 ＋ 既存 current 鍵の一度きり移行）は保持するようにした。これにより wrap モード鍵（暗号化 nsec が localStorage にしか無い）も失われず再ログイン可能。`logout()` 後は `hasKeyInfo()` が false になり無言の自動ログインを防止。`loginWith()`（新規作成 / nsec インポート / KeyInfo ファイルインポート / 保存済みアカウント再ログインの共通活性化経路）で復元。`SavedAccounts.svelte` がログインタブ上部に保存済みアカウント一覧（再ログイン＋5秒キャンセル可能な削除）を表示。影響ファイル: `store/accounts.ts`（新規）・`store/app-state.ts`・`components/SavedAccounts.svelte`（新規）・`components/screens/AuthScreen.svelte`・`components/settings/ImportKeyInfo.svelte`。`accounts.spec.ts` 追加。

--- a/examples/svelte-app/src/components/settings/ExportKeyInfoComponent.svelte
+++ b/examples/svelte-app/src/components/settings/ExportKeyInfoComponent.svelte
@@ -41,7 +41,7 @@ async function exportKeyInfo() {
 
   try {
     // 鍵情報をJSON文字列に変換
-    exportedKeyInfo = JSON.stringify(exportKeyInfo, null, 2);
+    exportedKeyInfo = JSON.stringify(currentKeyInfo, null, 2);
   } catch (error) {
     console.error('KeyInfoエクスポートエラー:', error);
     exportError = `エクスポートエラー: ${error instanceof Error ? error.message : String(error)}`;

--- a/examples/svelte-app/src/components/settings/ExportKeyInfoComponent.svelte
+++ b/examples/svelte-app/src/components/settings/ExportKeyInfoComponent.svelte
@@ -2,13 +2,13 @@
 import CopyIcon from '../../assets/copy-icon.svg';
 import { i18n } from '../../i18n/i18n-store.js';
 import { getNosskeyManager } from '../../services/nosskey-manager.service.js';
+import { serializeKeyInfoForExport } from '../../utils/key-info-export.js';
 import CardSection from '../ui/CardSection.svelte';
 import Button from '../ui/button/Button.svelte';
 import IconButton from '../ui/button/IconButton.svelte';
 
 // KeyInfoエクスポート関連の状態変数
 let showExportSection = $state(false);
-let isExporting = $state(false);
 let exportedKeyInfo = $state('');
 let exportError = $state('');
 let showCopiedMessage = $state(false);
@@ -27,27 +27,19 @@ function toggleExportKeySection() {
 }
 
 // 鍵情報をエクスポート
-async function exportKeyInfo() {
+function exportKeyInfo() {
   // 鍵情報が存在するか確認
   const currentKeyInfo = keyManager.getCurrentKeyInfo();
   if (!currentKeyInfo) {
+    exportedKeyInfo = '';
     exportError = $i18n.t.settings.exportKeyInfo.noCurrentKeyInfo;
     return;
   }
 
-  isExporting = true;
-  exportedKeyInfo = '';
+  // NostrKeyInfo は string フィールドのみで構成され JSON 直列化は失敗しないため
+  // try/catch は不要。インポート往復の正当性は key-info-export.spec.ts で担保。
   exportError = '';
-
-  try {
-    // 鍵情報をJSON文字列に変換
-    exportedKeyInfo = JSON.stringify(currentKeyInfo, null, 2);
-  } catch (error) {
-    console.error('KeyInfoエクスポートエラー:', error);
-    exportError = `エクスポートエラー: ${error instanceof Error ? error.message : String(error)}`;
-  } finally {
-    isExporting = false;
-  }
+  exportedKeyInfo = serializeKeyInfoForExport(currentKeyInfo);
 }
 
 // クリップボードにコピー
@@ -101,10 +93,8 @@ function saveKeyInfoToFile() {
         {$i18n.t.settings.exportKeyInfo.restoreWarning}
       </p>
 
-      <Button onclick={exportKeyInfo} disabled={isExporting}>
-        {isExporting
-          ? $i18n.t.common.loading
-          : $i18n.t.settings.exportKeyInfo.exportButton}
+      <Button onclick={exportKeyInfo}>
+        {$i18n.t.settings.exportKeyInfo.exportButton}
       </Button>
 
       {#if exportedKeyInfo}

--- a/examples/svelte-app/src/components/settings/RelaySettings.svelte
+++ b/examples/svelte-app/src/components/settings/RelaySettings.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 import type { RelayMap } from 'nosskey-iframe';
+import DeleteIcon from '../../assets/delete-icon.svg';
 import { i18n } from '../../i18n/i18n-store.js';
 import { loadRelays, saveRelays } from '../../services/relays-store.js';
 import CardSection from '../ui/CardSection.svelte';
 import Button from '../ui/button/Button.svelte';
+import IconButton from '../ui/button/IconButton.svelte';
 
 let relays = $state<RelayMap>(loadRelays());
 let newRelayUrl = $state('');
@@ -86,14 +88,13 @@ function relayEntries(map: RelayMap): Array<[string, { read: boolean; write: boo
             />
             {$i18n.t.settings.relays.writeLabel}
           </label>
-          <Button
-            variant="danger"
-            size="small"
-            fullWidth={false}
+          <IconButton
             onclick={() => removeRelay(url)}
+            title={$i18n.t.settings.relays.removeButton}
+            className="delete-icon-btn"
           >
-            {$i18n.t.settings.relays.removeButton}
-          </Button>
+            <img src={DeleteIcon} alt={$i18n.t.settings.relays.removeButton} />
+          </IconButton>
         </li>
       {/each}
     </ul>

--- a/examples/svelte-app/src/components/settings/TrustedOriginsSettings.svelte
+++ b/examples/svelte-app/src/components/settings/TrustedOriginsSettings.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+import DeleteIcon from '../../assets/delete-icon.svg';
 import { i18n } from '../../i18n/i18n-store.js';
 import { type PolicyKey, trustedOrigins } from '../../store/app-state.js';
 import CardSection from '../ui/CardSection.svelte';
-import Button from '../ui/button/Button.svelte';
+import IconButton from '../ui/button/IconButton.svelte';
 
 function removeMethod(origin: string, method: PolicyKey) {
   if (!confirm($i18n.t.settings.trustedOrigins.confirmRemove)) return;
@@ -39,27 +40,31 @@ function methodLabel(method: PolicyKey): string {
         <li class="origin-item">
           <div class="origin-header">
             <code class="origin-url" title={entry.origin}>{entry.origin}</code>
-            <Button
-              variant="danger"
-              size="small"
-              fullWidth={false}
+            <IconButton
               onclick={() => removeAll(entry.origin)}
+              title={$i18n.t.settings.trustedOrigins.removeAllButton}
+              className="delete-icon-btn"
             >
-              {$i18n.t.settings.trustedOrigins.removeAllButton}
-            </Button>
+              <img
+                src={DeleteIcon}
+                alt={$i18n.t.settings.trustedOrigins.removeAllButton}
+              />
+            </IconButton>
           </div>
           <ul class="method-list">
             {#each entry.methods as method (method)}
               <li class="method-item">
                 <span class="method-label">{methodLabel(method)}</span>
-                <Button
-                  variant="secondary"
-                  size="small"
-                  fullWidth={false}
+                <IconButton
                   onclick={() => removeMethod(entry.origin, method)}
+                  title={$i18n.t.settings.trustedOrigins.removeButton}
+                  className="delete-icon-btn"
                 >
-                  {$i18n.t.settings.trustedOrigins.removeButton}
-                </Button>
+                  <img
+                    src={DeleteIcon}
+                    alt={$i18n.t.settings.trustedOrigins.removeButton}
+                  />
+                </IconButton>
               </li>
             {/each}
           </ul>

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -308,8 +308,8 @@ export const ja: TranslationData = {
     registerTip:
       'パスキーは生体認証や端末のセキュリティ機能を使った安全な認証方法です。お使いの端末が直接対応していなくても、QRコードや通知を使ってスマートフォンなどを認証器として利用できます。',
     usernameTip: 'パスキーの表示名として使われます。任意項目で、未入力でも問題ありません。',
-    methodNew: 'パスキーを新規作成',
-    methodImport: '既存nsecをインポート（ベータ版）',
+    methodNew: '新規作成',
+    methodImport: 'インポート（ベータ版）',
     nsecLabel: '既存の nsec',
     nsecPlaceholder: 'nsec1...',
     nsecTip:
@@ -585,8 +585,8 @@ export const en: TranslationData = {
     registerTip:
       "Passkeys are a secure authentication method using biometrics or your device's security features. Even if your device doesn't directly support it, you can use your smartphone as an authenticator via QR code or browser notification.",
     usernameTip: 'Used as the display name for your passkey. Optional — you can leave it blank.',
-    methodNew: 'Create New Passkey',
-    methodImport: 'Import Existing nsec (Beta)',
+    methodNew: 'New',
+    methodImport: 'Import (Beta)',
     nsecLabel: 'Existing nsec',
     nsecPlaceholder: 'nsec1...',
     nsecTip:

--- a/examples/svelte-app/src/utils/key-info-export.spec.ts
+++ b/examples/svelte-app/src/utils/key-info-export.spec.ts
@@ -1,0 +1,42 @@
+import type { NostrKeyInfo } from 'nosskey-sdk';
+import { describe, expect, it } from 'vitest';
+import { isNostrKeyInfo } from '../store/accounts.js';
+import { serializeKeyInfoForExport } from './key-info-export.js';
+
+describe('serializeKeyInfoForExport', () => {
+  const directModeKeyInfo: NostrKeyInfo = {
+    credentialId: 'aabbcc',
+    pubkey: '0011223344556677889900112233445566778899001122334455667788990011',
+    salt: '6e6f7374722d70776b',
+    username: 'alice',
+  };
+
+  const wrapModeKeyInfo: NostrKeyInfo = {
+    credentialId: 'ddeeff',
+    pubkey: 'ffeeddccbbaa00998877665544332211ffeeddccbbaa009988776655443322110',
+    salt: '6e6f7374722d70776b2d77726170',
+    wrapped: { v: 1, alg: 'nip44-v2', payload: 'base64payload==' },
+  };
+
+  it('KeyInfo オブジェクトそのものを直列化する（関数自身ではない）', () => {
+    const json = serializeKeyInfoForExport(directModeKeyInfo);
+    const parsed = JSON.parse(json);
+    expect(parsed).toEqual(directModeKeyInfo);
+  });
+
+  // 元バグ（エクスポート関数自身を直列化していた）の回帰防止。
+  // 関数を直列化すると `JSON.stringify` は undefined を返すため、
+  // インポート側の型ガードを必ず弾く。出力は往復で必ず通ること。
+  it('出力がインポート側の isNostrKeyInfo 検証を通る（往復成立）', () => {
+    for (const keyInfo of [directModeKeyInfo, wrapModeKeyInfo]) {
+      const json = serializeKeyInfoForExport(keyInfo);
+      const parsed: unknown = JSON.parse(json);
+      expect(isNostrKeyInfo(parsed)).toBe(true);
+    }
+  });
+
+  it('pretty-print（2 スペースインデント）で出力する', () => {
+    const json = serializeKeyInfoForExport(directModeKeyInfo);
+    expect(json).toContain('\n  "credentialId"');
+  });
+});

--- a/examples/svelte-app/src/utils/key-info-export.ts
+++ b/examples/svelte-app/src/utils/key-info-export.ts
@@ -1,0 +1,14 @@
+import type { NostrKeyInfo } from 'nosskey-sdk';
+
+/**
+ * NostrKeyInfo をエクスポート（バックアップ／インポート往復）用の JSON 文字列へ
+ * 直列化する純粋関数。
+ *
+ * インポート側（`ImportKeyInfo.svelte`）は `JSON.parse` → `isNostrKeyInfo`
+ * 検証 → `loginWith` の経路で取り込むため、ここでは KeyInfo オブジェクト
+ * そのものを直列化する必要がある。以前は誤ってエクスポート関数自身を
+ * 直列化しており往復が成立しなかった（回帰防止のため本関数として切り出し）。
+ */
+export function serializeKeyInfoForExport(keyInfo: NostrKeyInfo): string {
+  return JSON.stringify(keyInfo, null, 2);
+}


### PR DESCRIPTION
TODO リストのうち「確認不要で自明」な項目と、その関連クリーンアップを対応しました。

## 対応内容

### 1. 鍵情報エクスポートのバグ修正（`8cf2ae4`）
`ExportKeyInfoComponent` が取得済みの `currentKeyInfo` ではなく **`exportKeyInfo` 関数自身**を `JSON.stringify` しており、エクスポート出力が不正になっていた。`currentKeyInfo`（`NostrKeyInfo`）を直列化するよう修正し、インポート側（`JSON.parse` → `isNostrKeyInfo` → `loginWith`）との往復が成立するようにした。

### 2. リファクタ・回帰防止（`4a67cee`）
- 直列化ロジックを純粋関数 `utils/key-info-export.ts`（`serializeKeyInfoForExport`）へ切り出し
- `key-info-export.spec.ts` で回帰防止テストを追加（`isNostrKeyInfo` との往復検証含む 3 件、カバレッジ 100%）
- デッドコードだった `try/catch` と未使用の `isExporting` state・テンプレート参照を除去

### 3. 認証タブのラベル簡潔化（`4a67cee`）
- ja: 「パスキーを新規作成」→「新規作成」、「既存nsecをインポート（ベータ版）」→「インポート（ベータ版）」
- en: `Create New Passkey` → `New`、`Import Existing nsec (Beta)` → `Import (Beta)`

### 4. 削除ボタンのゴミ箱アイコン統一（`4a67cee`）
`RelaySettings`（リレー削除）と `TrustedOriginsSettings`（origin 全削除・メソッド別削除）のテキストボタンを、`SavedAccounts` と同じ `IconButton` + `delete-icon.svg` に統一。SVG の intrinsic サイズに委譲。

## 検証
- `format:check` / `build` / `test:coverage`（svelte-app 14 ファイル / 167 テスト）/ `check -w svelte-app`（0 errors）すべてグリーン
- PC (1280px) / モバイル (375px) 両 viewport で実画確認済み（レイアウト崩れなし）

https://claude.ai/code/session_01TyfJu7UodECZ1ZeX7h4SXs