### PR TITLE
feat(svelte-app): add GitHub repository link to app info

### DIFF
--- a/examples/svelte-app/src/components/settings/AppInfo.svelte
+++ b/examples/svelte-app/src/components/settings/AppInfo.svelte
@@ -26,7 +26,7 @@ const commitHash = import.meta.env.VITE_GIT_COMMIT_HASH || 'unknown';
         target="_blank"
         rel="noopener noreferrer"
       >
-        github.com/ocknamo/nosskey-sdk
+        ocknamo/nosskey-sdk
       </a>
     </div>
   </div>
@@ -44,7 +44,7 @@ const commitHash = import.meta.env.VITE_GIT_COMMIT_HASH || 'unknown';
   }
 
   .label {
-    flex: 0 0 140px;
+    flex: 0 0 120px;
     font-weight: bold;
     color: var(--color-text-primary);
   }
@@ -56,7 +56,7 @@ const commitHash = import.meta.env.VITE_GIT_COMMIT_HASH || 'unknown';
   .value a {
     color: var(--color-primary);
     text-decoration: none;
-    word-break: break-all;
+    white-space: nowrap;
   }
 
   .value a:hover {

--- a/examples/svelte-app/src/components/settings/AppInfo.svelte
+++ b/examples/svelte-app/src/components/settings/AppInfo.svelte
@@ -18,6 +18,18 @@ const commitHash = import.meta.env.VITE_GIT_COMMIT_HASH || 'unknown';
     <div class="label">{$i18n.t.settings.appInfo.commitHash}</div>
     <div class="value">{commitHash}</div>
   </div>
+  <div class="info-item">
+    <div class="label">{$i18n.t.settings.appInfo.repository}</div>
+    <div class="value">
+      <a
+        href="https://github.com/ocknamo/nosskey-sdk"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        github.com/ocknamo/nosskey-sdk
+      </a>
+    </div>
+  </div>
 </CardSection>
 
 <style>
@@ -39,5 +51,15 @@ const commitHash = import.meta.env.VITE_GIT_COMMIT_HASH || 'unknown';
 
   .value {
     flex: 1;
+  }
+
+  .value a {
+    color: var(--color-primary);
+    text-decoration: none;
+    word-break: break-all;
+  }
+
+  .value a:hover {
+    text-decoration: underline;
   }
 </style>

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -368,7 +368,7 @@ export const ja: TranslationData = {
       version: 'バージョン:',
       buildDate: 'ビルド日時:',
       commitHash: 'コミットハッシュ:',
-      repository: 'リポジトリ:',
+      repository: 'GitHub:',
     },
     language: {
       title: '言語設定',
@@ -639,7 +639,7 @@ export const en: TranslationData = {
       version: 'Version:',
       buildDate: 'Build Date:',
       commitHash: 'Commit Hash:',
-      repository: 'Repository:',
+      repository: 'GitHub:',
     },
     language: {
       title: 'Language Settings',

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -120,6 +120,7 @@ export interface TranslationData {
       version: string;
       buildDate: string;
       commitHash: string;
+      repository: string;
     };
     language: {
       title: string;
@@ -367,6 +368,7 @@ export const ja: TranslationData = {
       version: 'バージョン:',
       buildDate: 'ビルド日時:',
       commitHash: 'コミットハッシュ:',
+      repository: 'リポジトリ:',
     },
     language: {
       title: '言語設定',
@@ -637,6 +639,7 @@ export const en: TranslationData = {
       version: 'Version:',
       buildDate: 'Build Date:',
       commitHash: 'Commit Hash:',
+      repository: 'Repository:',
     },
     language: {
       title: 'Language Settings',

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -367,7 +367,7 @@ export const ja: TranslationData = {
       title: 'アプリケーション情報',
       version: 'バージョン:',
       buildDate: 'ビルド日時:',
-      commitHash: 'コミットハッシュ:',
+      commitHash: 'ハッシュ:',
       repository: 'GitHub:',
     },
     language: {
@@ -638,7 +638,7 @@ export const en: TranslationData = {
       title: 'Application Info',
       version: 'Version:',
       buildDate: 'Build Date:',
-      commitHash: 'Commit Hash:',
+      commitHash: 'Hash:',
       repository: 'GitHub:',
     },
     language: {


### PR DESCRIPTION
Add a repository link to the Application Info section in the settings
screen, pointing to the project's GitHub repository.

https://claude.ai/code/session_016b2Z5wVVeqmCSEhQomo7SR