### PR TITLE
新規登録UIを簡素化: カード廃止・インポートをリンク化

### DIFF
--- a/examples/svelte-app/src/components/screens/AuthScreen.svelte
+++ b/examples/svelte-app/src/components/screens/AuthScreen.svelte
@@ -7,7 +7,6 @@ import { initAccounts } from '../../store/accounts.js';
 import * as appState from '../../store/app-state.js';
 import { isValidNsec, nsecToHex } from '../../utils/bech32-converter.js';
 import SavedAccounts from '../SavedAccounts.svelte';
-import CardSection from '../ui/CardSection.svelte';
 import HelpTip from '../ui/HelpTip.svelte';
 import Button from '../ui/button/Button.svelte';
 import TabButton from '../ui/button/TabButton.svelte';
@@ -22,7 +21,6 @@ let username = $state('');
 let createdCredentialId = $state('');
 let isPasskeyCreated = $state(false);
 let activeTab = $state<AuthTab>(appState.hasLoggedInBefore() ? 'login' : 'register');
-// biome-ignore lint: svelte
 let creationMethod = $state<CreationMethod>('new');
 let nsecInput = $state('');
 let nsecError = $state('');
@@ -148,6 +146,22 @@ async function login(credentialId?: string) {
 function selectTab(tab: AuthTab) {
   activeTab = tab;
   errorMessage = '';
+  // タブ切替でも入力途中の nsec を state/DOM に残さない（「戻る」経路と同じ破棄方針）。
+  showNew();
+}
+
+function showImport() {
+  creationMethod = 'import';
+  errorMessage = '';
+}
+
+function showNew() {
+  // 新規作成モードへ戻す共通処理（「戻る」リンク・タブ切替の双方から呼ぶ）。
+  // 入力途中の nsec を state/DOM から確実に消し、秘密鍵を残さない。
+  creationMethod = 'new';
+  nsecInput = '';
+  nsecError = '';
+  errorMessage = '';
 }
 
 $effect(() => {
@@ -187,115 +201,108 @@ $effect(() => {
 
     {#if activeTab === "login"}
       <SavedAccounts onError={(message) => (errorMessage = message)} />
-      <CardSection title={$i18n.t.auth.tabLogin}>
-        {#snippet titleAside()}
-          <HelpTip text={$i18n.t.auth.loginTip} placement="end" />
-        {/snippet}
-        <div class="tab-panel">
-          <Button onclick={() => login()} disabled={isLoading} size="large">
-            {$i18n.t.auth.loginWith}
-          </Button>
-        </div>
-      </CardSection>
+      <div class="tab-panel">
+        <Button onclick={() => login()} disabled={isLoading} size="large">
+          {$i18n.t.auth.loginWith}
+        </Button>
+      </div>
     {:else}
-      <CardSection title={$i18n.t.auth.tabRegister}>
-        {#snippet titleAside()}
-          <HelpTip text={$i18n.t.auth.registerTip} placement="end" />
-        {/snippet}
-        <div class="tab-panel">
-          {#if !isPasskeyCreated}
-            <div class="creation-method-selector">
-              <TabButton
-                active={creationMethod === "new"}
-                onclick={() => (creationMethod = "new")}
-                className="creation-method-tab"
-              >
-                {$i18n.t.auth.methodNew}
-              </TabButton>
-              <TabButton
-                active={creationMethod === "import"}
-                onclick={() => (creationMethod = "import")}
-                className="creation-method-tab"
+      <div class="tab-panel">
+        {#if !isPasskeyCreated}
+          <div class="username-input">
+            <div class="username-label-row">
+              <label for="username">{$i18n.t.auth.username}</label>
+              <HelpTip text={$i18n.t.auth.usernameTip} placement="start" />
+            </div>
+            <input
+              id="username"
+              type="text"
+              bind:value={username}
+              placeholder={$i18n.t.auth.usernamePlaceholder}
+              disabled={isLoading}
+            />
+          </div>
+
+          {#if creationMethod === "new"}
+            <Button onclick={createNew} disabled={isLoading} size="large">
+              {$i18n.t.auth.createNew}
+            </Button>
+            <div class="method-link-row">
+              <button
+                type="button"
+                class="method-link"
+                onclick={showImport}
+                disabled={isLoading}
               >
                 {$i18n.t.auth.methodImport}
-              </TabButton>
+              </button>
             </div>
-
-            <div class="username-input">
-              <div class="username-label-row">
-                <label for="username">{$i18n.t.auth.username}</label>
-                <HelpTip text={$i18n.t.auth.usernameTip} placement="start" />
-              </div>
-              <input
-                id="username"
-                type="text"
-                bind:value={username}
-                placeholder={$i18n.t.auth.usernamePlaceholder}
-                disabled={isLoading}
-              />
-            </div>
-
-            {#if creationMethod === "new"}
-              <Button onclick={createNew} disabled={isLoading} size="large">
-                {$i18n.t.auth.createNew}
-              </Button>
-            {:else}
-              <div class="nsec-input">
-                <div class="nsec-label-row">
-                  <label for="nsec">{$i18n.t.auth.nsecLabel}</label>
-                  <HelpTip text={$i18n.t.auth.nsecTip} placement="start" />
-                </div>
-                <input
-                  id="nsec"
-                  type="password"
-                  autocomplete="off"
-                  spellcheck="false"
-                  bind:value={nsecInput}
-                  placeholder={$i18n.t.auth.nsecPlaceholder}
-                  disabled={isLoading}
-                />
-                {#if nsecError}
-                  <div class="error-message">{nsecError}</div>
-                {/if}
-              </div>
-              <Button
-                onclick={importExisting}
-                disabled={isLoading || !nsecInput.trim()}
-                size="large"
-              >
-                {$i18n.t.auth.importNsec}
-              </Button>
-            {/if}
           {:else}
-            <div class="username-input">
-              <div class="username-label-row">
-                <label for="username">{$i18n.t.auth.username}</label>
-                <HelpTip text={$i18n.t.auth.usernameTip} placement="start" />
+            <div class="nsec-input">
+              <div class="nsec-label-row">
+                <label for="nsec">{$i18n.t.auth.nsecLabel}</label>
+                <HelpTip text={$i18n.t.auth.nsecTip} placement="start" />
               </div>
               <input
-                id="username"
-                type="text"
-                bind:value={username}
-                placeholder={$i18n.t.auth.usernamePlaceholder}
-                disabled
-              />
-            </div>
-            <div class="success-message">
-              <div class="success-icon">✅</div>
-              <h4>{$i18n.t.auth.passkeyCreated}</h4>
-              <p>{$i18n.t.auth.firstLogin}</p>
-              <Button
-                variant="success"
-                onclick={() => login(createdCredentialId)}
+                id="nsec"
+                type="password"
+                autocomplete="off"
+                spellcheck="false"
+                bind:value={nsecInput}
+                placeholder={$i18n.t.auth.nsecPlaceholder}
                 disabled={isLoading}
-                className="success-action-button"
+              />
+              {#if nsecError}
+                <div class="error-message">{nsecError}</div>
+              {/if}
+            </div>
+            <Button
+              onclick={importExisting}
+              disabled={isLoading || !nsecInput.trim()}
+              size="large"
+            >
+              {$i18n.t.auth.importNsec}
+            </Button>
+            <div class="method-link-row">
+              <button
+                type="button"
+                class="method-link"
+                onclick={showNew}
+                disabled={isLoading}
               >
-                {$i18n.t.auth.proceedWithLogin}
-              </Button>
+                {$i18n.t.common.back}
+              </button>
             </div>
           {/if}
-        </div>
-      </CardSection>
+        {:else}
+          <div class="username-input">
+            <div class="username-label-row">
+              <label for="username">{$i18n.t.auth.username}</label>
+              <HelpTip text={$i18n.t.auth.usernameTip} placement="start" />
+            </div>
+            <input
+              id="username"
+              type="text"
+              bind:value={username}
+              placeholder={$i18n.t.auth.usernamePlaceholder}
+              disabled
+            />
+          </div>
+          <div class="success-message">
+            <div class="success-icon">✅</div>
+            <h4>{$i18n.t.auth.passkeyCreated}</h4>
+            <p>{$i18n.t.auth.firstLogin}</p>
+            <Button
+              variant="success"
+              onclick={() => login(createdCredentialId)}
+              disabled={isLoading}
+              className="success-action-button"
+            >
+              {$i18n.t.auth.proceedWithLogin}
+            </Button>
+          </div>
+        {/if}
+      </div>
     {/if}
   {/if}
 
@@ -385,22 +392,32 @@ $effect(() => {
     flex: 1;
   }
 
-  .creation-method-selector {
-    display: flex;
-    gap: 4px;
-    padding: 4px;
-    background-color: var(--color-surface);
-    border: 1px solid var(--color-border);
-    border-radius: 10px;
-    margin: 0 0 20px 0;
-  }
-
-  .creation-method-selector :global(.creation-method-tab) {
-    flex: 1;
-  }
-
   .tab-panel {
     text-align: center;
+  }
+
+  .method-link-row {
+    margin-top: 16px;
+    text-align: center;
+  }
+
+  .method-link {
+    background: none;
+    border: none;
+    padding: 4px;
+    color: var(--color-text-secondary);
+    font-size: 0.85rem;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .method-link:hover:not(:disabled) {
+    color: var(--color-text-primary);
+  }
+
+  .method-link:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 
   .nsec-input {

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -45,10 +45,7 @@ export interface TranslationData {
     proceedWithLogin: string;
     tabLogin: string;
     tabRegister: string;
-    loginTip: string;
-    registerTip: string;
     usernameTip: string;
-    methodNew: string;
     methodImport: string;
     nsecLabel: string;
     nsecPlaceholder: string;
@@ -294,7 +291,7 @@ export const ja: TranslationData = {
   auth: {
     title: 'Nosskey',
     subtitle: 'Nostrアカウントをパスキーで',
-    createNew: '新規作成',
+    createNew: '作成',
     loginWith: 'パスキーでログイン',
     firstLogin: '初回ログイン',
     passkeyCreated: 'パスキーが作成されました',
@@ -304,17 +301,13 @@ export const ja: TranslationData = {
     usernamePlaceholder: 'ユーザー名を入力',
     tabLogin: 'ログイン',
     tabRegister: '新規登録',
-    loginTip: '以前作成したパスキーで再度ログインします',
-    registerTip:
-      'パスキーは生体認証や端末のセキュリティ機能を使った安全な認証方法です。お使いの端末が直接対応していなくても、QRコードや通知を使ってスマートフォンなどを認証器として利用できます。',
     usernameTip: 'パスキーの表示名として使われます。任意項目で、未入力でも問題ありません。',
-    methodNew: '新規作成',
-    methodImport: 'インポート（ベータ版）',
+    methodImport: '秘密鍵のインポート（ベータ版）',
     nsecLabel: '既存の nsec',
     nsecPlaceholder: 'nsec1...',
     nsecTip:
       '既存の Nostr 秘密鍵 (nsec1...) を入力。パスキーで暗号化保存され、署名・暗号化は透過的に動作します。',
-    importNsec: 'nsec をインポートしてログイン',
+    importNsec: 'インポート',
     invalidNsec: '無効な nsec 形式です。"nsec1..." で始まる bech32 文字列を入力してください。',
     accounts: {
       title: '保存済みアカウント',
@@ -571,7 +564,7 @@ export const en: TranslationData = {
   auth: {
     title: 'Nosskey',
     subtitle: 'Your Nostr account, with a passkey',
-    createNew: 'Create New',
+    createNew: 'Create',
     loginWith: 'Login with Passkey',
     loading: 'Loading...',
     username: 'Username (Optional)',
@@ -581,17 +574,13 @@ export const en: TranslationData = {
     proceedWithLogin: 'Proceed with Login',
     tabLogin: 'Login',
     tabRegister: 'Sign Up',
-    loginTip: 'Sign in again with a previously created passkey',
-    registerTip:
-      "Passkeys are a secure authentication method using biometrics or your device's security features. Even if your device doesn't directly support it, you can use your smartphone as an authenticator via QR code or browser notification.",
     usernameTip: 'Used as the display name for your passkey. Optional — you can leave it blank.',
-    methodNew: 'New',
-    methodImport: 'Import (Beta)',
+    methodImport: 'Import secret key (Beta)',
     nsecLabel: 'Existing nsec',
     nsecPlaceholder: 'nsec1...',
     nsecTip:
       'Enter your existing Nostr private key (nsec1...). It will be encrypted with your passkey and stored locally; signing and encryption operations work transparently via the passkey.',
-    importNsec: 'Import nsec and log in',
+    importNsec: 'Import',
     invalidNsec: 'Invalid nsec format. Please enter a bech32 string starting with "nsec1...".',
     accounts: {
       title: 'Saved accounts',


### PR DESCRIPTION
- login/register 両タブから CardSection（枠・タイトル）を廃止しフラット化
- register の「新規作成/インポート」タブを廃止し、インポートは下線リンクに格下げ
- インポートモードは「戻る」リンクで新規作成へ復帰
- 戻る/タブ切替時に入力途中の nsec を必ずクリア（秘密鍵を残さない）
- ボタン文言を短縮（作成 / インポート）
- 未使用化した registerTip・methodNew・loginTip を i18n から削除