### PR TITLE
feat(svelte-app): PRF 非対応認証器のエラーメッセージを分かりやすく

### DIFF
--- a/examples/svelte-app/src/components/screens/AuthScreen.svelte
+++ b/examples/svelte-app/src/components/screens/AuthScreen.svelte
@@ -5,6 +5,7 @@ import { i18n } from '../../i18n/i18n-store.js';
 import { getNosskeyManager } from '../../services/nosskey-manager.service.js';
 import { initAccounts } from '../../store/accounts.js';
 import * as appState from '../../store/app-state.js';
+import { formatAuthError } from '../../utils/auth-error.js';
 import { isValidNsec, nsecToHex } from '../../utils/bech32-converter.js';
 import SavedAccounts from '../SavedAccounts.svelte';
 import HelpTip from '../ui/HelpTip.svelte';
@@ -67,7 +68,11 @@ async function createNew() {
     await appState.loginWith(keyInfo);
   } catch (error) {
     console.error('パスキー作成エラー:', error);
-    errorMessage = `${$i18n.t.common.errorMessages.passkeyCreation} ${error instanceof Error ? error.message : String(error)}`;
+    errorMessage = formatAuthError(
+      $i18n.t.common.errorMessages.passkeyCreation,
+      $i18n.t.common.errorMessages.prfUnsupported,
+      error
+    );
   } finally {
     isLoading = false;
   }
@@ -120,7 +125,11 @@ async function importExisting() {
   } catch (error) {
     seckey.fill(0);
     console.error('nsec インポートエラー:', error);
-    errorMessage = `${$i18n.t.common.errorMessages.importNsec} ${error instanceof Error ? error.message : String(error)}`;
+    errorMessage = formatAuthError(
+      $i18n.t.common.errorMessages.importNsec,
+      $i18n.t.common.errorMessages.prfUnsupported,
+      error
+    );
   } finally {
     isLoading = false;
   }
@@ -138,7 +147,11 @@ async function login() {
     await appState.loginWith(keyInfo);
   } catch (error) {
     console.error('ログインエラー:', error);
-    errorMessage = `${$i18n.t.common.errorMessages.login} ${error instanceof Error ? error.message : String(error)}`;
+    errorMessage = formatAuthError(
+      $i18n.t.common.errorMessages.login,
+      $i18n.t.common.errorMessages.prfUnsupported,
+      error
+    );
   } finally {
     isLoading = false;
   }

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -289,7 +289,7 @@ export const ja: TranslationData = {
       login: 'ログインエラー:',
       importNsec: 'nsec インポートエラー:',
       prfUnsupported:
-        'このパスキー（認証器）は PRF 拡張に対応していないため利用できません。Bitwarden など一部の認証器は未対応です。別のパスキー（端末内蔵のパスキーやセキュリティキーなど）でお試しください。',
+        'このパスキーは利用できません。Bitwarden など一部の認証器は未対応なため、PRF 拡張に対応した別のパスキー（プラットフォームのパスキーなど）でお試しください。',
     },
   },
   appWarning: {
@@ -570,7 +570,7 @@ export const en: TranslationData = {
       login: 'Login Error:',
       importNsec: 'nsec Import Error:',
       prfUnsupported:
-        "This passkey (authenticator) can't be used because it doesn't support the PRF extension. Some authenticators such as Bitwarden are not yet supported. Please try a different passkey, such as your device's built-in passkey or a security key.",
+        "This passkey can't be used. Some authenticators such as Bitwarden are not supported, so please try a different passkey that supports the PRF extension (such as a platform passkey).",
     },
   },
   appWarning: {

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -26,6 +26,7 @@ export interface TranslationData {
       passkeyCreation: string;
       login: string;
       importNsec: string;
+      prfUnsupported: string;
     };
   };
   appWarning: {
@@ -287,6 +288,8 @@ export const ja: TranslationData = {
       passkeyCreation: 'パスキー作成エラー:',
       login: 'ログインエラー:',
       importNsec: 'nsec インポートエラー:',
+      prfUnsupported:
+        'このパスキー（認証器）は PRF 拡張に対応していないため利用できません。Bitwarden など一部の認証器は未対応です。別のパスキー（端末内蔵のパスキーやセキュリティキーなど）でお試しください。',
     },
   },
   appWarning: {
@@ -566,6 +569,8 @@ export const en: TranslationData = {
       passkeyCreation: 'Passkey Creation Error:',
       login: 'Login Error:',
       importNsec: 'nsec Import Error:',
+      prfUnsupported:
+        "This passkey (authenticator) can't be used because it doesn't support the PRF extension. Some authenticators such as Bitwarden are not yet supported. Please try a different passkey, such as your device's built-in passkey or a security key.",
     },
   },
   appWarning: {

--- a/examples/svelte-app/src/utils/auth-error.spec.ts
+++ b/examples/svelte-app/src/utils/auth-error.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { formatAuthError, isPrfUnsupportedError } from './auth-error.js';
+
+const PRF_UNSUPPORTED = 'try another passkey';
+
+describe('isPrfUnsupportedError', () => {
+  it('detects "PRF secret not available"', () => {
+    expect(isPrfUnsupportedError(new Error('PRF secret not available'))).toBe(true);
+  });
+
+  it('detects "Invalid PRF output: all zeros"', () => {
+    expect(isPrfUnsupportedError(new Error('Invalid PRF output: all zeros'))).toBe(true);
+  });
+
+  it('detects the message even when wrapped in additional context', () => {
+    expect(
+      isPrfUnsupportedError(new Error('createNostrKey failed: PRF secret not available'))
+    ).toBe(true);
+  });
+
+  it('handles non-Error values via String()', () => {
+    expect(isPrfUnsupportedError('PRF secret not available')).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isPrfUnsupportedError(new Error('Authentication failed'))).toBe(false);
+  });
+});
+
+describe('formatAuthError', () => {
+  it('returns only the PRF guidance message for PRF errors', () => {
+    expect(
+      formatAuthError('Login Error:', PRF_UNSUPPORTED, new Error('PRF secret not available'))
+    ).toBe(PRF_UNSUPPORTED);
+  });
+
+  it('returns prefix + raw message for unrelated errors', () => {
+    expect(formatAuthError('Login Error:', PRF_UNSUPPORTED, new Error('boom'))).toBe(
+      'Login Error: boom'
+    );
+  });
+
+  it('stringifies non-Error values for unrelated errors', () => {
+    expect(formatAuthError('Login Error:', PRF_UNSUPPORTED, 'boom')).toBe('Login Error: boom');
+  });
+});

--- a/examples/svelte-app/src/utils/auth-error.ts
+++ b/examples/svelte-app/src/utils/auth-error.ts
@@ -1,0 +1,29 @@
+// 認証フロー（パスキー作成・ログイン・nsec インポート・再ログイン）で投げられた
+// エラーをユーザー向け文言に整形する共通ロジック。
+//
+// PRF 拡張に対応しない認証器（Bitwarden など）では SDK が PRF 由来のエラーを投げる。
+// 生のメッセージ（"PRF secret not available" 等）は分かりにくいため、別パスキーを
+// 試すよう促す案内文へ差し替える。
+
+/** SDK が投げる PRF 由来のエラーかどうかを判定する。 */
+export function isPrfUnsupportedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  // prf-handler の "PRF secret not available"（PRF 結果が返らない）と、
+  // nosskey の "Invalid PRF output: all zeros"（PRF が無効値）を拾う。
+  return message.includes('PRF secret not available') || message.includes('Invalid PRF output');
+}
+
+/**
+ * エラーをユーザー向け文言に整形する。
+ * PRF 非対応のときは案内文のみを返し、それ以外はプレフィックス + 生メッセージを返す。
+ */
+export function formatAuthError(
+  prefix: string,
+  prfUnsupportedMessage: string,
+  error: unknown
+): string {
+  if (isPrfUnsupportedError(error)) {
+    return prfUnsupportedMessage;
+  }
+  return `${prefix} ${error instanceof Error ? error.message : String(error)}`;
+}


### PR DESCRIPTION
Bitwarden など PRF 拡張に対応しない認証器を選ぶとパスキー作成・ログイン・
nsec インポートが失敗するが、従来は SDK の生メッセージ（"PRF secret not
available" 等）がそのまま表示され原因が分かりにくかった。

- utils/auth-error.ts を追加し、PRF 由来エラー（"PRF secret not available" /
  "Invalid PRF output"）を検出して「別のパスキーを試して」と促す案内文へ
  差し替える formatAuthError() を実装
- translations.ts に prfUnsupported メッセージ（ja/en）を追加
- AuthScreen の createNew / login / importExisting の catch に適用

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012EL7wUbsjgyAeyyKhiAo9P