### PR TITLE
fix(nosskey-iframe): gate getPublicKey/getRelays behind per-origin connection approval (H-1)

### DIFF
--- a/docs/en/iframe-host.en.md
+++ b/docs/en/iframe-host.en.md
@@ -20,13 +20,13 @@ Nostr app**.
 
 ## Supported methods
 
-The iframe host is a **full NIP-07 provider**. It handles seven methods; five
-of them touch secret material and therefore go through the consent flow.
+The iframe host is a **full NIP-07 provider**. It handles seven methods, all
+of which go through the consent flow.
 
 | Method (protocol) | SDK method | Consent | Purpose |
 |-------------------|------------|---------|---------|
-| `getPublicKey`  | `getPublicKey()`  | — (none)   | Return the current public key |
-| `getRelays`     | (host callback)   | — (none)   | Return the relay configuration |
+| `getPublicKey`  | `getPublicKey()`  | required (connection approval) | Return the current public key |
+| `getRelays`     | (host callback)   | required (connection approval) | Return the relay configuration |
 | `signEvent`     | `signEvent()`     | required   | Sign a Nostr event |
 | `nip44_encrypt` | `nip44Encrypt()`  | required   | NIP-44 v2 encryption |
 | `nip44_decrypt` | `nip44Decrypt()`  | required   | NIP-44 v2 decryption |
@@ -36,8 +36,13 @@ of them touch secret material and therefore go through the consent flow.
 The protocol method names (underscore form) and the
 `CONSENT_REQUIRED_METHODS` list are defined in
 [`packages/nosskey-iframe/src/protocol.ts`](../../packages/nosskey-iframe/src/protocol.ts).
-`getPublicKey` and `getRelays` only expose non-secret data, so they never
-trigger a dialog.
+The consent for `getPublicKey` / `getRelays` acts as a **per-origin
+connection approval (pairing)**: the npub and relay set identify the
+logged-in user, so gating them blocks silent de-anonymization by arbitrary
+embedding sites. Choosing "always allow" in the dialog records the origin in
+the trusted-origins list under the `connect` bucket, after which responses
+are served without a dialog — the same model NIP-07 browser extensions use
+for first-time site access.
 
 ## Components
 
@@ -143,9 +148,10 @@ Two pieces of persisted state drive this (both in
 [`store/app-state.ts`](../../examples/svelte-app/src/store/app-state.ts)):
 
 - **`ConsentPolicy`** — per-method decision (`ask` / `always` / `deny`) keyed
-  by `signEvent` / `nip44` / `nip04`. `nip44_encrypt` and `nip44_decrypt`
-  collapse into the `nip44` bucket (same for `nip04`). Stored under
-  `localStorage` key `nosskey_consent_policy`.
+  by `connect` / `signEvent` / `nip44` / `nip04`. `getPublicKey` and
+  `getRelays` collapse into the `connect` bucket (connection approval), and
+  `nip44_encrypt` / `nip44_decrypt` collapse into the `nip44` bucket (same
+  for `nip04`). Stored under `localStorage` key `nosskey_consent_policy`.
 - **`TrustedOriginEntry[]`** — "always allow this site" records, scoped by
   `origin × method` rather than blanket-allowing an origin. Stored under
   `localStorage` key `nosskey_trusted_origins_v2`.
@@ -217,11 +223,17 @@ The encryption methods follow the same consent path. The host calls the
 matching SDK method (`manager.nip44Encrypt(pubkey, plaintext)` etc.) and
 returns the ciphertext (or plaintext, for decrypt) to the parent.
 
-### `getPublicKey` / `getRelays` (no consent)
+### `getPublicKey` / `getRelays` (connection approval)
 
-These resolve immediately — `getPublicKey` from the current `NostrKeyInfo`,
-`getRelays` from the `onGetRelays` callback — without touching the consent
-flow.
+These follow the same consent path. Both methods collapse into the shared
+`connect` policy bucket, so an origin that chose "always allow" on its first
+`getPublicKey` is also auto-approved for `getRelays` (one pairing covers
+both). `getPublicKey` resolves from the current `NostrKeyInfo`, `getRelays`
+from the `onGetRelays` callback.
+
+As an exception, `getRelays` returns an empty map `{}` without consent when
+`onGetRelays` is not configured or no key is set (not logged in) — an empty
+map carries no user-identifying information.
 
 ## Storage partitioning & Storage Access API
 

--- a/docs/ja/iframe-host.ja.md
+++ b/docs/ja/iframe-host.ja.md
@@ -12,19 +12,19 @@
 
 ## 対応メソッド
 
-iframe ホストは **NIP-07 の完全なプロバイダ**です。7 つのメソッドを処理し、そのうち 5 つは秘密情報を扱うため consent フローを経由します。
+iframe ホストは **NIP-07 の完全なプロバイダ**です。7 つのメソッドすべてが consent フローを経由します。
 
 | メソッド (プロトコル) | SDK メソッド | consent | 用途 |
 |----------------------|--------------|---------|------|
-| `getPublicKey`  | `getPublicKey()`  | — (不要)   | 現在の公開鍵を返す |
-| `getRelays`     | (host コールバック) | — (不要)   | リレー設定を返す |
+| `getPublicKey`  | `getPublicKey()`  | 必要 (接続承認) | 現在の公開鍵を返す |
+| `getRelays`     | (host コールバック) | 必要 (接続承認) | リレー設定を返す |
 | `signEvent`     | `signEvent()`     | 必要       | Nostr イベントに署名 |
 | `nip44_encrypt` | `nip44Encrypt()`  | 必要       | NIP-44 v2 暗号化 |
 | `nip44_decrypt` | `nip44Decrypt()`  | 必要       | NIP-44 v2 復号 |
 | `nip04_encrypt` | `nip04Encrypt()`  | 必要       | NIP-04 (レガシー) 暗号化 |
 | `nip04_decrypt` | `nip04Decrypt()`  | 必要       | NIP-04 (レガシー) 復号 |
 
-プロトコル上のメソッド名 (アンダースコア形式) と `CONSENT_REQUIRED_METHODS` リストは [`packages/nosskey-iframe/src/protocol.ts`](../../packages/nosskey-iframe/src/protocol.ts) で定義されています。`getPublicKey` と `getRelays` は非機密データのみを返すため、ダイアログは出ません。
+プロトコル上のメソッド名 (アンダースコア形式) と `CONSENT_REQUIRED_METHODS` リストは [`packages/nosskey-iframe/src/protocol.ts`](../../packages/nosskey-iframe/src/protocol.ts) で定義されています。`getPublicKey` / `getRelays` への同意は **オリジン単位の接続承認 (ペアリング)** として機能します。npub とリレー設定はユーザーを特定できる情報のため、任意の埋め込みサイトによるサイレント取得 (デアノニマイズ) を防ぎます。同意ダイアログで「常に許可」を選ぶと `connect` バケットとして信頼済みオリジンに記憶され、以後はダイアログなしで応答します (NIP-07 ブラウザ拡張の初回接続承認と同型)。
 
 ## 構成要素
 
@@ -110,7 +110,7 @@ export function startIframeHost(overrides = {}) {
 
 この判定を駆動する 2 つの永続状態 (いずれも [`store/app-state.ts`](../../examples/svelte-app/src/store/app-state.ts)):
 
-- **`ConsentPolicy`** — メソッド別の判定 (`ask` / `always` / `deny`)。キーは `signEvent` / `nip44` / `nip04`。`nip44_encrypt` と `nip44_decrypt` は `nip44` バケットに集約される (`nip04` も同様)。`localStorage` キー `nosskey_consent_policy` に保存。
+- **`ConsentPolicy`** — メソッド別の判定 (`ask` / `always` / `deny`)。キーは `connect` / `signEvent` / `nip44` / `nip04`。`getPublicKey` と `getRelays` は `connect` バケット (接続承認) に、`nip44_encrypt` と `nip44_decrypt` は `nip44` バケットに集約される (`nip04` も同様)。`localStorage` キー `nosskey_consent_policy` に保存。
 - **`TrustedOriginEntry[]`** — 「このサイトを常に許可」の記録。origin をまるごと許可するのではなく `origin × method` 単位でスコープする。`localStorage` キー `nosskey_trusted_origins_v2` に保存。
 
 自動拒否されたリクエストはメソッド別の `denyCounts` store を加算します。これにより、悪意ある親が (例: 任意 pubkey に対する `nip04_decrypt` を繰り返すなど) ユーザーに気づかれずプローブし続けることを防ぎます。
@@ -168,9 +168,11 @@ client.signEvent Promise 解決
 
 暗号化系メソッドも同じ consent 経路をたどります。Host は対応する SDK メソッド (`manager.nip44Encrypt(pubkey, plaintext)` 等) を呼び、暗号文 (decrypt の場合は平文) を親に返します。
 
-### `getPublicKey` / `getRelays` (consent 不要)
+### `getPublicKey` / `getRelays` (接続承認)
 
-これらは即座に解決します。`getPublicKey` は現在の `NostrKeyInfo` から、`getRelays` は `onGetRelays` コールバックから取得し、consent フローを経由しません。
+これらも同じ consent 経路をたどります。ポリシーキーは両メソッド共通の `connect` バケットに集約されるため、初回の `getPublicKey` で「常に許可」を選んだオリジンは `getRelays` も自動承認されます (1 回のペアリングで両方をカバー)。`getPublicKey` は現在の `NostrKeyInfo` から、`getRelays` は `onGetRelays` コールバックから取得します。
+
+例外として `getRelays` は、`onGetRelays` 未設定または鍵未設定 (未ログイン) の場合に限り、ユーザーを特定できる情報を含まない空マップ `{}` を consent なしで即返します。
 
 ## Storage Partitioning と Storage Access API
 

--- a/docs/ja/security-audit-2026-06-10.ja.md
+++ b/docs/ja/security-audit-2026-06-10.ja.md
@@ -27,6 +27,7 @@
 - **前提**: Nosskey の iframe は「任意の Nostr クライアントから埋め込める汎用署名プロバイダ」として提供する設計意図がある（クロスプラットフォーム利用）。したがってオリジン許可リストによる閉鎖は製品意図と衝突し、解にならない。本指摘はオープン埋め込みモデルを前提に残存リスクを評価したもの。
 - **内容**: `getPublicKey` / `getRelays` は同意ダイアログの対象外のため、**任意の悪意あるサイトが不可視 iframe を埋め込むだけで、ログイン中ユーザーの npub とリレー設定をサイレントに取得**できる。閲覧者の Nostr アカウント特定（デアノニマイズ・トラッキング）がウェブ全体でノーインタラクションで成立する。署名・暗号化・復号は同意ダイアログで守られるが、任意オリジンがダイアログを出し放題のため、同意疲れや紛らわしい文面による誤承認（さらに「常に許可」チェック → 恒久化）も誘発できる。
 - **推奨**: 同じ「どのサイトからでも使える」モデルの NIP-07 ブラウザ拡張（nos2x / Alby 等）が採用している方式に揃える。すなわち `getPublicKey` に**オリジン単位の初回接続承認**（ペアリング）を導入し、承認済みオリジンを既存の trusted origins 機構で記憶する。これによりクロスプラットフォームの利用性を損なわずにサイレント取得だけを塞げる。
+- **対応状況**: ✅ **対応済み（2026-06-12）**。推奨どおり nos2x / Alby 同等のオリジン単位接続承認を導入した。`CONSENT_REQUIRED_METHODS` に `getPublicKey` / `getRelays` を追加し、host の dispatch で両メソッドを既存の同意フロー（`#withVisibilityAndConsent`）に通すよう変更（`packages/nosskey-iframe/src/protocol.ts` / `host.ts`）。アプリ側はポリシーキー `connect` を新設して両メソッドを単一の接続承認バケットに集約し、「常に許可」で `origin × connect` を信頼済みオリジンに記憶（`examples/svelte-app` の `consent-gating.ts` / `app-state.ts` / `ConsentDialog.svelte`）。例外として、`onGetRelays` 未設定または鍵未設定（未ログイン）時の `getRelays` はユーザー識別情報を含まない空マップを同意なしで返す。`requireUserConsent: true`（デフォルト）+ `onConsent` 未設定のホストはフェイルクローズ（`INTERNAL`）になる破壊的変更であり、パッケージ README に明記した。
 
 ---
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -39,6 +39,15 @@ iframe 機能拡充の Phase 番号は `docs/iframe-expansion-plan.md` の体系
 - [ ] **`switchKey(credentialId)` メソッド（Phase 4-A）** — iframe 経由でのキー切り替え。マルチキーユーザー向け。
 - [ ] **秘密鍵 hex 文字列のメモリ残存リスクの対応可否検討** — SDK 内部で秘密鍵を `seckeySigner` 渡しや NIP-44 平文経路に通す際に hex 文字列（`string`）化される。JS の `string` は immutable で `Uint8Array.fill(0)` 相当のゼロ化 API が存在しないため、**GC タイミングまでヒープに残存**し、設計書 §11 NF5 の Uint8Array ゼロ化保証がカバーできない。影響箇所は `importNostrKey` / `exportNostrKey` / wrap モード復号後の `signEvent` / `nip44Encrypt` 平文経路など。**まず対応可否の判断から開始**: 脅威モデル上のリスク評価（ブラウザヒープに直接アクセスできる攻撃者は他経路でも危殆化済みか？） → 対応する場合は (a) `@rx-nostr/crypto` を捨てて `@noble/secp256k1` のバイト I/O へ置換、(b) `nip44Encrypt`/`nip44Decrypt` の plaintext シグネチャを `string | Uint8Array` 受けに拡張、の両方が必要。docs/{ja,en}/nosskey-sdk-interface（`importNostrKey` セキュリティメモ）・設計書 §11 (NF5) に制約として既に注記済み。
 
+### セキュリティ診断 2026-06-10 対応
+`docs/ja/security-audit-2026-06-10.ja.md` の指摘事項。High は対応済み、Middle (M-1〜M-5) は本診断書の「優先対応の提案」の順で消化する。
+
+- [x] **H-1: `getPublicKey` / `getRelays` のオリジン単位接続承認（ペアリング）導入** — 任意サイトが不可視 iframe で npub・リレー設定をサイレント取得できる問題への対応。`CONSENT_REQUIRED_METHODS` に両メソッドを追加し、host の dispatch を既存の同意フロー（`#withVisibilityAndConsent`）に統合（`packages/nosskey-iframe/src/protocol.ts` / `host.ts`、`isConnectMethod` ヘルパー追加）。svelte-app 側はポリシーキー `connect` を新設して両メソッドを単一バケットに集約し（`policyKeyFor`）、同意ダイアログの「常に許可」で `origin × connect` を信頼済みオリジンへ記憶 → 以後サイレント（nos2x / Alby の初回接続承認と同型）。例外: `onGetRelays` 未設定または鍵未設定時の `getRelays` は空マップを同意なしで返す（ユーザー識別情報なし）。`requireUserConsent: true` + `onConsent` 未設定ホストはフェイルクローズ（`INTERNAL`）になる破壊的変更で、パッケージ README（ja/en）と iframe-host 文書に明記。旧 localStorage（connect キー無し）は `ask` に倒れ、既存の信頼済みオリジンも connect は未承認のため初回に再承認が必要（意図どおり）。
+- [ ] **M-1/M-4**: decrypt 系の「常に許可」抑制とレート制限
+- [ ] **M-2**: wrap モードインポート時のバックアップ必須化
+- [ ] **M-3**: デプロイ環境への CSP 追加と TTL バリデーション
+- [ ] **M-5**: SDK の `allowedOrigins` デフォルト廃止（未指定 throw・`'*'` は明示オプトイン）
+
 ### wrap モードのセキュリティ堅牢化
 2026-06 の wrap モード（`importNostrKey` / `#getSecretKey`）セキュリティレビューで発見。暗号方式自体（NIP-44 v2 自己宛 DM・機密性は PRF と等価・完全性は HMAC・salt ドメイン分離）は健全で、以下は多層防御・鍵ライフサイクルの堅牢化項目。
 

--- a/examples/svelte-app/src/components/ConsentDialog.svelte
+++ b/examples/svelte-app/src/components/ConsentDialog.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-import { type NosskeyMethod, isDecryptMethod, isEncryptMethod } from 'nosskey-iframe';
+import {
+  type NosskeyMethod,
+  isConnectMethod,
+  isDecryptMethod,
+  isEncryptMethod,
+} from 'nosskey-iframe';
 import { i18n } from '../i18n/i18n-store.js';
 import { approveConsent, pendingConsent, rejectConsent } from '../iframe-mode.js';
 import { buildScreenUrl } from '../utils/app-navigation.js';
@@ -27,6 +32,10 @@ function renderPeerPubkey(hexPubkey: string): string {
 
 function methodLabel(method: NosskeyMethod, labels: typeof $i18n.t.consent.methodLabel): string {
   switch (method) {
+    case 'getPublicKey':
+      return labels.getPublicKey;
+    case 'getRelays':
+      return labels.getRelays;
     case 'signEvent':
       return labels.signEvent;
     case 'nip44_encrypt':
@@ -43,6 +52,7 @@ function methodLabel(method: NosskeyMethod, labels: typeof $i18n.t.consent.metho
 }
 
 function dialogTitle(method: NosskeyMethod, t: typeof $i18n.t.consent): string {
+  if (isConnectMethod(method)) return t.titleConnect;
   if (method === 'signEvent') return t.title;
   if (isDecryptMethod(method)) return t.titleDecrypt;
   return t.titleEncrypt;
@@ -72,6 +82,7 @@ function openConsentSettings(): void {
 
 {#if $pendingConsent}
   {@const c = $pendingConsent}
+  {@const isConnect = isConnectMethod(c.method)}
   {@const isEncrypt = isEncryptMethod(c.method)}
   {@const isDecrypt = isDecryptMethod(c.method)}
   <div class="consent-backdrop" role="dialog" aria-modal="true" aria-labelledby="consent-title">
@@ -81,6 +92,10 @@ function openConsentSettings(): void {
         <span class="label">{$i18n.t.consent.origin}</span>
         <code>{c.origin}</code>
       </p>
+
+      {#if isConnect}
+        <p class="consent-connect-description">{$i18n.t.consent.connectDescription}</p>
+      {/if}
 
       <dl class="consent-event">
         <dt>{$i18n.t.consent.method}</dt>
@@ -187,6 +202,12 @@ function openConsentSettings(): void {
   .consent-origin .label {
     font-weight: 600;
     margin-right: 8px;
+  }
+
+  .consent-connect-description {
+    margin: 4px 0 0;
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
   }
 
   code,

--- a/examples/svelte-app/src/components/settings/ConsentPolicySettings.svelte
+++ b/examples/svelte-app/src/components/settings/ConsentPolicySettings.svelte
@@ -74,7 +74,7 @@ function optionLabel(option: ConsentDecision): string {
     {/each}
   </div>
 
-  {#if $denyCounts.signEvent > 0 || $denyCounts.nip44 > 0 || $denyCounts.nip04 > 0}
+  {#if POLICY_KEYS.some((key) => $denyCounts[key] > 0)}
     <div class="deny-actions">
       <Button variant="secondary" size="small" onclick={resetDenyCounts}>
         {$i18n.t.settings.consentPolicy.resetDenyCounts}

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -163,6 +163,7 @@ export interface TranslationData {
       title: string;
       description: string;
       methodLabel: {
+        connect: string;
         signEvent: string;
         nip44: string;
         nip04: string;
@@ -202,8 +203,10 @@ export interface TranslationData {
   };
   consent: {
     title: string;
+    titleConnect: string;
     titleEncrypt: string;
     titleDecrypt: string;
+    connectDescription: string;
     origin: string;
     eventKind: string;
     eventContent: string;
@@ -215,6 +218,8 @@ export interface TranslationData {
     reject: string;
     method: string;
     methodLabel: {
+      getPublicKey: string;
+      getRelays: string;
       signEvent: string;
       nip44Encrypt: string;
       nip44Decrypt: string;
@@ -416,6 +421,7 @@ export const ja: TranslationData = {
       description:
         'リクエスト種別ごとに既定の挙動を設定できます。「常に許可」はサイトを問わずスキップ、「拒否」はダイアログを出さずに即拒否します。',
       methodLabel: {
+        connect: 'サイト接続（公開鍵・リレー設定の読み取り）',
         signEvent: 'イベント署名 (signEvent)',
         nip44: 'NIP-44 暗号化 / 復号',
         nip04: 'NIP-04 暗号化 / 復号（レガシー）',
@@ -472,8 +478,11 @@ export const ja: TranslationData = {
   },
   consent: {
     title: '署名リクエストの確認',
+    titleConnect: '接続リクエストの確認',
     titleEncrypt: '暗号化リクエストの確認',
     titleDecrypt: '復号リクエストの確認',
+    connectDescription:
+      'このサイトはあなたの公開鍵（npub）とリレー設定を読み取れるようになります。',
     origin: 'リクエスト元:',
     eventKind: 'イベント種別',
     eventContent: '本文',
@@ -485,6 +494,8 @@ export const ja: TranslationData = {
     reject: '拒否',
     method: 'リクエスト種別',
     methodLabel: {
+      getPublicKey: '公開鍵の取得',
+      getRelays: 'リレー設定の取得',
       signEvent: 'イベント署名',
       nip44Encrypt: 'NIP-44 暗号化',
       nip44Decrypt: 'NIP-44 復号',
@@ -689,6 +700,7 @@ export const en: TranslationData = {
       description:
         'Set the default behavior for each request type. "Always allow" skips the dialog regardless of site, "Deny" rejects without prompting.',
       methodLabel: {
+        connect: 'Site connection (read public key & relay list)',
         signEvent: 'Sign event (signEvent)',
         nip44: 'NIP-44 encrypt / decrypt',
         nip04: 'NIP-04 encrypt / decrypt (legacy)',
@@ -745,8 +757,10 @@ export const en: TranslationData = {
   },
   consent: {
     title: 'Signing request',
+    titleConnect: 'Connection request',
     titleEncrypt: 'Encryption request',
     titleDecrypt: 'Decryption request',
+    connectDescription: 'This site will be able to read your public key (npub) and relay settings.',
     origin: 'Requesting origin:',
     eventKind: 'Event kind',
     eventContent: 'Content',
@@ -758,6 +772,8 @@ export const en: TranslationData = {
     reject: 'Reject',
     method: 'Request type',
     methodLabel: {
+      getPublicKey: 'Read public key',
+      getRelays: 'Read relay list',
       signEvent: 'Sign event',
       nip44Encrypt: 'NIP-44 encrypt',
       nip44Decrypt: 'NIP-44 decrypt',

--- a/examples/svelte-app/src/iframe-mode.spec.ts
+++ b/examples/svelte-app/src/iframe-mode.spec.ts
@@ -33,13 +33,23 @@ const nip04Request: ConsentRequest = {
   pubkey: 'a'.repeat(64),
 };
 
+const getPublicKeyRequest: ConsentRequest = {
+  origin,
+  method: 'getPublicKey',
+};
+
+const getRelaysRequest: ConsentRequest = {
+  origin,
+  method: 'getRelays',
+};
+
 beforeEach(() => {
   // 各テストを独立させる: SDK マネージャのハンドル / ストレージ残留を持ち越さない。
   resetNosskeyManager();
   localStorage.clear();
   sessionStorage.clear();
   trustedOrigins.set([]);
-  consentPolicy.set({ signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
+  consentPolicy.set({ connect: 'ask', signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
   resetDenyCounts();
   pendingConsent.set(null);
 });
@@ -50,7 +60,7 @@ afterEach(() => {
 
 describe('onConsent', () => {
   it('resolves true immediately when policy is always (no dialog)', async () => {
-    consentPolicy.set({ signEvent: 'always', nip44: 'ask', nip04: 'ask' });
+    consentPolicy.set({ connect: 'ask', signEvent: 'always', nip44: 'ask', nip04: 'ask' });
     const result = await onConsent(signRequest);
     expect(result).toBe(true);
     expect(get(pendingConsent)).toBeNull();
@@ -58,7 +68,7 @@ describe('onConsent', () => {
 
   it('resolves false immediately when policy is deny, warns, and increments counter', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    consentPolicy.set({ signEvent: 'ask', nip44: 'ask', nip04: 'deny' });
+    consentPolicy.set({ connect: 'ask', signEvent: 'ask', nip44: 'ask', nip04: 'deny' });
     const result = await onConsent(nip04Request);
     expect(result).toBe(false);
     expect(get(pendingConsent)).toBeNull();
@@ -107,7 +117,7 @@ describe('onConsent', () => {
     trustedOrigins.set([{ origin, methods: ['nip04'] }]);
     // 既に trust 済みなら policy=ask の経路に乗らないが、念のためポリシーを上書きして
     // ダイアログ経路に流して同 method を再度許可した時に重複しないことを確認する。
-    consentPolicy.set({ signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
+    consentPolicy.set({ connect: 'ask', signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
     trustedOrigins.set([{ origin, methods: [] }]); // この origin はリストに居るが method 空
     const promise = onConsent(nip04Request);
     approveConsent({ trustOrigin: true });
@@ -125,11 +135,44 @@ describe('onConsent', () => {
 
   it('deny policy beats trusted origin', async () => {
     trustedOrigins.set([{ origin, methods: ['signEvent'] }]);
-    consentPolicy.set({ signEvent: 'deny', nip44: 'ask', nip04: 'ask' });
+    consentPolicy.set({ connect: 'ask', signEvent: 'deny', nip44: 'ask', nip04: 'ask' });
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     const result = await onConsent(signRequest);
     expect(result).toBe(false);
     expect(get(denyCounts).signEvent).toBe(1);
+  });
+
+  it('asks for getPublicKey by default (no silent pairing)', async () => {
+    const promise = onConsent(getPublicKeyRequest);
+    expect(get(pendingConsent)).not.toBeNull();
+    rejectConsent();
+    expect(await promise).toBe(false);
+  });
+
+  it('approveConsent with trustOrigin records the connect pairing for the origin', async () => {
+    const promise = onConsent(getPublicKeyRequest);
+    approveConsent({ trustOrigin: true });
+    expect(await promise).toBe(true);
+    expect(get(trustedOrigins)).toEqual([{ origin, methods: ['connect'] }]);
+  });
+
+  it('a connect pairing approves subsequent getRelays without a dialog (one approval covers both)', async () => {
+    const promise = onConsent(getPublicKeyRequest);
+    approveConsent({ trustOrigin: true });
+    expect(await promise).toBe(true);
+
+    const result = await onConsent(getRelaysRequest);
+    expect(result).toBe(true);
+    expect(get(pendingConsent)).toBeNull();
+  });
+
+  it('connect deny policy auto-rejects getPublicKey and increments the counter', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    consentPolicy.set({ connect: 'deny', signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
+    const result = await onConsent(getPublicKeyRequest);
+    expect(result).toBe(false);
+    expect(get(denyCounts).connect).toBe(1);
+    expect(warn).toHaveBeenCalledOnce();
   });
 });
 
@@ -137,7 +180,7 @@ describe('onConsentWithFreshSettings', () => {
   it('re-reads persisted settings so a settings-page deny overrides a stale always store', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     // iframe の in-memory ストアは古い「always 許可」のまま。
-    consentPolicy.set({ signEvent: 'always', nip44: 'ask', nip04: 'ask' });
+    consentPolicy.set({ connect: 'ask', signEvent: 'always', nip44: 'ask', nip04: 'ask' });
     // 設定画面タブが localStorage を deny に書き換えたことを模す。永続化 subscriber に
     // 上書きされないよう、ストア set より後にストレージへ直接書き込む。
     localStorage.setItem(
@@ -155,7 +198,7 @@ describe('onConsentWithFreshSettings', () => {
   it('re-reads persisted settings so a revoked trusted origin falls back to the dialog', async () => {
     // 古い「常に許可」が in-memory に残っている状態。
     trustedOrigins.set([{ origin, methods: ['signEvent'] }]);
-    consentPolicy.set({ signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
+    consentPolicy.set({ connect: 'ask', signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
     // 設定画面タブが信頼リストを空にした（信頼解除）ことを模す。
     localStorage.setItem('nosskey_trusted_origins_v2', JSON.stringify([]));
 
@@ -169,7 +212,7 @@ describe('onConsentWithFreshSettings', () => {
   it('reads through the granted SDK storage handle (SAA first-party path)', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     // in-memory ストアは古い「always 許可」のまま（localStorage に書かれる）。
-    consentPolicy.set({ signEvent: 'always', nip44: 'ask', nip04: 'ask' });
+    consentPolicy.set({ connect: 'ask', signEvent: 'always', nip44: 'ask', nip04: 'ask' });
     // SAA グラント後の first-party ストレージハンドルを sessionStorage で代用し、
     // 設定画面が deny を書き込んだ状態を模す。reloadSettings は
     // resolveSettingsStorage() 経由でこのハンドルを優先して読む。

--- a/examples/svelte-app/src/store/app-state.spec.ts
+++ b/examples/svelte-app/src/store/app-state.spec.ts
@@ -48,7 +48,7 @@ function grantFirstPartyStorage(seed: Record<string, string> = {}): Storage {
 beforeEach(() => {
   resetNosskeyManager();
   trustedOrigins.set([]);
-  consentPolicy.set({ signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
+  consentPolicy.set({ connect: 'ask', signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
   cacheSecrets.set(true);
   cacheTimeout.set(300);
 });
@@ -62,7 +62,13 @@ describe('reloadSettings', () => {
       ]),
     });
     reloadSettings();
-    expect(get(consentPolicy)).toEqual({ signEvent: 'always', nip44: 'deny', nip04: 'ask' });
+    // 旧形式（connect キー無し）の保存値は connect: 'ask' に倒れる。
+    expect(get(consentPolicy)).toEqual({
+      connect: 'ask',
+      signEvent: 'always',
+      nip44: 'deny',
+      nip04: 'ask',
+    });
     expect(get(trustedOrigins)).toEqual([
       { origin: 'https://parent.example', methods: ['signEvent'] },
     ]);
@@ -78,7 +84,12 @@ describe('reloadSettings', () => {
   it('falls back to defaults when the granted storage is empty', () => {
     grantFirstPartyStorage();
     reloadSettings();
-    expect(get(consentPolicy)).toEqual({ signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
+    expect(get(consentPolicy)).toEqual({
+      connect: 'ask',
+      signEvent: 'ask',
+      nip44: 'ask',
+      nip04: 'ask',
+    });
     expect(get(trustedOrigins)).toEqual([]);
     expect(get(cacheSecrets)).toBe(true);
     expect(get(cacheTimeout)).toBe(300);
@@ -112,12 +123,13 @@ describe('settings persistence after a storage grant', () => {
     const firstParty = grantFirstPartyStorage();
     reloadSettings();
 
-    consentPolicy.set({ signEvent: 'always', nip44: 'ask', nip04: 'ask' });
+    consentPolicy.set({ connect: 'ask', signEvent: 'always', nip44: 'ask', nip04: 'ask' });
 
     // The settings handle and the relay handle are one and the same:
     // manager.getStorageOptions().storage. No second copy is kept.
     expect(getNosskeyManager().getStorageOptions().storage).toBe(firstParty);
     expect(JSON.parse(firstParty.getItem('nosskey_consent_policy') as string)).toEqual({
+      connect: 'ask',
       signEvent: 'always',
       nip44: 'ask',
       nip04: 'ask',
@@ -141,7 +153,12 @@ describe('cross-context sync via storage events', () => {
     // storage イベントは発火しないが、テストでは経路検証のため明示的に dispatch する。
     window.dispatchEvent(new StorageEvent('storage', { key: 'nosskey_consent_policy' }));
 
-    expect(get(consentPolicy)).toEqual({ signEvent: 'deny', nip44: 'ask', nip04: 'ask' });
+    expect(get(consentPolicy)).toEqual({
+      connect: 'ask',
+      signEvent: 'deny',
+      nip44: 'ask',
+      nip04: 'ask',
+    });
     expect(get(trustedOrigins)).toEqual([
       { origin: 'https://parent.example', methods: ['signEvent'] },
     ]);
@@ -157,13 +174,18 @@ describe('cross-context sync via storage events', () => {
     firstParty.clear();
     window.dispatchEvent(new StorageEvent('storage', { key: null }));
 
-    expect(get(consentPolicy)).toEqual({ signEvent: 'ask', nip44: 'ask', nip04: 'ask' });
+    expect(get(consentPolicy)).toEqual({
+      connect: 'ask',
+      signEvent: 'ask',
+      nip44: 'ask',
+      nip04: 'ask',
+    });
   });
 
   it('ignores storage events for keys it does not own', () => {
     const firstParty = grantFirstPartyStorage();
     reloadSettings();
-    consentPolicy.set({ signEvent: 'always', nip44: 'ask', nip04: 'ask' });
+    consentPolicy.set({ connect: 'ask', signEvent: 'always', nip44: 'ask', nip04: 'ask' });
     // ストレージ側だけ deny に差し替える（in-memory は always のまま）。
     firstParty.setItem(
       'nosskey_consent_policy',
@@ -189,10 +211,10 @@ describe('cross-context sync via storage events', () => {
     expect(setItemSpy).not.toHaveBeenCalled();
 
     // ガードは reloadSettings の外では解除され、通常の変更は永続化される。
-    consentPolicy.set({ signEvent: 'deny', nip44: 'ask', nip04: 'ask' });
+    consentPolicy.set({ connect: 'ask', signEvent: 'deny', nip44: 'ask', nip04: 'ask' });
     expect(setItemSpy).toHaveBeenCalledWith(
       'nosskey_consent_policy',
-      JSON.stringify({ signEvent: 'deny', nip44: 'ask', nip04: 'ask' })
+      JSON.stringify({ connect: 'ask', signEvent: 'deny', nip44: 'ask', nip04: 'ask' })
     );
   });
 });

--- a/examples/svelte-app/src/store/app-state.ts
+++ b/examples/svelte-app/src/store/app-state.ts
@@ -9,9 +9,18 @@ export type ScreenName = 'account' | 'settings' | 'key' | 'iframe';
 
 export type ConsentDecision = 'ask' | 'always' | 'deny';
 
-/** ポリシーキーは `signEvent` / `nip44` / `nip04` の 3 種で、暗号化と復号は同一バケットに集約される。 */
-export type PolicyKey = 'signEvent' | 'nip44' | 'nip04';
-export const POLICY_KEYS: readonly PolicyKey[] = ['signEvent', 'nip44', 'nip04'] as const;
+/**
+ * ポリシーキーは `connect` / `signEvent` / `nip44` / `nip04` の 4 種。
+ * `connect` は `getPublicKey` / `getRelays`（オリジン単位の接続承認）を、
+ * `nip44` / `nip04` は暗号化と復号を同一バケットに集約する。
+ */
+export type PolicyKey = 'connect' | 'signEvent' | 'nip44' | 'nip04';
+export const POLICY_KEYS: readonly PolicyKey[] = [
+  'connect',
+  'signEvent',
+  'nip44',
+  'nip04',
+] as const;
 
 export type ConsentPolicy = Record<PolicyKey, ConsentDecision>;
 
@@ -25,6 +34,7 @@ export interface TrustedOriginEntry {
 }
 
 const DEFAULT_CONSENT_POLICY: ConsentPolicy = {
+  connect: 'ask',
   signEvent: 'ask',
   nip44: 'ask',
   nip04: 'ask',
@@ -40,7 +50,7 @@ function isConsentDecision(value: unknown): value is ConsentDecision {
 }
 
 function isPolicyKey(value: unknown): value is PolicyKey {
-  return value === 'signEvent' || value === 'nip44' || value === 'nip04';
+  return value === 'connect' || value === 'signEvent' || value === 'nip44' || value === 'nip04';
 }
 
 export function isScreenName(hash: string): hash is ScreenName {
@@ -88,6 +98,7 @@ export const consentPolicy = writable<ConsentPolicy>({ ...DEFAULT_CONSENT_POLICY
  * メソッドキー単位で集計し、永続化はしない（プロセス内のみ）。
  */
 export const denyCounts = writable<Record<PolicyKey, number>>({
+  connect: 0,
   signEvent: 0,
   nip44: 0,
   nip04: 0,
@@ -98,7 +109,7 @@ export function incrementDenyCount(key: PolicyKey): void {
 }
 
 export function resetDenyCounts(): void {
-  denyCounts.set({ signEvent: 0, nip44: 0, nip04: 0 });
+  denyCounts.set({ connect: 0, signEvent: 0, nip44: 0, nip04: 0 });
 }
 
 /**
@@ -188,6 +199,7 @@ function loadConsentPolicy(): ConsentPolicy {
   try {
     const parsed = JSON.parse(raw) as Partial<Record<keyof ConsentPolicy, unknown>>;
     const result: ConsentPolicy = {
+      connect: isConsentDecision(parsed.connect) ? parsed.connect : 'ask',
       signEvent: isConsentDecision(parsed.signEvent) ? parsed.signEvent : 'ask',
       nip44: isConsentDecision(parsed.nip44) ? parsed.nip44 : 'ask',
       nip04: isConsentDecision(parsed.nip04) ? parsed.nip04 : 'ask',

--- a/examples/svelte-app/src/utils/consent-gating.spec.ts
+++ b/examples/svelte-app/src/utils/consent-gating.spec.ts
@@ -3,6 +3,7 @@ import type { ConsentPolicy, TrustedOriginEntry } from '../store/app-state.js';
 import { evaluateConsent, policyKeyFor } from './consent-gating.js';
 
 const askPolicy: ConsentPolicy = {
+  connect: 'ask',
   signEvent: 'ask',
   nip44: 'ask',
   nip04: 'ask',
@@ -10,6 +11,8 @@ const askPolicy: ConsentPolicy = {
 
 describe('policyKeyFor', () => {
   it.each([
+    ['getPublicKey', 'connect'],
+    ['getRelays', 'connect'],
     ['signEvent', 'signEvent'],
     ['nip44_encrypt', 'nip44'],
     ['nip44_decrypt', 'nip44'],
@@ -85,5 +88,32 @@ describe('evaluateConsent', () => {
         reason: 'policy-deny',
       });
     }
+  });
+
+  it('treats getPublicKey and getRelays as the same connect bucket (one pairing covers both)', () => {
+    const trusted: TrustedOriginEntry[] = [{ origin, methods: ['connect'] }];
+    for (const method of ['getPublicKey', 'getRelays'] as const) {
+      expect(
+        evaluateConsent({ origin, method }, { trustedOrigins: trusted, policy: askPolicy })
+      ).toEqual({ decision: 'approve', reason: 'trusted-origin' });
+    }
+  });
+
+  it('asks for connect when origin is trusted only for signEvent (no implicit pairing)', () => {
+    const trusted: TrustedOriginEntry[] = [{ origin, methods: ['signEvent'] }];
+    expect(
+      evaluateConsent(
+        { origin, method: 'getPublicKey' },
+        { trustedOrigins: trusted, policy: askPolicy }
+      )
+    ).toEqual({ decision: 'ask' });
+  });
+
+  it('rejects connect requests when the connect policy is deny', () => {
+    const policy: ConsentPolicy = { ...askPolicy, connect: 'deny' };
+    const trusted: TrustedOriginEntry[] = [{ origin, methods: ['connect'] }];
+    expect(
+      evaluateConsent({ origin, method: 'getPublicKey' }, { trustedOrigins: trusted, policy })
+    ).toEqual({ decision: 'reject', reason: 'policy-deny' });
   });
 });

--- a/examples/svelte-app/src/utils/consent-gating.ts
+++ b/examples/svelte-app/src/utils/consent-gating.ts
@@ -14,18 +14,19 @@ export type ConsentEvaluation =
 
 /**
  * メソッド名を `ConsentPolicy` のキーへマップする。
- * `nip44_encrypt` / `nip44_decrypt` は `nip44` に集約され、
- * `nip04_*` も同様。`signEvent` のみ単独。
+ * `getPublicKey` / `getRelays` はオリジン単位の接続承認（ペアリング）として
+ * `connect` に集約され、`nip44_encrypt` / `nip44_decrypt` は `nip44` に、
+ * `nip04_*` も同様に集約される。`signEvent` のみ単独。
  *
  * 全分岐を網羅。`NosskeyMethod` の union に新値が追加されたら
  * `default` の `never` 代入で TS コンパイルエラーになる。
  * これにより新メソッド追加時のサイレントなフォールスルーを防ぐ。
- *
- * 非 consent メソッド (`getPublicKey` / `getRelays`) はそもそも
- * `onConsent` に到達しないが、防御的に throw する。
  */
 export function policyKeyFor(method: ConsentRequest['method']): PolicyKey {
   switch (method) {
+    case 'getPublicKey':
+    case 'getRelays':
+      return 'connect';
     case 'signEvent':
       return 'signEvent';
     case 'nip44_encrypt':
@@ -34,9 +35,6 @@ export function policyKeyFor(method: ConsentRequest['method']): PolicyKey {
     case 'nip04_encrypt':
     case 'nip04_decrypt':
       return 'nip04';
-    case 'getPublicKey':
-    case 'getRelays':
-      throw new Error(`policyKeyFor called with non-consent method: ${method}`);
     default: {
       const exhaustive: never = method;
       throw new Error(`Unhandled NosskeyMethod in policyKeyFor: ${String(exhaustive)}`);

--- a/packages/nosskey-iframe/README.ja.md
+++ b/packages/nosskey-iframe/README.ja.md
@@ -111,7 +111,9 @@ host.start();
 // host.stop();
 ```
 
-機密素材に触れるメソッド (`signEvent`, `nip44_*`, `nip04_*`) は `onConsent` で gate されます。`getPublicKey` と `getRelays` は対象外です。
+全 7 つの NIP-07 メソッドが `onConsent` で gate されます。`getPublicKey` / `getRelays` に対する同意は、NIP-07 ブラウザ拡張と同じ「オリジン単位の接続承認（ペアリング）」として機能します。これにより、任意の埋め込みサイトがログイン中ユーザーの npub やリレー設定をサイレントに読み取ることを防ぎます。承認済みオリジンは同意 UI 側で記憶してください（参照実装では信頼済みオリジンとして保存）。これでログインフローの摩擦は初回のみになります。
+
+> **破壊的変更（セキュリティ修正）:** 以前のバージョンは `getPublicKey` / `getRelays` を同意なしで返していました。デフォルトの `requireUserConsent: true` のままのホストは `onConsent` を必ず提供してください。未提供の場合、これらのメソッドは `INTERNAL` エラーになります。従来のサイレント動作に戻すには `requireUserConsent: false` を明示してください。なお `onGetRelays` 未設定または鍵未設定のときの `getRelays` は従来どおり同意なしで `{}` を返します。
 
 詳細アーキテクチャ (同意 UI パターン、Storage Access API、7 メソッドの NIP-07 実装、embedded テーマ/言語伝搬) は
 [`docs/ja/iframe-host.ja.md`](../../docs/ja/iframe-host.ja.md) を参照。

--- a/packages/nosskey-iframe/README.md
+++ b/packages/nosskey-iframe/README.md
@@ -112,7 +112,9 @@ host.start();
 // host.stop();
 ```
 
-Methods that touch secret material (`signEvent`, `nip44_*`, `nip04_*`) are gated by `onConsent`. `getPublicKey` and `getRelays` are not.
+All seven NIP-07 methods are gated by `onConsent`. For `getPublicKey` / `getRelays` the consent acts as a per-origin connection approval (pairing) — the same model NIP-07 browser extensions use — so an arbitrary embedding site cannot silently read the logged-in user's npub or relay list. Remember approved origins in your consent UI (the reference app stores them as trusted origins) to keep login flows friction-free.
+
+> **Breaking change (security fix):** earlier versions served `getPublicKey` / `getRelays` without consent. Hosts that keep the default `requireUserConsent: true` must provide `onConsent`, or these methods now fail with `INTERNAL`. To restore the old silent behavior, opt out explicitly with `requireUserConsent: false`. `getRelays` still returns `{}` without prompting when `onGetRelays` is not configured or no key is set.
 
 For the full architecture (consent UI patterns, Storage Access API, the seven NIP-07 methods, embedded theme/lang propagation) see
 [`docs/en/iframe-host.en.md`](../../docs/en/iframe-host.en.md).

--- a/packages/nosskey-iframe/src/host.spec.ts
+++ b/packages/nosskey-iframe/src/host.spec.ts
@@ -121,14 +121,16 @@ describe('NosskeyIframeHost', () => {
     expect(warnSpy).toHaveBeenCalledOnce();
   });
 
-  it('routes getPublicKey and returns the manager result', async () => {
+  it('routes getPublicKey after onConsent resolves true', async () => {
     const win = createFakeWindow() as DispatchableWindow;
+    const onConsent = vi.fn(async () => true);
     const manager = makeManager({
       getPublicKey: vi.fn(async () => 'deadbeef'),
     });
     const host = new NosskeyIframeHost({
       manager,
       allowedOrigins: ['https://parent.example'],
+      onConsent,
       window: win as unknown as Window,
     });
     host.start();
@@ -138,6 +140,10 @@ describe('NosskeyIframeHost', () => {
       'https://parent.example'
     );
 
+    expect(onConsent).toHaveBeenCalledWith({
+      origin: 'https://parent.example',
+      method: 'getPublicKey',
+    });
     expect(manager.getPublicKey).toHaveBeenCalledOnce();
     expect(win.sent).toHaveLength(1);
     const msg = win.sent[0];
@@ -147,16 +153,139 @@ describe('NosskeyIframeHost', () => {
     host.stop();
   });
 
-  it('routes getRelays via the onGetRelays callback', async () => {
+  it('returns USER_REJECTED for getPublicKey when consent is denied', async () => {
+    const win = createFakeWindow() as DispatchableWindow;
+    const manager = makeManager({
+      getPublicKey: vi.fn(async () => {
+        throw new Error('should not be called');
+      }),
+    });
+    const host = new NosskeyIframeHost({
+      manager,
+      allowedOrigins: ['https://parent.example'],
+      onConsent: async () => false,
+      window: win as unknown as Window,
+    });
+    host.start();
+
+    await win.dispatchMessage(
+      { type: 'nosskey:request', id: 'r1d', method: 'getPublicKey' },
+      'https://parent.example'
+    );
+
+    expect(manager.getPublicKey).not.toHaveBeenCalled();
+    expect((win.sent[0].data as { error: { code: string } }).error.code).toBe('USER_REJECTED');
+    host.stop();
+  });
+
+  it('returns INTERNAL for getPublicKey when onConsent is missing (fail-closed default)', async () => {
+    const win = createFakeWindow() as DispatchableWindow;
+    const manager = makeManager({ getPublicKey: vi.fn(async () => 'deadbeef') });
+    const host = new NosskeyIframeHost({
+      manager,
+      allowedOrigins: ['https://parent.example'],
+      // onConsent intentionally omitted while requireUserConsent defaults to true
+      window: win as unknown as Window,
+    });
+    host.start();
+
+    await win.dispatchMessage(
+      { type: 'nosskey:request', id: 'r1i', method: 'getPublicKey' },
+      'https://parent.example'
+    );
+
+    expect(manager.getPublicKey).not.toHaveBeenCalled();
+    expect((win.sent[0].data as { error: { code: string } }).error.code).toBe('INTERNAL');
+    host.stop();
+  });
+
+  it('serves getPublicKey silently when requireUserConsent is false (explicit opt-out)', async () => {
+    const win = createFakeWindow() as DispatchableWindow;
+    const manager = makeManager({ getPublicKey: vi.fn(async () => 'deadbeef') });
+    const host = new NosskeyIframeHost({
+      manager,
+      allowedOrigins: ['https://parent.example'],
+      requireUserConsent: false,
+      window: win as unknown as Window,
+    });
+    host.start();
+
+    await win.dispatchMessage(
+      { type: 'nosskey:request', id: 'r1s', method: 'getPublicKey' },
+      'https://parent.example'
+    );
+
+    expect((win.sent[0].data as { result: unknown }).result).toBe('deadbeef');
+    host.stop();
+  });
+
+  it('posts visibility true/false around a consented getPublicKey', async () => {
+    const win = createFakeWindow() as DispatchableWindow;
+    const parent = { postMessage: vi.fn() } as unknown as Window;
+    Object.defineProperty(win, 'parent', { value: parent, configurable: true });
+    const manager = makeManager({ getPublicKey: vi.fn(async () => 'deadbeef') });
+    const host = new NosskeyIframeHost({
+      manager,
+      allowedOrigins: ['https://parent.example'],
+      onConsent: async () => true,
+      window: win as unknown as Window,
+    });
+    host.start();
+
+    await win.dispatchMessage(
+      { type: 'nosskey:request', id: 'r1v', method: 'getPublicKey' },
+      'https://parent.example'
+    );
+
+    const visibilityMessages = (
+      parent.postMessage as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls
+      .map((c) => c[0])
+      .filter(isNosskeyVisibility);
+    expect(visibilityMessages.map((m) => m.visible)).toEqual([true, false]);
+    host.stop();
+  });
+
+  it('does not post visibility when getPublicKey fails with NO_KEY', async () => {
+    const win = createFakeWindow() as DispatchableWindow;
+    const parent = { postMessage: vi.fn() } as unknown as Window;
+    Object.defineProperty(win, 'parent', { value: parent, configurable: true });
+    const manager = makeManager({ hasKeyInfo: () => false });
+    const host = new NosskeyIframeHost({
+      manager,
+      allowedOrigins: ['https://parent.example'],
+      onConsent: async () => true,
+      window: win as unknown as Window,
+    });
+    host.start();
+
+    await win.dispatchMessage(
+      { type: 'nosskey:request', id: 'r1n', method: 'getPublicKey' },
+      'https://parent.example'
+    );
+
+    const visibilityMessages = (
+      parent.postMessage as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls
+      .map((c) => c[0])
+      .filter(isNosskeyVisibility);
+    expect(visibilityMessages).toHaveLength(0);
+    expect((win.sent[0].data as { error: { code: string } }).error.code).toBe('NO_KEY');
+    host.stop();
+  });
+
+  it('routes getRelays via onGetRelays after onConsent resolves true', async () => {
     const win = createFakeWindow() as DispatchableWindow;
     const relays = {
       'wss://relay.example': { read: true, write: true },
       'wss://relay.read.example': { read: true, write: false },
     };
     const onGetRelays = vi.fn(async () => relays);
+    const onConsent = vi.fn(async () => true);
     const host = new NosskeyIframeHost({
       manager: makeManager(),
       allowedOrigins: ['https://parent.example'],
+      onConsent,
       onGetRelays,
       window: win as unknown as Window,
     });
@@ -167,6 +296,10 @@ describe('NosskeyIframeHost', () => {
       'https://parent.example'
     );
 
+    expect(onConsent).toHaveBeenCalledWith({
+      origin: 'https://parent.example',
+      method: 'getRelays',
+    });
     expect(onGetRelays).toHaveBeenCalledOnce();
     expect(win.sent).toHaveLength(1);
     const msg = win.sent[0];
@@ -176,11 +309,35 @@ describe('NosskeyIframeHost', () => {
     host.stop();
   });
 
-  it('returns an empty map for getRelays when onGetRelays is not provided', async () => {
+  it('returns USER_REJECTED for getRelays when consent is denied', async () => {
     const win = createFakeWindow() as DispatchableWindow;
+    const onGetRelays = vi.fn(async () => ({}));
     const host = new NosskeyIframeHost({
       manager: makeManager(),
       allowedOrigins: ['https://parent.example'],
+      onConsent: async () => false,
+      onGetRelays,
+      window: win as unknown as Window,
+    });
+    host.start();
+
+    await win.dispatchMessage(
+      { type: 'nosskey:request', id: 'rg1d', method: 'getRelays' },
+      'https://parent.example'
+    );
+
+    expect(onGetRelays).not.toHaveBeenCalled();
+    expect((win.sent[0].data as { error: { code: string } }).error.code).toBe('USER_REJECTED');
+    host.stop();
+  });
+
+  it('returns an empty map for getRelays without consent when onGetRelays is not provided', async () => {
+    const win = createFakeWindow() as DispatchableWindow;
+    const onConsent = vi.fn(async () => true);
+    const host = new NosskeyIframeHost({
+      manager: makeManager(),
+      allowedOrigins: ['https://parent.example'],
+      onConsent,
       window: win as unknown as Window,
     });
     host.start();
@@ -190,7 +347,34 @@ describe('NosskeyIframeHost', () => {
       'https://parent.example'
     );
 
+    expect(onConsent).not.toHaveBeenCalled();
     expect(win.sent).toHaveLength(1);
+    expect((win.sent[0].data as { result: unknown }).result).toEqual({});
+    host.stop();
+  });
+
+  it('returns an empty map for getRelays without consent when no key is configured', async () => {
+    const win = createFakeWindow() as DispatchableWindow;
+    const onConsent = vi.fn(async () => true);
+    const onGetRelays = vi.fn(async () => ({
+      'wss://relay.example': { read: true, write: true },
+    }));
+    const host = new NosskeyIframeHost({
+      manager: makeManager({ hasKeyInfo: () => false }),
+      allowedOrigins: ['https://parent.example'],
+      onConsent,
+      onGetRelays,
+      window: win as unknown as Window,
+    });
+    host.start();
+
+    await win.dispatchMessage(
+      { type: 'nosskey:request', id: 'rg3', method: 'getRelays' },
+      'https://parent.example'
+    );
+
+    expect(onConsent).not.toHaveBeenCalled();
+    expect(onGetRelays).not.toHaveBeenCalled();
     expect((win.sent[0].data as { result: unknown }).result).toEqual({});
     host.stop();
   });
@@ -335,6 +519,7 @@ describe('NosskeyIframeHost', () => {
     const host = new NosskeyIframeHost({
       manager,
       allowedOrigins: ['https://parent.example'],
+      onConsent: async () => true,
       window: win as unknown as Window,
     });
     host.start();
@@ -562,6 +747,7 @@ describe('NosskeyIframeHost', () => {
     const host = new NosskeyIframeHost({
       manager,
       allowedOrigins: ['https://parent.example'],
+      onConsent: async () => true,
       window: win as unknown as Window,
     });
     host.start();

--- a/packages/nosskey-iframe/src/host.ts
+++ b/packages/nosskey-iframe/src/host.ts
@@ -20,7 +20,7 @@ import type { NosskeyManagerLike, NostrEvent } from './types.js';
 export interface ConsentRequest {
   origin: string;
   method: NosskeyMethod;
-  /** Set for `signEvent`. */
+  /** Set for `signEvent`. Always undefined for `getPublicKey` / `getRelays`. */
   event?: NostrEvent;
   /** Counterparty public key for nip44 / nip04 methods (32-byte hex). */
   pubkey?: string;
@@ -42,15 +42,21 @@ export interface NosskeyIframeHostOptions {
    */
   allowedOrigins?: string[] | '*';
   /**
-   * When true, signEvent requests require {@link onConsent} to resolve truthy.
+   * When true, all consent-required methods (`getPublicKey`, `getRelays`,
+   * `signEvent`, nip44/nip04 encrypt/decrypt) require {@link onConsent} to
+   * resolve truthy. For `getPublicKey` / `getRelays` this acts as a
+   * per-origin connection approval that blocks silent user identification
+   * by arbitrary embedding origins.
    * @default true
    */
   requireUserConsent?: boolean;
   /** Called to obtain user consent. Required when `requireUserConsent` is true. */
   onConsent?: (request: ConsentRequest) => Promise<boolean>;
   /**
-   * Resolves the relay map returned by NIP-07 `getRelays()`. Read-only and
-   * never prompts the user. Omit to return an empty map.
+   * Resolves the relay map returned by NIP-07 `getRelays()`. Subject to the
+   * same consent gate as `getPublicKey` when a key is configured (the relay
+   * set identifies the logged-in user). Omit to return an empty map without
+   * prompting.
    */
   onGetRelays?: () => Promise<RelayMap>;
   /** Override the window used to install the message listener. Defaults to globalThis.window. */
@@ -179,15 +185,18 @@ export class NosskeyIframeHost {
 
     switch (request.method) {
       case 'getPublicKey': {
-        if (!manager.hasKeyInfo()) {
-          throw new HostError('NO_KEY', 'No key is configured in the iframe.');
-        }
-        return manager.getPublicKey();
+        return this.#withVisibilityAndConsent({ origin, method: 'getPublicKey' }, () =>
+          manager.getPublicKey()
+        );
       }
       case 'getRelays': {
         const { onGetRelays } = this.#options;
+        // An empty map carries no user-identifying information, so the two
+        // cases below stay consent-free: no relay resolver configured, or no
+        // key (= nobody logged in to identify).
         if (!onGetRelays) return {} satisfies RelayMap;
-        return onGetRelays();
+        if (!manager.hasKeyInfo()) return {} satisfies RelayMap;
+        return this.#withVisibilityAndConsent({ origin, method: 'getRelays' }, () => onGetRelays());
       }
       case 'signEvent': {
         const event = request.params?.event;
@@ -265,7 +274,8 @@ export class NosskeyIframeHost {
 
   /**
    * Show the iframe, request user consent, run the operation, and hide the iframe.
-   * Shared by signEvent and the nip44/nip04 encrypt/decrypt methods.
+   * Shared by getPublicKey, getRelays, signEvent, and the nip44/nip04
+   * encrypt/decrypt methods.
    */
   async #withVisibilityAndConsent<T>(consent: ConsentRequest, run: () => Promise<T>): Promise<T> {
     const { manager, requireUserConsent, onConsent } = this.#options;

--- a/packages/nosskey-iframe/src/index.ts
+++ b/packages/nosskey-iframe/src/index.ts
@@ -8,7 +8,9 @@ export type { NosskeyIframeClientOptions } from './client.js';
 export { NosskeyIframeHost } from './host.js';
 export type { ConsentRequest, NosskeyIframeHostOptions } from './host.js';
 export {
+  CONSENT_REQUIRED_METHODS,
   NOSSKEY_ERROR_CODES,
+  isConnectMethod,
   isDecryptMethod,
   isEncryptMethod,
   isNosskeyReady,

--- a/packages/nosskey-iframe/src/protocol.spec.ts
+++ b/packages/nosskey-iframe/src/protocol.spec.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
+  CONSENT_REQUIRED_METHODS,
   NOSSKEY_ERROR_CODES,
   type NosskeyErrorCode,
+  type NosskeyMethod,
+  isConnectMethod,
   isDecryptMethod,
   isEncryptMethod,
   isNosskeyReady,
@@ -189,6 +192,42 @@ describe('protocol: isNosskeyVisibility', () => {
 
   it.each([null, undefined, 'nosskey:visibility', 0, []])('rejects %s', (value) => {
     expect(isNosskeyVisibility(value)).toBe(false);
+  });
+});
+
+describe('protocol: CONSENT_REQUIRED_METHODS', () => {
+  it('covers every supported method (no silent reads for arbitrary origins)', () => {
+    const expected: NosskeyMethod[] = [
+      'getPublicKey',
+      'getRelays',
+      'signEvent',
+      'nip44_encrypt',
+      'nip44_decrypt',
+      'nip04_encrypt',
+      'nip04_decrypt',
+    ];
+    expect(CONSENT_REQUIRED_METHODS).toEqual(expected);
+  });
+
+  it('includes getPublicKey and getRelays (per-origin pairing approval)', () => {
+    expect(CONSENT_REQUIRED_METHODS).toContain('getPublicKey');
+    expect(CONSENT_REQUIRED_METHODS).toContain('getRelays');
+  });
+});
+
+describe('protocol: isConnectMethod', () => {
+  it.each(['getPublicKey', 'getRelays'] as const)('returns true for %s', (method) => {
+    expect(isConnectMethod(method)).toBe(true);
+  });
+
+  it.each([
+    'signEvent',
+    'nip44_encrypt',
+    'nip44_decrypt',
+    'nip04_encrypt',
+    'nip04_decrypt',
+  ] as const)('returns false for %s', (method) => {
+    expect(isConnectMethod(method)).toBe(false);
   });
 });
 

--- a/packages/nosskey-iframe/src/protocol.ts
+++ b/packages/nosskey-iframe/src/protocol.ts
@@ -18,14 +18,34 @@ export type NosskeyMethod =
   | 'nip04_encrypt'
   | 'nip04_decrypt';
 
-/** Methods that mutate or expose secret material and therefore require user consent. */
+/**
+ * Methods that mutate secret material or expose user-identifying information
+ * and therefore require user consent. `getPublicKey` / `getRelays` are
+ * included because they let an arbitrary embedding origin silently identify
+ * the logged-in user (npub + relay set) — the consent here acts as a
+ * per-origin pairing approval, mirroring NIP-07 browser extensions.
+ *
+ * Exception: `getRelays` skips consent and returns an empty map when no
+ * `onGetRelays` resolver is configured or no key is set (an empty map
+ * carries no user-identifying information).
+ *
+ * The actual enforcement lives in the host's dispatch (`host.ts`); keep
+ * this list in sync when adding a new method there.
+ */
 export const CONSENT_REQUIRED_METHODS: readonly NosskeyMethod[] = [
+  'getPublicKey',
+  'getRelays',
   'signEvent',
   'nip44_encrypt',
   'nip44_decrypt',
   'nip04_encrypt',
   'nip04_decrypt',
 ] as const;
+
+/** True for `getPublicKey` / `getRelays` (per-origin connection approval). */
+export function isConnectMethod(method: NosskeyMethod): boolean {
+  return method === 'getPublicKey' || method === 'getRelays';
+}
 
 /** True for `nip44_encrypt` / `nip04_encrypt`. */
 export function isEncryptMethod(method: NosskeyMethod): boolean {


### PR DESCRIPTION
Security audit 2026-06-10 H-1: any site could embed an invisible iframe and
silently read the logged-in user's npub and relay list (de-anonymization).

Mirror the NIP-07 extension model (nos2x/Alby): both methods now go through
the consent flow as a per-origin pairing approval.

SDK (packages/nosskey-iframe):
- Add getPublicKey/getRelays to CONSENT_REQUIRED_METHODS, add isConnectMethod
- Route both methods through #withVisibilityAndConsent in the host dispatch
- Exception: getRelays still returns {} without consent when onGetRelays is
  unset or no key is configured (no user-identifying information)
- BREAKING: hosts with default requireUserConsent: true must provide
  onConsent or these methods fail closed with INTERNAL

Reference app (examples/svelte-app):
- New PolicyKey 'connect' bundles both methods into one approval bucket;
  "always allow" remembers origin x connect in trusted origins
- Connection-request dialog copy (ja/en) and settings policy row

Docs: package READMEs, iframe-host (ja/en), audit report status, todo list.

https://claude.ai/code/session_01LaMUuF7QfZq64V9B66t8RS