### PR TITLE
feat(svelte-app): add CSP and clamp cache TTL (security audit M-3)

### DIFF
--- a/examples/svelte-app/public/_headers
+++ b/examples/svelte-app/public/_headers
@@ -1,2 +1,3 @@
 /*
   Permissions-Policy: publickey-credentials-get=*, publickey-credentials-create=*
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' wss: https:; base-uri 'self'; form-action 'self'; object-src 'none'; frame-ancestors *

--- a/examples/svelte-app/public/_headers
+++ b/examples/svelte-app/public/_headers
@@ -1,3 +1,3 @@
 /*
   Permissions-Policy: publickey-credentials-get=*, publickey-credentials-create=*
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' wss: https:; base-uri 'self'; form-action 'self'; object-src 'none'; frame-ancestors *
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' wss: ws: https:; base-uri 'self'; form-action 'self'; object-src 'none'; frame-ancestors *

--- a/examples/svelte-app/src/components/settings/SecretCacheSettings.svelte
+++ b/examples/svelte-app/src/components/settings/SecretCacheSettings.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
 import { i18n } from '../../i18n/i18n-store.js';
 import { clearSecretCache, getNosskeyManager } from '../../services/nosskey-manager.service.js';
-import { cacheSecrets, cacheTimeout } from '../../store/secret-cache-settings.js';
+import {
+  MAX_CACHE_TTL_SECONDS,
+  MIN_CACHE_TTL_SECONDS,
+  cacheSecrets,
+  cacheTimeout,
+  clampCacheTimeout,
+} from '../../store/secret-cache-settings.js';
 import CardSection from '../ui/CardSection.svelte';
 import SettingMessage from '../ui/SettingMessage.svelte';
 import Button from '../ui/button/Button.svelte';
@@ -39,18 +45,18 @@ function updateCacheSetting(value: boolean) {
 // タイムアウト設定を更新
 function updateTimeoutSetting(event: Event) {
   const input = event.target as HTMLInputElement;
-  const value = Number.parseInt(input.value, 10);
+  // 範囲外・非数値（空欄含む）はすべて clampCacheTimeout に委ねて端 / 既定値へ
+  // 丸め、入力欄にも丸めた値を反映する（NaN→既定値）。cacheTimeout ストアも
+  // set 時にクランプするため二重防御。
+  const value = clampCacheTimeout(Number.parseInt(input.value, 10));
+  timeoutSeconds = value;
+  cacheTimeout.set(value); // keyManager.serviceがサブスクライブして自動的に反映
 
-  if (!Number.isNaN(value) && value > 0) {
-    timeoutSeconds = value;
-    cacheTimeout.set(value); // keyManager.serviceがサブスクライブして自動的に反映
-
-    cacheMessageType = 'success';
-    cacheSettingMessage = $i18n.t.settings.cacheSettings.saved;
-    setTimeout(() => {
-      cacheSettingMessage = '';
-    }, 3000);
-  }
+  cacheMessageType = 'success';
+  cacheSettingMessage = $i18n.t.settings.cacheSettings.saved;
+  setTimeout(() => {
+    cacheSettingMessage = '';
+  }, 3000);
 }
 
 // キャッシュをクリアする関数
@@ -109,8 +115,8 @@ function clearCache() {
         <input
           id="timeout-seconds"
           type="number"
-          min="10"
-          max="86400"
+          min={MIN_CACHE_TTL_SECONDS}
+          max={MAX_CACHE_TTL_SECONDS}
           value={timeoutSeconds}
           onchange={updateTimeoutSetting}
         />

--- a/examples/svelte-app/src/csp.spec.ts
+++ b/examples/svelte-app/src/csp.spec.ts
@@ -29,6 +29,13 @@ describe('CONTENT_SECURITY_POLICY', () => {
     // vitest は svelte-app をカレントに実行されるため cwd 起点で解決する
     // （happy-dom 環境では import.meta.url が file スキームにならないため）。
     const headers = readFileSync(resolve(process.cwd(), 'public/_headers'), 'utf8');
-    expect(headers).toContain(`Content-Security-Policy: ${CONTENT_SECURITY_POLICY}`);
+    const cspLine = headers
+      .split('\n')
+      .map((line) => line.trim())
+      .find((line) => line.startsWith('Content-Security-Policy:'));
+    expect(cspLine).toBeDefined();
+    // 部分一致ではなく値を厳密一致させ、_headers 側への行末追記による乖離も検出する。
+    const value = cspLine?.slice('Content-Security-Policy:'.length).trim();
+    expect(value).toBe(CONTENT_SECURITY_POLICY);
   });
 });

--- a/examples/svelte-app/src/csp.spec.ts
+++ b/examples/svelte-app/src/csp.spec.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { CONTENT_SECURITY_POLICY } from './csp.js';
+
+describe('CONTENT_SECURITY_POLICY', () => {
+  it('includes the directives required for the app to function', () => {
+    // 必須ディレクティブが揃っていること（欠けると機能が無言で壊れるため回帰防止）。
+    expect(CONTENT_SECURITY_POLICY).toContain("default-src 'self'");
+    expect(CONTENT_SECURITY_POLICY).toContain("script-src 'self'");
+    // 任意リレーへの WebSocket。
+    expect(CONTENT_SECURITY_POLICY).toContain('connect-src');
+    expect(CONTENT_SECURITY_POLICY).toContain('wss:');
+    // オープン埋め込みモデル（任意の親が署名 iframe を埋め込める）。
+    expect(CONTENT_SECURITY_POLICY).toContain('frame-ancestors *');
+  });
+
+  it('does not allow inline scripts (the core XSS defense)', () => {
+    // script-src に 'unsafe-inline' / 'unsafe-eval' を許すと多層防御が無効化する。
+    const scriptSrc = CONTENT_SECURITY_POLICY.split('; ').find((d) => d.startsWith('script-src'));
+    expect(scriptSrc).toBeDefined();
+    expect(scriptSrc).not.toContain('unsafe-inline');
+    expect(scriptSrc).not.toContain('unsafe-eval');
+  });
+
+  it('stays in sync with public/_headers (single source of truth)', () => {
+    // 本番（Cloudflare Pages）配信用の _headers と dev/preview の vite プラグインが
+    // 同じポリシーを使うことを保証する。乖離するとデプロイ後に初めて壊れる。
+    // vitest は svelte-app をカレントに実行されるため cwd 起点で解決する
+    // （happy-dom 環境では import.meta.url が file スキームにならないため）。
+    const headers = readFileSync(resolve(process.cwd(), 'public/_headers'), 'utf8');
+    expect(headers).toContain(`Content-Security-Policy: ${CONTENT_SECURITY_POLICY}`);
+  });
+});

--- a/examples/svelte-app/src/csp.ts
+++ b/examples/svelte-app/src/csp.ts
@@ -11,8 +11,11 @@
  *   `'unsafe-inline'` を **付けない**ことが防御の本体。
  * - `style-src ... 'unsafe-inline' ...googleapis`: Svelte はスタイルをインライン
  *   注入するため style に限り inline を許可。Google Fonts の CSS も通す。
- * - `connect-src ... wss:`: ユーザーが設定する任意の Nostr リレーへの WebSocket。
- *   個別ドメインを列挙できないため scheme 単位で許可する。
+ * - `connect-src ... wss: ws:`: ユーザーが設定する任意の Nostr リレーへの
+ *   WebSocket。個別ドメインを列挙できないため scheme 単位で許可する。アプリの
+ *   リレー入力は `wss://` / `ws://` 双方を受理する（`isValidRelayUrl`）ため両方を
+ *   許可し挙動を一致させる。なお本番（https 配信）では `ws://`（平文）はブラウザの
+ *   mixed-content 規制で遮断されるため、実害はローカル開発の `ws://` 利用に限られる。
  * - `frame-ancestors *`: nosskey は「任意サイトが署名 iframe を埋め込む」オープン
  *   埋め込みモデルが設計意図のため全許可。ここを閉じると iframe モードが壊れる。
  */
@@ -22,7 +25,7 @@ const CSP_DIRECTIVES: string[] = [
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "font-src 'self' https://fonts.gstatic.com",
   "img-src 'self' data: https:",
-  "connect-src 'self' wss: https:",
+  "connect-src 'self' wss: ws: https:",
   "base-uri 'self'",
   "form-action 'self'",
   "object-src 'none'",

--- a/examples/svelte-app/src/csp.ts
+++ b/examples/svelte-app/src/csp.ts
@@ -1,0 +1,33 @@
+/**
+ * Content-Security-Policy の正準定義。
+ *
+ * 秘密鍵を扱うホストアプリに対する XSS 多層防御（セキュリティ診断 2026-06-10 の
+ * M-3）。本番では `public/_headers`（Cloudflare Pages）で配信し、開発・preview
+ * サーバーでは `vite.config.ts` のプラグインが同じ値を付与する。両者が乖離しない
+ * よう `csp.spec.ts` が `_headers` に本定数が含まれることを検証する。
+ *
+ * 設計上の要点:
+ * - `script-src 'self'`: インライン/外部の注入スクリプトを止める XSS 対策の核。
+ *   `'unsafe-inline'` を **付けない**ことが防御の本体。
+ * - `style-src ... 'unsafe-inline' ...googleapis`: Svelte はスタイルをインライン
+ *   注入するため style に限り inline を許可。Google Fonts の CSS も通す。
+ * - `connect-src ... wss:`: ユーザーが設定する任意の Nostr リレーへの WebSocket。
+ *   個別ドメインを列挙できないため scheme 単位で許可する。
+ * - `frame-ancestors *`: nosskey は「任意サイトが署名 iframe を埋め込む」オープン
+ *   埋め込みモデルが設計意図のため全許可。ここを閉じると iframe モードが壊れる。
+ */
+const CSP_DIRECTIVES: string[] = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "font-src 'self' https://fonts.gstatic.com",
+  "img-src 'self' data: https:",
+  "connect-src 'self' wss: https:",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+  'frame-ancestors *',
+];
+
+/** 1 行にまとめた Content-Security-Policy ヘッダー値。 */
+export const CONTENT_SECURITY_POLICY: string = CSP_DIRECTIVES.join('; ');

--- a/examples/svelte-app/src/store/app-state.spec.ts
+++ b/examples/svelte-app/src/store/app-state.spec.ts
@@ -13,7 +13,12 @@ import {
   reloadSettings,
   trustedOrigins,
 } from './app-state.js';
-import { cacheSecrets, cacheTimeout } from './secret-cache-settings.js';
+import {
+  MAX_CACHE_TTL_SECONDS,
+  MIN_CACHE_TTL_SECONDS,
+  cacheSecrets,
+  cacheTimeout,
+} from './secret-cache-settings.js';
 
 /** Map-backed in-memory Storage stand-in for a first-party storage handle. */
 function createFakeStorage(seed: Record<string, string> = {}): Storage {
@@ -99,6 +104,19 @@ describe('reloadSettings', () => {
     grantFirstPartyStorage({ nosskey_cache_timeout: 'not-a-number' });
     reloadSettings();
     expect(get(cacheTimeout)).toBe(300);
+  });
+
+  it('clamps a tampered oversized cache timeout to the maximum', () => {
+    // localStorage は改ざん可能。巨大値が SDK の timeoutMs まで伝播しないこと。
+    grantFirstPartyStorage({ nosskey_cache_timeout: '999999999' });
+    reloadSettings();
+    expect(get(cacheTimeout)).toBe(MAX_CACHE_TTL_SECONDS);
+  });
+
+  it('clamps a tampered negative cache timeout to the minimum', () => {
+    grantFirstPartyStorage({ nosskey_cache_timeout: '-100' });
+    reloadSettings();
+    expect(get(cacheTimeout)).toBe(MIN_CACHE_TTL_SECONDS);
   });
 });
 

--- a/examples/svelte-app/src/store/app-state.ts
+++ b/examples/svelte-app/src/store/app-state.ts
@@ -3,7 +3,12 @@ import { writable } from 'svelte/store';
 import { getNosskeyManager, resolveStorageHandle } from '../services/nosskey-manager.service.js';
 import { type ThemeMode, normalizeThemeMode } from '../theme/palettes.js';
 import { refreshAccounts } from './accounts.js';
-import { cacheSecrets, cacheTimeout } from './secret-cache-settings.js';
+import {
+  DEFAULT_CACHE_TTL_SECONDS,
+  cacheSecrets,
+  cacheTimeout,
+  clampCacheTimeout,
+} from './secret-cache-settings.js';
 
 export type ScreenName = 'account' | 'settings' | 'key' | 'iframe';
 
@@ -132,11 +137,12 @@ function loadCacheSecretsSetting(): boolean {
 // キャッシュタイムアウト設定を読み込む
 function loadCacheTimeoutSetting(): number {
   const saved = resolveSettingsStorage()?.getItem('nosskey_cache_timeout') ?? null;
-  if (saved === null) return 300; // デフォルトは300秒（5分）
-  // 破損値（NaN 等）はデフォルトに倒す。reloadSettings 経由で first-party の
-  // 壊れた値を取り込んだ場合に NaN が SDK の timeoutMs まで伝播するのを防ぐ。
-  const parsed = Number.parseInt(saved, 10);
-  return Number.isFinite(parsed) ? parsed : 300;
+  if (saved === null) return DEFAULT_CACHE_TTL_SECONDS;
+  // 破損値（NaN・負値・巨大値）は clampCacheTimeout が許容範囲（既定 / 上下限）へ
+  // 倒す。reloadSettings 経由で first-party の壊れた値を取り込んでも、SDK の
+  // timeoutMs まで範囲外の値が伝播しないようにする。cacheTimeout ストア側でも
+  // set 時にクランプするが、読み込み時にも明示してサニタイズ意図を示す。
+  return clampCacheTimeout(Number.parseInt(saved, 10));
 }
 
 // テーマ設定を読み込む。旧値 ('light'/'dark') は normalizeThemeMode がパープル系へ移行する。

--- a/examples/svelte-app/src/store/secret-cache-settings.spec.ts
+++ b/examples/svelte-app/src/store/secret-cache-settings.spec.ts
@@ -1,0 +1,66 @@
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_CACHE_TTL_SECONDS,
+  MAX_CACHE_TTL_SECONDS,
+  MIN_CACHE_TTL_SECONDS,
+  cacheTimeout,
+  clampCacheTimeout,
+} from './secret-cache-settings.js';
+
+describe('clampCacheTimeout', () => {
+  it('keeps values within the allowed range unchanged', () => {
+    expect(clampCacheTimeout(MIN_CACHE_TTL_SECONDS)).toBe(MIN_CACHE_TTL_SECONDS);
+    expect(clampCacheTimeout(300)).toBe(300);
+    expect(clampCacheTimeout(MAX_CACHE_TTL_SECONDS)).toBe(MAX_CACHE_TTL_SECONDS);
+  });
+
+  it('clamps values below the minimum up to MIN', () => {
+    expect(clampCacheTimeout(0)).toBe(MIN_CACHE_TTL_SECONDS);
+    expect(clampCacheTimeout(-100)).toBe(MIN_CACHE_TTL_SECONDS);
+    expect(clampCacheTimeout(MIN_CACHE_TTL_SECONDS - 1)).toBe(MIN_CACHE_TTL_SECONDS);
+  });
+
+  it('clamps values above the maximum down to MAX', () => {
+    expect(clampCacheTimeout(MAX_CACHE_TTL_SECONDS + 1)).toBe(MAX_CACHE_TTL_SECONDS);
+    expect(clampCacheTimeout(999999999)).toBe(MAX_CACHE_TTL_SECONDS);
+  });
+
+  it('falls back to the default for non-finite values', () => {
+    expect(clampCacheTimeout(Number.NaN)).toBe(DEFAULT_CACHE_TTL_SECONDS);
+    expect(clampCacheTimeout(Number.POSITIVE_INFINITY)).toBe(DEFAULT_CACHE_TTL_SECONDS);
+    expect(clampCacheTimeout(Number.NEGATIVE_INFINITY)).toBe(DEFAULT_CACHE_TTL_SECONDS);
+  });
+
+  it('floors fractional values', () => {
+    expect(clampCacheTimeout(300.9)).toBe(300);
+  });
+});
+
+describe('cacheTimeout store', () => {
+  // モジュールシングルトンを共有するため各テスト前に既知値へ戻し、状態漏れを防ぐ。
+  beforeEach(() => {
+    cacheTimeout.set(DEFAULT_CACHE_TTL_SECONDS);
+  });
+
+  it('clamps on set so out-of-range values never reach subscribers', () => {
+    cacheTimeout.set(999999999);
+    expect(get(cacheTimeout)).toBe(MAX_CACHE_TTL_SECONDS);
+
+    cacheTimeout.set(-5);
+    expect(get(cacheTimeout)).toBe(MIN_CACHE_TTL_SECONDS);
+
+    cacheTimeout.set(300);
+    expect(get(cacheTimeout)).toBe(300);
+  });
+
+  it('clamps the result of update() at both ends', () => {
+    cacheTimeout.set(300);
+    cacheTimeout.update((v) => v * 100000);
+    expect(get(cacheTimeout)).toBe(MAX_CACHE_TTL_SECONDS);
+
+    cacheTimeout.set(300);
+    cacheTimeout.update((v) => v - 100000);
+    expect(get(cacheTimeout)).toBe(MIN_CACHE_TTL_SECONDS);
+  });
+});

--- a/examples/svelte-app/src/store/secret-cache-settings.ts
+++ b/examples/svelte-app/src/store/secret-cache-settings.ts
@@ -11,8 +11,48 @@ import { writable } from 'svelte/store';
  * `nosskey-manager.service.ts` がそれぞれ担う。
  */
 
+/** キャッシュ TTL（秒）の下限。 */
+export const MIN_CACHE_TTL_SECONDS = 10;
+/**
+ * キャッシュ TTL（秒）の上限。セキュリティ診断 2026-06-10（M-3）の推奨に基づき
+ * 1 時間で頭打ちにする。長すぎる TTL は平文鍵がメモリに残る時間を不必要に延ばす。
+ */
+export const MAX_CACHE_TTL_SECONDS = 3600;
+/** キャッシュ TTL（秒）の既定値（5 分）。不正値はここへ倒す。 */
+export const DEFAULT_CACHE_TTL_SECONDS = 300;
+
+/**
+ * キャッシュ TTL（秒）を許容範囲へクランプする純粋関数。
+ *
+ * localStorage は改ざん可能なため、保存値（負値・巨大値・NaN/Infinity）が SDK の
+ * `timeoutMs` までそのまま伝播するのを防ぐ。NaN/Infinity は既定値、範囲外は端へ
+ * 丸め、小数は切り捨てる。
+ */
+export function clampCacheTimeout(seconds: number): number {
+  if (!Number.isFinite(seconds)) return DEFAULT_CACHE_TTL_SECONDS;
+  if (seconds < MIN_CACHE_TTL_SECONDS) return MIN_CACHE_TTL_SECONDS;
+  if (seconds > MAX_CACHE_TTL_SECONDS) return MAX_CACHE_TTL_SECONDS;
+  return Math.floor(seconds);
+}
+
 /** 秘密鍵情報をメモリにキャッシュするか。 */
 export const cacheSecrets = writable<boolean>(true);
 
-/** キャッシュのタイムアウト時間（秒）。 */
-export const cacheTimeout = writable<number>(300);
+/**
+ * キャッシュのタイムアウト時間（秒）。
+ *
+ * `set` / `update` を `clampCacheTimeout` で包んだカスタムストアにし、UI 入力・
+ * ストレージ読み込み・外部同期のいずれの経路から値が入っても必ず許容範囲に収まる
+ * 単一の強制点とする。これにより SDK へ渡る `timeoutMs` も常にクランプ済みになる。
+ */
+function createCacheTimeoutStore() {
+  const { subscribe, set, update } = writable<number>(DEFAULT_CACHE_TTL_SECONDS);
+  return {
+    subscribe,
+    set: (value: number) => set(clampCacheTimeout(value)),
+    update: (updater: (value: number) => number) =>
+      update((value) => clampCacheTimeout(updater(value))),
+  };
+}
+
+export const cacheTimeout = createCacheTimeoutStore();

--- a/examples/svelte-app/vite.config.ts
+++ b/examples/svelte-app/vite.config.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
-import { defineConfig } from 'vite';
+import { type Connect, type Plugin, defineConfig } from 'vite';
+import { CONTENT_SECURITY_POLICY } from './src/csp.js';
 
 // Gitのcommit hashを取得
 const getGitHash = () => {
@@ -11,9 +12,27 @@ const getGitHash = () => {
   }
 };
 
+// 本番は public/_headers（Cloudflare Pages）で CSP を配信する。dev / preview でも
+// 同じポリシーを効かせ、CSP 違反を本番デプロイ前に検出できるようにする。
+const securityHeadersPlugin = (): Plugin => {
+  const middleware: Connect.NextHandleFunction = (_req, res, next) => {
+    res.setHeader('Content-Security-Policy', CONTENT_SECURITY_POLICY);
+    next();
+  };
+  return {
+    name: 'nosskey-security-headers',
+    configureServer: (server) => {
+      server.middlewares.use(middleware);
+    },
+    configurePreviewServer: (server) => {
+      server.middlewares.use(middleware);
+    },
+  };
+};
+
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [svelte()],
+  plugins: [svelte(), securityHeadersPlugin()],
   define: {
     'import.meta.env.VITE_GIT_COMMIT_HASH': JSON.stringify(getGitHash()),
   },


### PR DESCRIPTION
## Summary

Addresses security audit findings from 2026-06-10 for the svelte-app example:
- **M-3b**: Introduces Content-Security-Policy (CSP) as a layered XSS defense for the host app that handles private keys.
- **M-3a**: Clamps the secret-cache TTL to a safe range to prevent localStorage tampering from propagating dangerous values (e.g., negative, NaN, or excessively large timeouts) into the SDK.

## Changes

- **`examples/svelte-app/src/csp.ts`** (new): Defines the canonical CSP string as the single source of truth shared by all environments.
- **`examples/svelte-app/public/_headers`**: Applies the canonical CSP via Cloudflare Pages response headers for production.
- **`examples/svelte-app/vite.config.ts`**: Applies the same CSP in the dev/preview server so policy violations are caught before deployment.
- **`examples/svelte-app/src/csp.spec.ts`** (new): Verifies required directives, absence of `unsafe-inline`/`unsafe-eval` in `script-src`, and strict byte-level sync between `csp.ts` and `_headers`.
- **`examples/svelte-app/src/lib/secret-cache-settings.ts`**: Adds `clampCacheTimeout` (MIN 10 s / MAX 3600 s / default 300 s) and a clamping custom store as the single enforcement point for TTL values.
- **`examples/svelte-app/src/lib/SecretCacheSettings.svelte`**: Changes the UI input `max` from 86400 to 3600 to match the clamp ceiling, and sanitizes the value on load.
- **`examples/svelte-app/src/lib/secret-cache-settings.spec.ts`**: Adds regression tests for clamp behavior (negative, NaN, out-of-range values).

## Notes

CSP policy highlights:
- `script-src 'self'` — core XSS defense; no `unsafe-inline` or `unsafe-eval`
- `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com` — required for Svelte inline styles and Google Fonts
- `connect-src 'self' wss: ws: https:` — allows arbitrary Nostr relays
- `frame-ancestors *` — preserves the open embedding model (any site may embed the signing iframe)

Cache TTL clamp:
- Range: 10 s – 3600 s (default 300 s)
- Prevents localStorage-injected values (e.g., `9999999`, `-1`, `NaN`) from reaching `timeoutMs` in the SDK

---

## 概要

svelte-app サンプルに対するセキュリティ診断 2026-06-10 の M-3 対応:
- **M-3b**: 秘密鍵を扱うホストアプリに CSP を導入し、XSS 多層防御を追加。
- **M-3a**: localStorage 改ざんによる危険な TTL 値（負値・NaN・過大値）が SDK の `timeoutMs` まで伝播しないよう、秘密鍵キャッシュ TTL を安全な範囲にクランプ。

## 変更内容

- **`examples/svelte-app/src/csp.ts`**（新規）: 全環境で共有する正準 CSP 文字列を定義（単一の真実源）。
- **`examples/svelte-app/public/_headers`**: Cloudflare Pages のレスポンスヘッダーとして本番に正準 CSP を適用。
- **`examples/svelte-app/vite.config.ts`**: dev/preview サーバにも同ポリシーを付与し、デプロイ前に違反を検出可能に。
- **`examples/svelte-app/src/csp.spec.ts`**（新規）: 必須ディレクティブ・`script-src` の `unsafe-inline`/`unsafe-eval` 不在・`csp.ts` と `_headers` のバイト単位同期を検証。
- **`examples/svelte-app/src/lib/secret-cache-settings.ts`**: `clampCacheTimeout`（MIN 10 s / MAX 3600 s / 既定 300 s）とクランプ機能付きカスタムストアを追加（単一強制点）。
- **`examples/svelte-app/src/lib/SecretCacheSettings.svelte`**: UI 入力の `max` を 86400→3600 に変更し、読込時にサニタイズを実施。
- **`examples/svelte-app/src/lib/secret-cache-settings.spec.ts`**: 負値・NaN・範囲外値に対するクランプ動作の回帰テストを追加。

## 使い方・備考

CSP ポリシーのポイント:
- `script-src 'self'` — XSS 対策の核。`unsafe-inline` / `unsafe-eval` なし
- `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com` — Svelte の inline style と Google Fonts に必要
- `connect-src 'self' wss: ws: https:` — 任意の Nostr リレーへの接続を許可
- `frame-ancestors *` — 任意サイトが署名 iframe を埋め込めるオープン埋め込みモデルを維持

キャッシュ TTL クランプ:
- 範囲: 10 s – 3600 s（既定 300 s）
- localStorage から注入された値（`9999999`・`-1`・`NaN` 等）が SDK に伝播するのを防止