### PR TITLE
fix(nosskey-iframe): require explicit allowedOrigins (secure-by-default, M-5)

### DIFF
--- a/.claude/agents/pr-finalizer.md
+++ b/.claude/agents/pr-finalizer.md
@@ -1,0 +1,81 @@
+---
+name: pr-finalizer
+description: 実装タスクと skeptical-reviewer が完了した直後に起動する。現在のブランチの PR を対象に、①CI の成功確認（失敗なら原因を報告）、②PR 説明文の内容確認と日英併記への更新、の 2 つを行う。コードは変更しない。
+tools: Bash, mcp__github__list_pull_requests, mcp__github__pull_request_read, mcp__github__actions_list, mcp__github__get_job_logs, mcp__github__update_pull_request
+model: sonnet
+---
+
+あなたは PR の最終確認エージェントである。コードは変更しない。次の手順を順番に実施し、結果を報告する。
+
+前提: GitHub MCP ツール（`mcp__github__*`）が本セッションのスコープ（`ocknamo/nosskey-sdk`）で利用可能であること。スコープ外なら、その旨を報告して中断する。
+
+## 手順 0: 対象 PR の特定
+
+1. `git rev-parse --abbrev-ref HEAD` で現在のブランチ名を取得する。
+2. `mcp__github__list_pull_requests`（`head: 'ocknamo:<branch>'`、`state: 'open'`）でそのブランチの open PR を取得し、PR 番号と head SHA を控える。
+3. open PR が無ければ「対象 PR なし」と報告して終了する（PR を勝手に作らない）。
+
+## 手順 1: CI の確認
+
+1. `mcp__github__pull_request_read`（`method: 'get_check_runs'`）で PR の head SHA に紐づく check run 一覧を取得する。これが PR の実体を最も正確に反映する。
+   - 補足: legacy の `get_status` は `pending` / `total_count: 0` を返すことがあるが、check runs が success なら CI はグリーン。判断は check runs を優先する。
+2. 各 check run の `conclusion` を確認する:
+   - **全て success / skipped / neutral**: 「CI グリーン」と報告して手順 2 へ進む。
+   - **failure / cancelled / timed_out が 1 件でもある**: `mcp__github__actions_list` と `mcp__github__get_job_logs`（`failed_only: true`、`return_content: true`）で失敗ジョブのログを取得し、失敗原因を要約して報告する。**CI が落ちている場合も手順 2 は実施する。**
+   - **in_progress / queued が残る**: 実行中のため CI 判定は保留し、その旨を報告して手順 2 へ進む。
+
+## 手順 2: PR 説明文の確認と更新
+
+1. `git log --oneline origin/main..HEAD` でブランチのコミット一覧を取得する（必要なら事前に `git fetch origin main`）。
+2. `mcp__github__pull_request_read`（`method: 'get'`）で PR の現在の説明文を取得する。
+3. 説明文を評価する。**以下の条件をすべて満たす場合のみ更新不要**と判断する:
+   - 日本語と英語の両方で書かれている（日英併記）
+   - コミット全件の変更内容が網羅されている
+   - 利用方法・影響（コマンド例 / 破壊的変更 / 移行手順など）が該当する場合に含まれている
+4. 条件を満たさない場合、`mcp__github__update_pull_request` で説明文を更新する。
+
+### 更新時の説明文フォーマット
+
+前半を英語、後半を日本語の 2 ブロック構成にする。
+
+```
+## Summary
+
+（英語で 1〜3 行の概要）
+
+## Changes
+
+- **`path/to/file`**: （英語の説明）
+- ...
+
+## Usage / Notes（該当する場合のみ — コマンド例・破壊的変更・移行手順）
+
+\`\`\`sh
+# command examples
+\`\`\`
+
+---
+
+## 概要
+
+（日本語で 1〜3 行の概要）
+
+## 変更内容
+
+- **`path/to/file`**: （日本語の説明）
+- ...
+
+## 使い方・備考（該当する場合のみ — コマンド例・破壊的変更・移行手順）
+
+\`\`\`sh
+# コマンド例
+\`\`\`
+```
+
+## 厳守事項
+
+- コードファイルは変更しない。PR 説明文の更新のみ行う。
+- PR を新規作成しない。既存の open PR が無ければ報告して終了する。
+- CI が失敗していても説明文の更新は実施する（別の問題として報告する）。
+- 既存の説明文が条件を満たしていれば更新しない（不要な上書きをしない）。
+- 証拠のない推測をしない。取得した情報だけをもとに判断する。

--- a/docs/en/iframe-host.en.md
+++ b/docs/en/iframe-host.en.md
@@ -129,9 +129,13 @@ Key points:
   is pressed
 - **`getRelays` callback**: `onGetRelays` reads the relay map through the SDK's
   storage handle so it hits first-party storage after a Storage Access grant
-- `allowedOrigins: '*'` only opens the postMessage entry point for the demo.
-  It is **not** an origin filter — production hosts must restrict it to a
-  specific allowlist
+- `allowedOrigins` is **required** (no default); omitting it throws at
+  construction. Hosts like nosskey.app, whose design intent is open embedding by
+  arbitrary sites, must **explicitly** pass `'*'` to opt in (a console warning is
+  emitted on start). Self-hosted integrations with a known parent origin should
+  restrict it to a specific allowlist instead. `'*'` only opens the postMessage
+  entry point and is **not** itself an origin filter — arbitrary-site access is
+  still guarded by the H-1 per-origin consent gate
 
 ### 4. Consent gating — `consent-gating.ts` + `app-state.ts`
 

--- a/docs/ja/iframe-host.ja.md
+++ b/docs/ja/iframe-host.ja.md
@@ -97,7 +97,7 @@ export function startIframeHost(overrides = {}) {
 - **consent は単なる確認ではなくゲート**: `onConsent` は副作用のない純粋関数 `evaluateConsent()` に委譲する。保存済みポリシー / 信頼済みオリジンに応じて自動承認・自動拒否・ダイアログ表示のいずれかに分岐する
 - **Promise ブリッジ**: `ask` 経路では Promise を返し、その `resolve` を `pendingConsent` store に退避。UI のボタンが押されるまで Host は待機
 - **`getRelays` コールバック**: `onGetRelays` は SDK のストレージハンドル経由でリレーマップを読むため、Storage Access グラント後はファーストパーティのストレージを参照する
-- `allowedOrigins: '*'` はデモ用に postMessage の入口を全許可する設定であり、オリジンフィルタ**ではない**。本番ホストでは特定 origin の許可リストに絞ること
+- `allowedOrigins` は **必須** (デフォルト廃止)。省略するとコンストラクタで throw する。nosskey.app のように任意サイトからの埋め込みを設計意図とするホストは `'*'` を**明示**してオープン埋め込みにオプトインする (起動時に警告ログ)。一方、親オリジンが固定できるセルフホスト統合では特定 origin の許可リストに絞ること。`'*'` は postMessage の入口を全許可する設定であり、それ自体はオリジンフィルタ**ではない** (任意サイトからの接続は H-1 の同意ゲートで守られる)
 
 ### 4. Consent ゲーティング — `consent-gating.ts` + `app-state.ts`
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -46,7 +46,7 @@ iframe 機能拡充の Phase 番号は `docs/iframe-expansion-plan.md` の体系
 - [ ] **M-1/M-4**: decrypt 系の「常に許可」抑制とレート制限
 - [ ] **M-2**: wrap モードインポート時のバックアップ必須化
 - [ ] **M-3**: デプロイ環境への CSP 追加と TTL バリデーション
-- [ ] **M-5**: SDK の `allowedOrigins` デフォルト廃止（未指定 throw・`'*'` は明示オプトイン）
+- [x] **M-5**: SDK の `allowedOrigins` デフォルト廃止（未指定 throw・`'*'` は明示オプトイン）— `NosskeyIframeHostOptions.allowedOrigins` を必須化（型・ランタイム両方）。未指定でコンストラクタ throw、`'*'` は明示オプトイン（オープン埋め込み・起動時 console.warn は維持）。nosskey.app 自身（`examples/svelte-app/src/iframe-mode.ts`）は既に `'*'` を明示済みのため無退行。`host.ts`（`resolveOptions` の throw・JSDoc）、`host.spec.ts`（省略時 throw テスト追加・既存2テストに明示付与）、`packages/nosskey-iframe/README{,.ja}.md`・`docs/{ja,en}/iframe-host` に secure-by-default の破壊的変更注記を追加。
 
 ### wrap モードのセキュリティ堅牢化
 2026-06 の wrap モード（`importNostrKey` / `#getSecretKey`）セキュリティレビューで発見。暗号方式自体（NIP-44 v2 自己宛 DM・機密性は PRF と等価・完全性は HMAC・salt ドメイン分離）は健全で、以下は多層防御・鍵ライフサイクルの堅牢化項目。

--- a/packages/nosskey-iframe/README.ja.md
+++ b/packages/nosskey-iframe/README.ja.md
@@ -92,7 +92,8 @@ const manager = new NosskeyManager(/* storage / PRF オプション */);
 
 const host = new NosskeyIframeHost({
   manager,
-  // 信頼する親オリジンに絞ります。'*' はデバッグ用途のみ。
+  // 必須（デフォルトなし）。信頼する親オリジンを列挙するか、オープン埋め込みを
+  // 意図的に有効化する場合のみ '*' を渡します（全オリジン許可・起動時に警告ログ）。
   allowedOrigins: ['https://your-parent-app.example'],
   requireUserConsent: true,
   onConsent: async (req: ConsentRequest) => {
@@ -114,6 +115,8 @@ host.start();
 全 7 つの NIP-07 メソッドが `onConsent` で gate されます。`getPublicKey` / `getRelays` に対する同意は、NIP-07 ブラウザ拡張と同じ「オリジン単位の接続承認（ペアリング）」として機能します。これにより、任意の埋め込みサイトがログイン中ユーザーの npub やリレー設定をサイレントに読み取ることを防ぎます。承認済みオリジンは同意 UI 側で記憶してください（参照実装では信頼済みオリジンとして保存）。これでログインフローの摩擦は初回のみになります。
 
 > **破壊的変更（セキュリティ修正）:** 以前のバージョンは `getPublicKey` / `getRelays` を同意なしで返していました。デフォルトの `requireUserConsent: true` のままのホストは `onConsent` を必ず提供してください。未提供の場合、これらのメソッドは `INTERNAL` エラーになります。従来のサイレント動作に戻すには `requireUserConsent: false` を明示してください。なお `onGetRelays` 未設定または鍵未設定のときの `getRelays` は従来どおり同意なしで `{}` を返します。
+
+> **破壊的変更（secure-by-default）:** `allowedOrigins` は **必須** になりました（`'*'` のデフォルトは廃止）。省略するとコンストラクタで throw します。親オリジンが分かる場合（セルフホスト統合等）は明示的な許可リストを、オープン埋め込みを意図的に有効化する場合は `'*'` を渡してください。オープン埋め込みモデル自体は引き続き利用できますが、「全オリジン許可」がサイレントなデフォルトにならないようにする変更です。
 
 詳細アーキテクチャ (同意 UI パターン、Storage Access API、7 メソッドの NIP-07 実装、embedded テーマ/言語伝搬) は
 [`docs/ja/iframe-host.ja.md`](../../docs/ja/iframe-host.ja.md) を参照。

--- a/packages/nosskey-iframe/README.md
+++ b/packages/nosskey-iframe/README.md
@@ -93,7 +93,8 @@ const manager = new NosskeyManager(/* storage / PRF options */);
 
 const host = new NosskeyIframeHost({
   manager,
-  // Restrict to the parent origins you trust. '*' is debug-only.
+  // Required (no default). List the parent origins you trust, or pass '*' to
+  // deliberately opt in to open embedding (any origin; emits a console warning).
   allowedOrigins: ['https://your-parent-app.example'],
   requireUserConsent: true,
   onConsent: async (req: ConsentRequest) => {
@@ -115,6 +116,8 @@ host.start();
 All seven NIP-07 methods are gated by `onConsent`. For `getPublicKey` / `getRelays` the consent acts as a per-origin connection approval (pairing) — the same model NIP-07 browser extensions use — so an arbitrary embedding site cannot silently read the logged-in user's npub or relay list. Remember approved origins in your consent UI (the reference app stores them as trusted origins) to keep login flows friction-free.
 
 > **Breaking change (security fix):** earlier versions served `getPublicKey` / `getRelays` without consent. Hosts that keep the default `requireUserConsent: true` must provide `onConsent`, or these methods now fail with `INTERNAL`. To restore the old silent behavior, opt out explicitly with `requireUserConsent: false`. `getRelays` still returns `{}` without prompting when `onGetRelays` is not configured or no key is set.
+
+> **Breaking change (secure-by-default):** `allowedOrigins` is now **required** — it no longer defaults to `'*'`. Omitting it throws at construction. Pass an explicit allowlist (recommended when the parent origin is known, e.g. self-hosted integrations), or the literal `'*'` to deliberately opt in to open embedding. This keeps the open-embedding model available for hosts that want it while preventing "accept every origin" from being a silent default.
 
 For the full architecture (consent UI patterns, Storage Access API, the seven NIP-07 methods, embedded theme/lang propagation) see
 [`docs/en/iframe-host.en.md`](../../docs/en/iframe-host.en.md).

--- a/packages/nosskey-iframe/src/host.spec.ts
+++ b/packages/nosskey-iframe/src/host.spec.ts
@@ -103,6 +103,7 @@ describe('NosskeyIframeHost', () => {
     Object.defineProperty(win, 'parent', { value: parent, configurable: true });
     const host = new NosskeyIframeHost({
       manager: makeManager(),
+      allowedOrigins: ['https://parent.example'],
       window: win as unknown as Window,
     });
     host.start();
@@ -116,9 +117,21 @@ describe('NosskeyIframeHost', () => {
     const win = createFakeWindow();
     new NosskeyIframeHost({
       manager: makeManager(),
+      allowedOrigins: '*',
       window: win as unknown as Window,
     }).start();
     expect(warnSpy).toHaveBeenCalledOnce();
+  });
+
+  it('throws when allowedOrigins is omitted (no silent open default)', () => {
+    const win = createFakeWindow();
+    expect(
+      () =>
+        new NosskeyIframeHost({
+          manager: makeManager(),
+          window: win as unknown as Window,
+        } as unknown as ConstructorParameters<typeof NosskeyIframeHost>[0])
+    ).toThrow(/allowedOrigins/);
   });
 
   it('routes getPublicKey after onConsent resolves true', async () => {
@@ -735,7 +748,12 @@ describe('NosskeyIframeHost', () => {
   it('throws when no Window is available', () => {
     vi.stubGlobal('window', undefined);
     try {
-      expect(() => new NosskeyIframeHost({ manager: makeManager() })).toThrow(/requires a Window/);
+      expect(
+        () =>
+          new NosskeyIframeHost({
+            manager: makeManager(),
+          } as unknown as ConstructorParameters<typeof NosskeyIframeHost>[0])
+      ).toThrow(/requires a Window/);
     } finally {
       vi.unstubAllGlobals();
     }

--- a/packages/nosskey-iframe/src/host.ts
+++ b/packages/nosskey-iframe/src/host.ts
@@ -35,12 +35,14 @@ export interface NosskeyIframeHostOptions {
   /** Manager that fulfils the NIP-07 requests (normally a NosskeyManager instance). */
   manager: NosskeyManagerLike;
   /**
-   * Origins allowed to communicate with this host. `'*'` disables the check
-   * (useful during development — a console warning is emitted on start).
-   *
-   * @default '*'
+   * Origins allowed to communicate with this host. This is **required** — there
+   * is no default. Pass an explicit allowlist (recommended whenever the parent
+   * origin is known, e.g. self-hosted integrations) or the literal `'*'` to
+   * opt in to open embedding (any origin may send requests; a console warning
+   * is emitted on start). Omitting it throws so that "accept every origin" is
+   * always a deliberate choice rather than a silent default (secure-by-default).
    */
-  allowedOrigins?: string[] | '*';
+  allowedOrigins: string[] | '*';
   /**
    * When true, all consent-required methods (`getPublicKey`, `getRelays`,
    * `signEvent`, nip44/nip04 encrypt/decrypt) require {@link onConsent} to
@@ -77,9 +79,15 @@ function resolveOptions(options: NosskeyIframeHostOptions): ResolvedOptions {
   if (!win) {
     throw new Error('NosskeyIframeHost requires a Window (provide options.window).');
   }
+  if (options.allowedOrigins !== '*' && !Array.isArray(options.allowedOrigins)) {
+    throw new Error(
+      'NosskeyIframeHost requires options.allowedOrigins: pass an explicit list of ' +
+        "parent origins, or '*' to deliberately opt in to open embedding."
+    );
+  }
   return {
     manager: options.manager,
-    allowedOrigins: options.allowedOrigins ?? '*',
+    allowedOrigins: options.allowedOrigins,
     requireUserConsent: options.requireUserConsent ?? true,
     onConsent: options.onConsent,
     onGetRelays: options.onGetRelays,


### PR DESCRIPTION
## Summary

Remove the implicit `allowedOrigins: '*'` default from `NosskeyIframeHost`, making it a required constructor parameter. Omitting it (or passing null / a non-array, non-`'*'` value) now throws at construction time, preventing silent open-embedding for self-hosted integrators. This addresses M-5 from the 2026-06-10 security audit.

## Changes

- **`packages/nosskey-iframe/src/host.ts`**: Make `allowedOrigins` required in the type and enforce it at runtime; throw on missing or invalid value.
- **`packages/nosskey-iframe/src/host.spec.ts`**: Add "throws when omitted" test; cast type-violating constructions in existing Window/throw tests.
- **`packages/nosskey-iframe/README.md`** / **`README.ja.md`**: Document the secure-by-default breaking change for iframe-host consumers.
- **`docs/todo.md`**: Mark M-5 as done.
- **`.claude/agents/pr-finalizer.md`**: Add pr-finalizer agent definition for automated PR CI check and bilingual description updates.

## Usage / Notes

**Breaking change**: `allowedOrigins` is now required. Self-hosted integrators who previously relied on the default must now pass an explicit value.

```ts
// Before (was silently open)
new NosskeyIframeHost({ ... });

// After — pass '*' explicitly to keep open embedding (emits a console warning)
new NosskeyIframeHost({ allowedOrigins: '*', ... });

// Or restrict to a known origin
new NosskeyIframeHost({ allowedOrigins: ['https://your-app.example.com'], ... });
```

---

## 概要

`NosskeyIframeHost` のコンストラクタで `allowedOrigins` を必須パラメータに変更しました。省略した場合（または null・非配列・`'*'` 以外の値を渡した場合）はコンストラクト時に例外をスローします。これにより、自己ホスト型インテグレーターが意図せずオープン埋め込み状態になることを防ぎます。2026-06-10 のセキュリティ監査 M-5 に対応します。

## 変更内容

- **`packages/nosskey-iframe/src/host.ts`**: `allowedOrigins` を型・ランタイムの両方で必須化し、省略または不正値の場合に例外をスローするよう変更。
- **`packages/nosskey-iframe/src/host.spec.ts`**: 省略時の例外テストを追加。既存の Window/throw テストで型違反箇所をキャスト対応。
- **`packages/nosskey-iframe/README.md`** / **`README.ja.md`**: iframe-host 利用者向けに破壊的変更（secure-by-default）をドキュメントに追記。
- **`docs/todo.md`**: M-5 を完了済みとしてマーク。
- **`.claude/agents/pr-finalizer.md`**: PR の CI 確認と日英併記説明文更新を自動化する pr-finalizer エージェント定義を追加。

## 使い方・備考

**破壊的変更**: `allowedOrigins` が必須になりました。これまでデフォルトに依存していた自己ホスト型インテグレーターは、明示的な値を渡す必要があります。

```ts
// 変更前（暗黙的にオープン状態だった）
new NosskeyIframeHost({ ... });

// 変更後 — オープン埋め込みを維持する場合は '*' を明示的に渡す（コンソール警告が出ます）
new NosskeyIframeHost({ allowedOrigins: '*', ... });

// または既知のオリジンに限定する
new NosskeyIframeHost({ allowedOrigins: ['https://your-app.example.com'], ... });
```