### PR TITLE
fix: 鍵画面の直接リロードでログイン状態が復元されない問題の修正とライブデモリンク追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -190,6 +190,8 @@ window.nostr = {
 
 参照実装は [`examples/svelte-app`](examples/svelte-app) (ルート `#/iframe`) にあります。ホスト側アーキテクチャの詳細は [docs/ja/iframe-host.ja.md](docs/ja/iframe-host.ja.md) を参照してください。
 
+動作する親アプリのサンプルは [`examples/parent-sample`](examples/parent-sample) にあります。ライブ版が [https://ocknamo.github.io/nosskey-sdk/](https://ocknamo.github.io/nosskey-sdk/) でホスティングされており、ブラウザ上で実際の埋め込み動作を試せます。
+
 #### Storage Partitioning への対応
 
 Chrome 115+ や Firefox の Total Cookie Protection では、**サードパーティ iframe の

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ For a complete step-by-step guide to embedding the iframe into your own app, see
 
 See [`examples/svelte-app`](examples/svelte-app) (route `#/iframe`) for a reference host implementation. The host architecture is documented in detail at [docs/en/iframe-host.en.md](docs/en/iframe-host.en.md).
 
+For a working parent-app sample, see [`examples/parent-sample`](examples/parent-sample). A live build is hosted at [https://ocknamo.github.io/nosskey-sdk/](https://ocknamo.github.io/nosskey-sdk/), where you can try the embedding flow in the browser.
+
 #### Storage partitioning
 
 Chrome 115+ and Firefox's Total Cookie Protection **partition third-party

--- a/examples/svelte-app/src/App.svelte
+++ b/examples/svelte-app/src/App.svelte
@@ -6,7 +6,13 @@ import AccountScreen from './components/screens/AccountScreen.svelte';
 import IframeHostScreen from './components/screens/IframeHostScreen.svelte';
 import KeyManagementScreen from './components/screens/KeyManagement.svelte';
 import SettingsScreen from './components/screens/SettingsScreen.svelte';
-import { type ThemeMode, currentScreen, currentTheme, isScreenName } from './store/app-state.js';
+import {
+  type ThemeMode,
+  currentScreen,
+  currentTheme,
+  isScreenName,
+  restoreLoginState,
+} from './store/app-state.js';
 import { THEME_PALETTES, resolveTheme } from './theme/palettes.js';
 
 let screen = $state('account');
@@ -148,6 +154,14 @@ onMount(() => {
   // ブラウザの自動スクロール復元は無効化する。
   if (typeof window !== 'undefined' && 'scrollRestoration' in window.history) {
     window.history.scrollRestoration = 'manual';
+  }
+
+  // 保存済み鍵情報からログイン状態を復元する。account 画面だけでなく key /
+  // settings へ直接リロードした場合もログイン状態を反映するため、画面非依存で
+  // ここで一度だけ実行する。iframe モードは IframeHostScreen が独自に
+  // Storage Access ゲートを伴う初期化を行うため対象外。
+  if (screen !== 'iframe') {
+    void restoreLoginState();
   }
 
   // 初期テーマの適用

--- a/examples/svelte-app/src/components/screens/AccountScreen.svelte
+++ b/examples/svelte-app/src/components/screens/AccountScreen.svelte
@@ -1,30 +1,17 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import { i18n } from '../../i18n/i18n-store.js';
-import { getNosskeyManager } from '../../services/nosskey-manager.service.js';
-import { isLoggedIn, publicKey } from '../../store/app-state.js';
+import { isLoggedIn, restoreLoginState } from '../../store/app-state.js';
 import PublicKeyDisplay from '../PublicKeyDisplay.svelte';
 import AuthScreen from './AuthScreen.svelte';
 
 const login = $derived($isLoggedIn);
 
-onMount(async () => {
-  const keyManager = getNosskeyManager();
-
-  if (keyManager.hasKeyInfo()) {
-    if (!$isLoggedIn) {
-      try {
-        const pubKey = await keyManager.getPublicKey();
-        publicKey.set(pubKey);
-        isLoggedIn.set(true);
-      } catch (error) {
-        console.error('公開鍵の取得に失敗しました:', error);
-      }
-    }
-  } else if ($isLoggedIn) {
-    isLoggedIn.set(false);
-    publicKey.set(null);
-  }
+// 通常はアプリ起動時に App.svelte でログイン状態を復元済みだが、
+// account 画面へ初めて遷移したときにも念のため整合させる（鍵が無いのに
+// ログイン状態が残っている場合のリセットも兼ねる）。
+onMount(() => {
+  void restoreLoginState();
 });
 </script>
 

--- a/examples/svelte-app/src/store/app-state.spec.ts
+++ b/examples/svelte-app/src/store/app-state.spec.ts
@@ -11,6 +11,7 @@ import {
   loginWith,
   publicKey,
   reloadSettings,
+  restoreLoginState,
   trustedOrigins,
 } from './app-state.js';
 import {
@@ -261,5 +262,54 @@ describe('loginWith', () => {
     expect(listAccounts().some((a) => a.pubkey === 'pubkey-login-abc')).toBe(true);
     const persisted = JSON.parse(firstParty.getItem('nosskey_accounts') as string);
     expect(persisted.some((a: { pubkey: string }) => a.pubkey === 'pubkey-login-abc')).toBe(true);
+  });
+});
+
+describe('restoreLoginState', () => {
+  // 画面非依存のログイン状態復元。`#/key` などへ直接リロードした場合でも
+  // AccountScreen のマウントを待たずにログイン状態を反映できることを保証する。
+  it('鍵情報があり未ログインなら公開鍵を復元してログイン状態にする', async () => {
+    grantFirstPartyStorage();
+    await loginWith({
+      credentialId: 'cred-restore',
+      pubkey: 'pubkey-restore-abc',
+      salt: '6e6f7374722d70776b',
+    });
+    // リロード相当: SDK manager は鍵を保持したまま、ストアだけ初期状態へ戻す。
+    isLoggedIn.set(false);
+    publicKey.set(null);
+
+    await restoreLoginState();
+
+    expect(get(isLoggedIn)).toBe(true);
+    expect(get(publicKey)).toBe('pubkey-restore-abc');
+  });
+
+  it('すでにログイン済みなら何もしない（早期 return）', async () => {
+    grantFirstPartyStorage();
+    await loginWith({
+      credentialId: 'cred-restore',
+      pubkey: 'pubkey-restore-abc',
+      salt: '6e6f7374722d70776b',
+    });
+    // 既ログイン状態。公開鍵ストアの値は上書きされず保持される。
+    publicKey.set('sentinel-unchanged');
+
+    await restoreLoginState();
+
+    expect(get(isLoggedIn)).toBe(true);
+    expect(get(publicKey)).toBe('sentinel-unchanged');
+  });
+
+  it('鍵情報が無ければログイン状態をリセットする', async () => {
+    grantFirstPartyStorage();
+    // 鍵が無いのにログイン状態が残っているケース（ログアウト跨ぎ等）。
+    isLoggedIn.set(true);
+    publicKey.set('stale-pubkey');
+
+    await restoreLoginState();
+
+    expect(get(isLoggedIn)).toBe(false);
+    expect(get(publicKey)).toBe(null);
   });
 });

--- a/examples/svelte-app/src/store/app-state.ts
+++ b/examples/svelte-app/src/store/app-state.ts
@@ -1,5 +1,5 @@
 import type { NostrKeyInfo } from 'nosskey-sdk';
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import { getNosskeyManager, resolveStorageHandle } from '../services/nosskey-manager.service.js';
 import { type ThemeMode, normalizeThemeMode } from '../theme/palettes.js';
 import { refreshAccounts } from './accounts.js';
@@ -364,6 +364,30 @@ export const logout = () => {
 
   // 画面を認証画面に戻す
   currentScreen.set('account');
+};
+
+/**
+ * 保存済みの鍵情報からログイン状態を復元する。アプリ起動時に画面（account /
+ * key / settings）に依存せず一度だけ実行する。これを AccountScreen の onMount
+ * だけに置くと、`#/key` などへ直接リロードした場合に AccountScreen がマウント
+ * されず、鍵情報があるのに未ログイン表示（ImportKeyInfo）になってしまう。
+ * `getPublicKey()` はパスキープロンプトを出さないため起動時に呼んでも安全。
+ */
+export const restoreLoginState = async (): Promise<void> => {
+  const nosskeyManager = getNosskeyManager();
+
+  if (nosskeyManager.hasKeyInfo()) {
+    if (get(isLoggedIn)) return;
+    try {
+      publicKey.set(await nosskeyManager.getPublicKey());
+      isLoggedIn.set(true);
+    } catch (error) {
+      console.error('公開鍵の取得に失敗しました:', error);
+    }
+  } else {
+    isLoggedIn.set(false);
+    publicKey.set(null);
+  }
 };
 
 /**


### PR DESCRIPTION
## 概要 / Summary

細かい2点の修正です。

This PR contains two small fixes.

### 1. 鍵画面の直接リロードでログイン状態にならないバグ修正 / Restore login state on direct reload

**日本語**

`nosskey.app` でログイン中に鍵画面 (`#/key`) を直接リロードするとログイン状態にならず、一度アカウント画面を経由しないとログイン状態が反映されない問題を修正しました。

- **原因**: 保存済み鍵情報からログイン状態を復元する処理が `AccountScreen.svelte` の `onMount` にしか無く、`#/key` などへ直接リロードすると `AccountScreen` がマウントされず復元が走らなかった。結果 `isLoggedIn` が `false` のままで `KeyManagement` が「鍵インポート」表示になっていた。
- **修正**: 復元ロジックを画面非依存の共通関数 `restoreLoginState()` に切り出し、`App.svelte` の `onMount`（iframe モード以外）で呼ぶようにした。どの画面へ直接リロードしてもログイン状態が復元される。`getPublicKey()` はパスキープロンプトを出さないため起動時に呼んでも安全。

**English**

When logged in on `nosskey.app`, directly reloading on the key screen (`#/key`) did not restore the login state — the user had to visit the account screen once first.

- **Cause**: login-state restoration lived only in `AccountScreen.svelte`'s `onMount`, so a direct reload to `#/key` never mounted `AccountScreen` and never restored the session, leaving `KeyManagement` showing the import view.
- **Fix**: extracted the restoration into a screen-independent `restoreLoginState()` and call it from `App.svelte`'s `onMount` (except in iframe mode). `getPublicKey()` does not trigger a passkey prompt, so it is safe to call on startup.

### 2. iframe 親アプリサンプルのライブデモリンク追加 / Add live demo link

`README.md` / `README.ja.md` の iframe セクションに、親アプリサンプル (`examples/parent-sample`) のライブデモ https://ocknamo.github.io/nosskey-sdk/ へのリンクが欠落していたため追加しました。

Added the missing link to the live parent-app demo (https://ocknamo.github.io/nosskey-sdk/) in the iframe section of `README.md` / `README.ja.md`.

## 変更ファイル / Changed files

- `examples/svelte-app/src/store/app-state.ts` — `restoreLoginState()` を追加 / add `restoreLoginState()`
- `examples/svelte-app/src/App.svelte` — `onMount` で復元を呼ぶ / call restore on mount
- `examples/svelte-app/src/components/screens/AccountScreen.svelte` — 重複ロジックを共通関数へ置換 / replace duplicated logic
- `examples/svelte-app/src/store/app-state.spec.ts` — テスト3ケース追加 / add 3 tests
- `README.md` / `README.ja.md` — ライブデモリンク追加 / add live demo link

## 検証 / Verification

- `npm run format:check` ✅
- `npm run build` ✅
- `npm run test:coverage` ✅ (新規3件含む / incl. 3 new tests)
- `npm run check -w svelte-app` ✅ (0 errors / 0 warnings)

## 補足 / Note

今回の修正はマークアップ/CSS を変更しないロジック修正のため、実機で鍵作成済みの状態で `#/key` に直接リロードしてログイン状態が維持されることの確認を推奨します。

This is a logic-only change (no markup/CSS); manual verification by reloading `#/key` while a passkey already exists is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMrGKKUV4hfhAzXqLykEYU)_