### PR TITLE
feat(svelte-app): add simple terminology mode (default on)

### DIFF
--- a/examples/svelte-app/src/components/ConsentDialog.svelte
+++ b/examples/svelte-app/src/components/ConsentDialog.svelte
@@ -145,7 +145,7 @@ function openConsentSettings(): void {
         <p class="consent-decrypt-note">{$i18n.t.consent.decryptAlwaysAsk}</p>
       {/if}
 
-      {#if c.event}
+      {#if c.event && $i18n.termMode === "standard"}
         <details class="consent-raw">
           <summary>{$i18n.t.consent.showRaw}</summary>
           <pre>{JSON.stringify(c.event, null, 2)}</pre>

--- a/examples/svelte-app/src/components/ConsentDialog.svelte
+++ b/examples/svelte-app/src/components/ConsentDialog.svelte
@@ -71,10 +71,10 @@ function handleReject() {
 }
 
 // Open the standalone app's settings screen in a new tab so the user can
-// review trusted sites and the consent policy. A new tab (rather than
-// in-place navigation) is used because the consent prompt is shown while
-// the app is acting as the signing iframe — navigating away would tear
-// down the iframe host.
+// review trusted sites (and, in technical mode, the consent policy).
+// A new tab (rather than in-place navigation) is used because the consent
+// prompt is shown while the app is acting as the signing iframe —
+// navigating away would tear down the iframe host.
 function openConsentSettings(): void {
   window.open(buildScreenUrl(window.location, 'settings'), '_blank', 'noopener');
 }

--- a/examples/svelte-app/src/components/screens/KeyManagement.svelte
+++ b/examples/svelte-app/src/components/screens/KeyManagement.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { termMode } from '../../i18n/i18n-store.js';
 import { isLoggedIn } from '../../store/app-state.js';
 import ExportKeyInfoComponent from '../settings/ExportKeyInfoComponent.svelte';
 import ExportSecretKey from '../settings/ExportSecretKey.svelte';
@@ -10,11 +11,17 @@ import SecretCacheSettings from '../settings/SecretCacheSettings.svelte';
 
 <div class="settings-container">
   {#if $isLoggedIn}
-    <SecretCacheSettings />
+    {#if $termMode === "standard"}
+      <SecretCacheSettings />
+    {/if}
     <ExportKeyInfoComponent />
-    <ExportSecretKey />
+    {#if $termMode === "standard"}
+      <ExportSecretKey />
+    {/if}
     <LogoutSection />
-    <LocalStorageSection />
+    {#if $termMode === "standard"}
+      <LocalStorageSection />
+    {/if}
   {:else}
     <ImportKeyInfo />
   {/if}

--- a/examples/svelte-app/src/components/screens/KeyManagement.svelte
+++ b/examples/svelte-app/src/components/screens/KeyManagement.svelte
@@ -15,9 +15,7 @@ import SecretCacheSettings from '../settings/SecretCacheSettings.svelte';
       <SecretCacheSettings />
     {/if}
     <ExportKeyInfoComponent />
-    {#if $termMode === "standard"}
-      <ExportSecretKey />
-    {/if}
+    <ExportSecretKey />
     <LogoutSection />
     {#if $termMode === "standard"}
       <LocalStorageSection />

--- a/examples/svelte-app/src/components/screens/SettingsScreen.svelte
+++ b/examples/svelte-app/src/components/screens/SettingsScreen.svelte
@@ -4,6 +4,7 @@ import ConsentPolicySettings from '../settings/ConsentPolicySettings.svelte';
 import DeveloperSection from '../settings/DeveloperSection.svelte';
 import LanguageSettings from '../settings/LanguageSettings.svelte';
 import RelaySettings from '../settings/RelaySettings.svelte';
+import TermModeSettings from '../settings/TermModeSettings.svelte';
 import TrustedOriginsSettings from '../settings/TrustedOriginsSettings.svelte';
 import ThemeSettings from '../settings/theme-settings.svelte';
 </script>
@@ -13,6 +14,7 @@ import ThemeSettings from '../settings/theme-settings.svelte';
   <ConsentPolicySettings />
   <TrustedOriginsSettings />
   <LanguageSettings />
+  <TermModeSettings />
   <ThemeSettings />
   <AppInfo />
   <DeveloperSection />

--- a/examples/svelte-app/src/components/screens/SettingsScreen.svelte
+++ b/examples/svelte-app/src/components/screens/SettingsScreen.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { termMode } from '../../i18n/i18n-store.js';
 import AppInfo from '../settings/AppInfo.svelte';
 import ConsentPolicySettings from '../settings/ConsentPolicySettings.svelte';
 import DeveloperSection from '../settings/DeveloperSection.svelte';
@@ -10,14 +11,18 @@ import ThemeSettings from '../settings/theme-settings.svelte';
 </script>
 
 <div class="settings-container">
-  <RelaySettings />
-  <ConsentPolicySettings />
+  {#if $termMode === "standard"}
+    <RelaySettings />
+    <ConsentPolicySettings />
+  {/if}
   <TrustedOriginsSettings />
   <LanguageSettings />
   <TermModeSettings />
   <ThemeSettings />
   <AppInfo />
-  <DeveloperSection />
+  {#if $termMode === "standard"}
+    <DeveloperSection />
+  {/if}
 </div>
 
 <style>

--- a/examples/svelte-app/src/components/settings/TermModeSettings.svelte
+++ b/examples/svelte-app/src/components/settings/TermModeSettings.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+import { changeTermMode, i18n } from '../../i18n/i18n-store.js';
+import type { TermMode } from '../../i18n/translations.js';
+import CardSection from '../ui/CardSection.svelte';
+import SettingMessage from '../ui/SettingMessage.svelte';
+
+// 状態変数
+let termModeMessage = $state('');
+
+// 用語表示モードを変更する関数
+function updateTermMode(mode: TermMode) {
+  changeTermMode(mode);
+  termModeMessage = $i18n.t.settings.termMode.changed;
+  setTimeout(() => {
+    termModeMessage = '';
+  }, 3000);
+}
+</script>
+
+<CardSection title={$i18n.t.settings.termMode.title}>
+  <div class="term-mode-selector">
+    <p>{$i18n.t.settings.termMode.selectMode}</p>
+    <div class="radio-group">
+      <label>
+        <input
+          type="radio"
+          name="term-mode"
+          value="simple"
+          checked={$i18n.termMode === "simple"}
+          onclick={() => updateTermMode("simple")}
+        />
+        {$i18n.t.settings.termMode.simpleLabel}
+      </label>
+      <label>
+        <input
+          type="radio"
+          name="term-mode"
+          value="standard"
+          checked={$i18n.termMode === "standard"}
+          onclick={() => updateTermMode("standard")}
+        />
+        {$i18n.t.settings.termMode.standardLabel}
+      </label>
+    </div>
+
+    <SettingMessage message={termModeMessage} />
+  </div>
+</CardSection>
+
+<style>
+  p {
+    margin-bottom: 15px;
+    color: var(--color-text-secondary);
+    transition: color 0.3s ease;
+  }
+
+  .term-mode-selector {
+    margin-top: 15px;
+  }
+
+  .radio-group {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin: 15px 0;
+  }
+
+  .radio-group label {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+  }
+
+  .radio-group input[type="radio"] {
+    margin-right: 10px;
+  }
+</style>

--- a/examples/svelte-app/src/i18n/i18n-store.spec.ts
+++ b/examples/svelte-app/src/i18n/i18n-store.spec.ts
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ja } from './translations/ja.js';
+import { simpleJa } from './translations/simple-ja.js';
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.resetModules();
+  // happy-dom の navigator.language は環境依存（既定は英語）なので、
+  // 日本語文言を検証するテストのため言語を明示的に固定する。
+  localStorage.setItem('nosskey_language', 'ja');
+});
+
+// i18n-store はモジュール読み込み時に localStorage を参照して初期状態を決めるため、
+// テストごとに vi.resetModules() + 動的 import で再評価する。
+async function importStore() {
+  return await import('./i18n-store.js');
+}
+
+describe('termMode の初期値', () => {
+  it('localStorage 未設定時はシンプルモードがデフォルト', async () => {
+    const { termMode } = await importStore();
+    expect(get(termMode)).toBe('simple');
+  });
+
+  it('保存済みの standard を復元する', async () => {
+    localStorage.setItem('nosskey_term_mode', 'standard');
+    const { termMode } = await importStore();
+    expect(get(termMode)).toBe('standard');
+  });
+
+  it('不正な保存値はシンプルモードにフォールバックする', async () => {
+    localStorage.setItem('nosskey_term_mode', 'bogus');
+    const { termMode } = await importStore();
+    expect(get(termMode)).toBe('simple');
+  });
+});
+
+describe('i18n の翻訳解決', () => {
+  it('シンプルモードではオーバーレイのキーが置換される', async () => {
+    const { i18n } = await importStore();
+    const t = get(i18n).t;
+    expect(t.nostr.publicKey).toBe(simpleJa.nostr?.publicKey);
+    expect(t.nostr.publicKey).toBe('ユーザーID');
+    expect(t.consent.methodLabel.signEvent).toBe('投稿の承認');
+  });
+
+  it('オーバーレイに無いキーは標準文言にフォールバックする', async () => {
+    const { i18n } = await importStore();
+    const t = get(i18n).t;
+    // copyToClipboard は simpleJa に定義していないため ja.ts の値が残る
+    expect(t.nostr.copyToClipboard).toBe(ja.nostr.copyToClipboard);
+    expect(t.common.save).toBe(ja.common.save);
+  });
+
+  it('standard モードでは常に元の標準文言を返す', async () => {
+    localStorage.setItem('nosskey_term_mode', 'standard');
+    const { i18n } = await importStore();
+    const t = get(i18n).t;
+    expect(t.nostr.publicKey).toBe(ja.nostr.publicKey);
+    expect(t.nostr.publicKey).toBe('公開鍵');
+  });
+});
+
+describe('changeTermMode', () => {
+  it('モードを切り替えると翻訳と localStorage が更新される', async () => {
+    const { i18n, changeTermMode } = await importStore();
+    expect(get(i18n).t.nostr.publicKey).toBe('ユーザーID');
+
+    changeTermMode('standard');
+    expect(get(i18n).t.nostr.publicKey).toBe('公開鍵');
+    expect(get(i18n).termMode).toBe('standard');
+    expect(localStorage.getItem('nosskey_term_mode')).toBe('standard');
+
+    changeTermMode('simple');
+    expect(get(i18n).t.nostr.publicKey).toBe('ユーザーID');
+    expect(localStorage.getItem('nosskey_term_mode')).toBe('simple');
+  });
+});

--- a/examples/svelte-app/src/i18n/i18n-store.ts
+++ b/examples/svelte-app/src/i18n/i18n-store.ts
@@ -1,6 +1,12 @@
 import { derived, writable } from 'svelte/store';
-import type { I18nStore, Language, TranslationData } from './translations.js';
-import { en, ja } from './translations.js';
+import type {
+  DeepPartial,
+  I18nStore,
+  Language,
+  TermMode,
+  TranslationData,
+} from './translations.js';
+import { en, ja, simpleEn, simpleJa } from './translations.js';
 
 // デフォルト言語（日本語）と翻訳データ
 const DEFAULT_LANGUAGE: Language = 'ja';
@@ -10,6 +16,16 @@ const translations: Record<Language, TranslationData> = {
   ja,
   en,
 };
+
+// シンプルモード（専門用語の置き換え）の部分オーバーレイ
+const simpleOverlays: Record<Language, DeepPartial<TranslationData>> = {
+  ja: simpleJa,
+  en: simpleEn,
+};
+
+// 用語表示モードのデフォルトはシンプル（一般ユーザー向け）
+const DEFAULT_TERM_MODE: TermMode = 'simple';
+export const TERM_MODE_STORAGE_KEY = 'nosskey_term_mode';
 
 // 親オリジンから `?embedded=1&lang=...` で言語を上書きされた場合、
 // localStorage には書き戻さない（次回スタンドアロン起動時に保持するため）。
@@ -64,11 +80,72 @@ export function changeLanguage(lang: Language): void {
   currentLanguage.set(lang);
 }
 
-// 現在の言語に基づいた翻訳データを提供するストア
-export const i18n = derived<typeof currentLanguage, I18nStore>(
-  currentLanguage,
-  ($currentLanguage) => ({
+// 用語表示モードをローカルストレージから読み込む（未保存時はシンプルモード）
+function loadTermMode(): TermMode {
+  if (typeof window !== 'undefined') {
+    const saved = localStorage.getItem(TERM_MODE_STORAGE_KEY);
+    if (saved === 'simple' || saved === 'standard') {
+      return saved;
+    }
+  }
+  return DEFAULT_TERM_MODE;
+}
+
+// 現在の用語表示モードを管理するストア
+export const termMode = writable<TermMode>(loadTermMode());
+
+// モード変更時にローカルストレージに保存
+termMode.subscribe((mode) => {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(TERM_MODE_STORAGE_KEY, mode);
+  }
+});
+
+// 用語表示モードを変更する関数
+export function changeTermMode(mode: TermMode): void {
+  termMode.set(mode);
+}
+
+// オーバーレイに定義されたキーだけを上書きする deep merge。
+// オーバーレイ側に無いキーは base（標準文言）がそのまま残る。
+function deepMerge<T extends object>(base: T, overlay: DeepPartial<T>): T {
+  const result: Record<string, unknown> = { ...(base as Record<string, unknown>) };
+  for (const [key, value] of Object.entries(overlay)) {
+    if (value === undefined) continue;
+    const baseValue = result[key];
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      typeof baseValue === 'object' &&
+      baseValue !== null
+    ) {
+      result[key] = deepMerge(baseValue as object, value as DeepPartial<object>);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result as T;
+}
+
+// 言語×モードの組み合わせは少ないので、マージ結果はモジュールスコープでキャッシュする
+const mergedCache = new Map<Language, TranslationData>();
+
+function resolveTranslation(lang: Language, mode: TermMode): TranslationData {
+  if (mode === 'standard') return translations[lang];
+  let merged = mergedCache.get(lang);
+  if (!merged) {
+    merged = deepMerge(translations[lang], simpleOverlays[lang]);
+    mergedCache.set(lang, merged);
+  }
+  return merged;
+}
+
+// 現在の言語と用語表示モードに基づいた翻訳データを提供するストア
+export const i18n = derived<[typeof currentLanguage, typeof termMode], I18nStore>(
+  [currentLanguage, termMode],
+  ([$currentLanguage, $termMode]) => ({
     currentLanguage: $currentLanguage,
-    t: translations[$currentLanguage],
+    termMode: $termMode,
+    t: resolveTranslation($currentLanguage, $termMode),
   })
 );

--- a/examples/svelte-app/src/i18n/i18n-store.ts
+++ b/examples/svelte-app/src/i18n/i18n-store.ts
@@ -127,17 +127,12 @@ function deepMerge<T extends object>(base: T, overlay: DeepPartial<T>): T {
   return result as T;
 }
 
-// 言語×モードの組み合わせは少ないので、マージ結果はモジュールスコープでキャッシュする
-const mergedCache = new Map<Language, TranslationData>();
-
+// derived は言語/モードが変わったときだけ再計算し、結果も derived 側でメモ化される。
+// deepMerge はオーバーレイのキー数（数十）を走査するだけの軽処理なので、
+// 切替のたびに毎回マージして問題ない（キャッシュは不要）。
 function resolveTranslation(lang: Language, mode: TermMode): TranslationData {
   if (mode === 'standard') return translations[lang];
-  let merged = mergedCache.get(lang);
-  if (!merged) {
-    merged = deepMerge(translations[lang], simpleOverlays[lang]);
-    mergedCache.set(lang, merged);
-  }
-  return merged;
+  return deepMerge(translations[lang], simpleOverlays[lang]);
 }
 
 // 現在の言語と用語表示モードに基づいた翻訳データを提供するストア

--- a/examples/svelte-app/src/i18n/translations.ts
+++ b/examples/svelte-app/src/i18n/translations.ts
@@ -4,6 +4,14 @@
  * 型定義・各言語データは肥大化したため `translations/` 配下へ分割した。
  * このファイルは互換性のためのバレル（再エクスポート）で、import パスは従来どおり。
  */
-export type { I18nStore, Language, TranslationData } from './translations/types.js';
+export type {
+  DeepPartial,
+  I18nStore,
+  Language,
+  TermMode,
+  TranslationData,
+} from './translations/types.js';
 export { ja } from './translations/ja.js';
 export { en } from './translations/en.js';
+export { simpleJa } from './translations/simple-ja.js';
+export { simpleEn } from './translations/simple-en.js';

--- a/examples/svelte-app/src/i18n/translations/en.ts
+++ b/examples/svelte-app/src/i18n/translations/en.ts
@@ -120,6 +120,13 @@ export const en: TranslationData = {
       englishLabel: 'English',
       changed: 'Language changed',
     },
+    termMode: {
+      title: 'Terminology',
+      selectMode: 'Choose the wording used in the app:',
+      simpleLabel: 'Simple (plain words)',
+      standardLabel: 'Standard (Nostr terms)',
+      changed: 'Terminology changed',
+    },
     theme: {
       title: 'Theme Settings',
       description: 'Change the appearance of the application.',

--- a/examples/svelte-app/src/i18n/translations/en.ts
+++ b/examples/svelte-app/src/i18n/translations/en.ts
@@ -121,11 +121,11 @@ export const en: TranslationData = {
       changed: 'Language changed',
     },
     termMode: {
-      title: 'Terminology',
-      selectMode: 'Choose the wording used in the app:',
-      simpleLabel: 'Simple (plain words)',
-      standardLabel: 'Standard (Nostr terms)',
-      changed: 'Terminology changed',
+      title: 'Mode',
+      selectMode: 'Select mode:',
+      simpleLabel: 'Simple',
+      standardLabel: 'Technical',
+      changed: 'Mode changed',
     },
     theme: {
       title: 'Theme Settings',

--- a/examples/svelte-app/src/i18n/translations/ja.ts
+++ b/examples/svelte-app/src/i18n/translations/ja.ts
@@ -120,6 +120,13 @@ export const ja: TranslationData = {
       englishLabel: '英語 (English)',
       changed: '言語を変更しました',
     },
+    termMode: {
+      title: '用語の表示',
+      selectMode: 'アプリ内で使う用語を選択:',
+      simpleLabel: 'シンプル（わかりやすい用語）',
+      standardLabel: '標準（Nostr の用語）',
+      changed: '用語の表示を変更しました',
+    },
     theme: {
       title: 'テーマ設定',
       description: 'アプリケーションの外観を変更できます。',

--- a/examples/svelte-app/src/i18n/translations/ja.ts
+++ b/examples/svelte-app/src/i18n/translations/ja.ts
@@ -121,11 +121,11 @@ export const ja: TranslationData = {
       changed: '言語を変更しました',
     },
     termMode: {
-      title: '用語の表示',
-      selectMode: 'アプリ内で使う用語を選択:',
-      simpleLabel: 'シンプル（わかりやすい用語）',
-      standardLabel: '標準（Nostr の用語）',
-      changed: '用語の表示を変更しました',
+      title: 'モード',
+      selectMode: 'モードを選択:',
+      simpleLabel: 'シンプル',
+      standardLabel: 'テクニカル',
+      changed: 'モードを変更しました',
     },
     theme: {
       title: 'テーマ設定',

--- a/examples/svelte-app/src/i18n/translations/simple-en.ts
+++ b/examples/svelte-app/src/i18n/translations/simple-en.ts
@@ -26,7 +26,7 @@ export const simpleEn: DeepPartial<TranslationData> = {
     exportSecretKey: 'Export Recovery Key',
     exportSecretKeyWarning:
       'Warning: Never share your recovery key with anyone. Anyone with your recovery key can fully control your account.',
-    showExportSection: 'Export',
+    showExportSection: 'Show Export',
     hideExportSection: 'Hide Export',
     exportWarningFinal:
       'Final Warning: Sharing this recovery key can lead to your account being compromised. Use only for backup purposes.',

--- a/examples/svelte-app/src/i18n/translations/simple-en.ts
+++ b/examples/svelte-app/src/i18n/translations/simple-en.ts
@@ -1,0 +1,118 @@
+import type { DeepPartial, TranslationData } from './types.js';
+
+// Simple mode (English): partial overlay that replaces Nostr jargon
+// (public key, secret key, nsec, relay, sign, NIP, ...) with plain wording.
+// Keys not defined here fall back to the standard strings in en.ts.
+export const simpleEn: DeepPartial<TranslationData> = {
+  common: {
+    errorMessages: {
+      importNsec: 'Account Transfer Error:',
+    },
+  },
+  auth: {
+    methodImport: 'Bring your existing account (Beta)',
+    nsecLabel: 'Recovery key',
+    nsecTip:
+      'Enter the recovery key (a string starting with nsec1...) from another Nostr app to use that account here. The key is encrypted with your passkey and stored safely.',
+    invalidNsec: 'Invalid recovery key. Please enter a string starting with "nsec1...".',
+  },
+  nostr: {
+    publicKey: 'User ID',
+  },
+  key: {
+    title: 'Backup',
+  },
+  settings: {
+    exportSecretKey: 'Export Recovery Key',
+    exportSecretKeyWarning:
+      'Warning: Never share your recovery key with anyone. Anyone with your recovery key can fully control your account.',
+    showExportSection: 'Export Recovery Key (Dangerous)',
+    exportWarningFinal:
+      'Final Warning: Sharing this recovery key can lead to your account being compromised. Use only for backup purposes.',
+    confirmExport: 'Export Recovery Key',
+    yourSecretKey: 'Your Recovery Key:',
+    noKeyToExport: 'No recovery key to export. Please check your login status.',
+    localStorage: {
+      title: 'Data on This Device',
+      cleared: 'Data on this device cleared',
+    },
+    cacheSettings: {
+      title: 'Re-authentication Interval',
+      description:
+        'Remember your authentication for a while so you can skip re-authenticating on every operation. Longer durations increase the risk of unauthorized use of your account.',
+      enabled: 'Remember authentication for a while',
+      disabled: 'Authenticate every time',
+      timeoutLabel: 'Remember for (seconds)',
+      clearTitle: 'Forget Remembered Authentication',
+      clearDescription:
+        'Forget the remembered authentication. You will need to re-authenticate on the next operation.',
+      clearButton: 'Forget Now',
+      clearSuccess: 'Remembered authentication has been cleared.',
+      clearError: 'Failed to clear remembered authentication.',
+    },
+    relays: {
+      title: 'Servers',
+      description: 'The servers this account connects to. Connected apps read this list.',
+      empty: 'No servers configured.',
+    },
+    consentPolicy: {
+      methodLabel: {
+        connect: 'Site connection (read user ID & servers)',
+        signEvent: 'Approve posts',
+        nip44: 'Message encryption (standard)',
+        nip04: 'Message encryption (legacy)',
+      },
+      decryptTip:
+        'For safety, reading (decrypting) messages always prompts even when set to "Always allow". "Always allow" applies only to other operations.',
+    },
+    exportKeyInfo: {
+      title: 'Account Backup',
+      description:
+        'Back up your account to use it on another device or restore it if your browser data is erased.',
+      warning:
+        'Warning: Losing this backup may result in loss of access to your account. Store it in a safe place.',
+      showExportSection: 'Create Backup',
+      restoreWarning:
+        'This backup file can be used for recovery when you cannot login with the same passkey and the same username.',
+      exportButton: 'Create Backup',
+      backupData: 'Backup Data:',
+      noCurrentKeyInfo: 'Current account data not found. Please check your login status.',
+    },
+    import: {
+      title: 'Restore from Backup',
+      description: 'Use a previously created backup file or data to login.',
+      fileSelect: '📁Select Backup File',
+      dataInput: 'Enter Backup Data',
+      dataPlaceholder: 'Paste your backup data here',
+      loginButton: 'Login with Backup Data',
+    },
+  },
+  navigation: {
+    key: 'Backup',
+  },
+  consent: {
+    title: 'Request from this site',
+    connectDescription: 'This site will be able to read your user ID and server settings.',
+    eventKind: 'Type of content',
+    method: 'Request type',
+    methodLabel: {
+      getPublicKey: 'Read user ID',
+      getRelays: 'Read server list',
+      signEvent: 'Approve post',
+      nip44Encrypt: 'Encrypt message',
+      nip44Decrypt: 'Read message (decrypt)',
+      nip04Encrypt: 'Encrypt message (legacy)',
+      nip04Decrypt: 'Read message (legacy)',
+    },
+    peerPubkey: "Peer's user ID",
+    showRaw: 'Show technical details',
+    kindLabel: {
+      metadata: 'Profile',
+      textNote: 'Post',
+      legacyDm: 'Direct message (legacy)',
+      rumor: 'Private message (internal)',
+      seal: 'Private message (internal)',
+      giftWrap: 'Private message (internal)',
+    },
+  },
+};

--- a/examples/svelte-app/src/i18n/translations/simple-en.ts
+++ b/examples/svelte-app/src/i18n/translations/simple-en.ts
@@ -27,6 +27,7 @@ export const simpleEn: DeepPartial<TranslationData> = {
     exportSecretKeyWarning:
       'Warning: Never share your recovery key with anyone. Anyone with your recovery key can fully control your account.',
     showExportSection: 'Export Recovery Key (Dangerous)',
+    hideExportSection: 'Hide Export',
     exportWarningFinal:
       'Final Warning: Sharing this recovery key can lead to your account being compromised. Use only for backup purposes.',
     confirmExport: 'Export Recovery Key',
@@ -72,6 +73,7 @@ export const simpleEn: DeepPartial<TranslationData> = {
       warning:
         'Warning: Losing this backup may result in loss of access to your account. Store it in a safe place.',
       showExportSection: 'Create Backup',
+      hideExportSection: 'Hide Backup',
       restoreWarning:
         'This backup file can be used for recovery when you cannot login with the same passkey and the same username.',
       exportButton: 'Create Backup',
@@ -92,9 +94,14 @@ export const simpleEn: DeepPartial<TranslationData> = {
   },
   consent: {
     title: 'Request from this site',
+    titleConnect: 'Connection request from this site',
+    titleEncrypt: 'Message encryption request',
+    titleDecrypt: 'Read message request',
     connectDescription: 'This site will be able to read your user ID and server settings.',
     eventKind: 'Type of content',
     method: 'Request type',
+    plaintext: 'Message content',
+    decryptNoPreview: 'The message content can only be seen after it is read.',
     methodLabel: {
       getPublicKey: 'Read user ID',
       getRelays: 'Read server list',
@@ -113,6 +120,7 @@ export const simpleEn: DeepPartial<TranslationData> = {
       rumor: 'Private message (internal)',
       seal: 'Private message (internal)',
       giftWrap: 'Private message (internal)',
+      unknown: 'Other content',
     },
   },
 };

--- a/examples/svelte-app/src/i18n/translations/simple-en.ts
+++ b/examples/svelte-app/src/i18n/translations/simple-en.ts
@@ -26,11 +26,11 @@ export const simpleEn: DeepPartial<TranslationData> = {
     exportSecretKey: 'Export Recovery Key',
     exportSecretKeyWarning:
       'Warning: Never share your recovery key with anyone. Anyone with your recovery key can fully control your account.',
-    showExportSection: 'Export Recovery Key (Dangerous)',
+    showExportSection: 'Export',
     hideExportSection: 'Hide Export',
     exportWarningFinal:
       'Final Warning: Sharing this recovery key can lead to your account being compromised. Use only for backup purposes.',
-    confirmExport: 'Export Recovery Key',
+    confirmExport: 'Export',
     yourSecretKey: 'Your Recovery Key:',
     noKeyToExport: 'No recovery key to export. Please check your login status.',
     localStorage: {

--- a/examples/svelte-app/src/i18n/translations/simple-ja.ts
+++ b/examples/svelte-app/src/i18n/translations/simple-ja.ts
@@ -28,6 +28,7 @@ export const simpleJa: DeepPartial<TranslationData> = {
     exportSecretKeyWarning:
       '警告：リカバリーキーは誰とも共有しないでください。リカバリーキーを持つ人はあなたのアカウントを完全に制御できます。',
     showExportSection: 'リカバリーキーをエクスポート（危険）',
+    hideExportSection: 'エクスポートを隠す',
     exportWarningFinal:
       '最終警告：このリカバリーキーを共有すると、あなたのアカウントが乗っ取られる可能性があります。必ずバックアップ目的でのみ使用してください。',
     confirmExport: 'リカバリーキーをエクスポートする',
@@ -73,6 +74,7 @@ export const simpleJa: DeepPartial<TranslationData> = {
       warning:
         '注意: このバックアップを紛失するとアカウントへのアクセスができなくなる場合があります。安全な場所に保管してください。',
       showExportSection: 'バックアップを作成',
+      hideExportSection: 'バックアップの作成を隠す',
       restoreWarning:
         'このバックアップファイルは、同じパスキーと同じユーザー名でログインできない場合の復元に使用できます。',
       exportButton: 'バックアップを作成',
@@ -93,10 +95,15 @@ export const simpleJa: DeepPartial<TranslationData> = {
   },
   consent: {
     title: 'このサイトからのリクエスト',
+    titleConnect: 'このサイトからの接続リクエスト',
+    titleEncrypt: 'メッセージの暗号化リクエスト',
+    titleDecrypt: 'メッセージを読むリクエスト',
     connectDescription:
       'このサイトはあなたのユーザーIDと接続先サーバーの設定を読み取れるようになります。',
     eventKind: '内容の種類',
     method: 'リクエストの種類',
+    plaintext: 'メッセージの内容',
+    decryptNoPreview: 'メッセージの内容は読み込んだ後にしか確認できません。',
     methodLabel: {
       getPublicKey: 'ユーザーIDの取得',
       getRelays: '接続先サーバーの読み取り',
@@ -115,6 +122,7 @@ export const simpleJa: DeepPartial<TranslationData> = {
       rumor: '非公開メッセージ（内部データ）',
       seal: '非公開メッセージ（内部データ）',
       giftWrap: '非公開メッセージ（内部データ）',
+      unknown: 'その他の内容',
     },
   },
 };

--- a/examples/svelte-app/src/i18n/translations/simple-ja.ts
+++ b/examples/svelte-app/src/i18n/translations/simple-ja.ts
@@ -27,7 +27,7 @@ export const simpleJa: DeepPartial<TranslationData> = {
     exportSecretKey: 'リカバリーキーのエクスポート',
     exportSecretKeyWarning:
       '警告：リカバリーキーは誰とも共有しないでください。リカバリーキーを持つ人はあなたのアカウントを完全に制御できます。',
-    showExportSection: 'エクスポート',
+    showExportSection: 'エクスポートを表示',
     hideExportSection: 'エクスポートを隠す',
     exportWarningFinal:
       '最終警告：このリカバリーキーを共有すると、あなたのアカウントが乗っ取られる可能性があります。必ずバックアップ目的でのみ使用してください。',

--- a/examples/svelte-app/src/i18n/translations/simple-ja.ts
+++ b/examples/svelte-app/src/i18n/translations/simple-ja.ts
@@ -27,11 +27,11 @@ export const simpleJa: DeepPartial<TranslationData> = {
     exportSecretKey: 'リカバリーキーのエクスポート',
     exportSecretKeyWarning:
       '警告：リカバリーキーは誰とも共有しないでください。リカバリーキーを持つ人はあなたのアカウントを完全に制御できます。',
-    showExportSection: 'リカバリーキーをエクスポート（危険）',
+    showExportSection: 'エクスポート',
     hideExportSection: 'エクスポートを隠す',
     exportWarningFinal:
       '最終警告：このリカバリーキーを共有すると、あなたのアカウントが乗っ取られる可能性があります。必ずバックアップ目的でのみ使用してください。',
-    confirmExport: 'リカバリーキーをエクスポートする',
+    confirmExport: 'エクスポートする',
     yourSecretKey: 'あなたのリカバリーキー：',
     noKeyToExport: 'エクスポートするリカバリーキーがありません。ログイン状態を確認してください。',
     localStorage: {

--- a/examples/svelte-app/src/i18n/translations/simple-ja.ts
+++ b/examples/svelte-app/src/i18n/translations/simple-ja.ts
@@ -1,0 +1,120 @@
+import type { DeepPartial, TranslationData } from './types.js';
+
+// シンプルモード（日本語）: Nostr の専門用語（公開鍵・秘密鍵・nsec・リレー・署名・NIP など）を
+// 一般ユーザー向けの表現に置き換える部分オーバーレイ。
+// ここに定義のないキーは ja.ts の標準文言にフォールバックする。
+export const simpleJa: DeepPartial<TranslationData> = {
+  common: {
+    errorMessages: {
+      importNsec: 'アカウント引き継ぎエラー:',
+    },
+  },
+  auth: {
+    methodImport: '既存アカウントを引き継ぐ（ベータ版）',
+    nsecLabel: 'リカバリーキー',
+    nsecTip:
+      '別の Nostr アプリで使っていたリカバリーキー（nsec1... で始まる文字列）を入力すると、そのアカウントをこのアプリで使えます。キーはパスキーで暗号化されて安全に保存されます。',
+    invalidNsec:
+      'リカバリーキーの形式が正しくありません。"nsec1..." で始まる文字列を入力してください。',
+  },
+  nostr: {
+    publicKey: 'ユーザーID',
+  },
+  key: {
+    title: 'バックアップ',
+  },
+  settings: {
+    exportSecretKey: 'リカバリーキーのエクスポート',
+    exportSecretKeyWarning:
+      '警告：リカバリーキーは誰とも共有しないでください。リカバリーキーを持つ人はあなたのアカウントを完全に制御できます。',
+    showExportSection: 'リカバリーキーをエクスポート（危険）',
+    exportWarningFinal:
+      '最終警告：このリカバリーキーを共有すると、あなたのアカウントが乗っ取られる可能性があります。必ずバックアップ目的でのみ使用してください。',
+    confirmExport: 'リカバリーキーをエクスポートする',
+    yourSecretKey: 'あなたのリカバリーキー：',
+    noKeyToExport: 'エクスポートするリカバリーキーがありません。ログイン状態を確認してください。',
+    localStorage: {
+      title: 'この端末に保存されたデータ',
+      cleared: 'この端末に保存されたデータをクリアしました',
+    },
+    cacheSettings: {
+      title: '再認証の間隔',
+      description:
+        '認証を一定時間記憶して、操作のたびの再認証をスキップできます。記憶する時間を長くすると、その分アカウントを不正利用されるリスクが高まります。',
+      enabled: '認証を一定時間記憶する',
+      disabled: '毎回認証する',
+      timeoutLabel: '記憶する時間（秒）',
+      clearTitle: '記憶した認証のクリア',
+      clearDescription: '記憶している認証をクリアします。次回の操作時に再認証が必要になります。',
+      clearButton: '認証をクリア',
+      clearSuccess: '記憶した認証をクリアしました。',
+      clearError: '認証のクリアに失敗しました。',
+    },
+    relays: {
+      title: '接続先サーバー',
+      description:
+        'このアカウントが使う接続先サーバーの一覧です。連携するアプリがこの一覧を参照します。',
+      empty: '接続先サーバーが登録されていません。',
+    },
+    consentPolicy: {
+      methodLabel: {
+        connect: 'サイト接続（ユーザーID・接続先サーバーの読み取り）',
+        signEvent: '投稿の承認',
+        nip44: 'メッセージの暗号化（標準方式）',
+        nip04: 'メッセージの暗号化（旧方式）',
+      },
+      decryptTip:
+        '安全のため、メッセージを読む（復号する）操作は「常に許可」にしても毎回確認します。「常に許可」はそれ以外の操作にのみ適用されます。',
+    },
+    exportKeyInfo: {
+      title: 'アカウントのバックアップ',
+      description:
+        'アカウントをバックアップして別のデバイスで利用したり、ブラウザデータが消去された場合に復元することができます。',
+      warning:
+        '注意: このバックアップを紛失するとアカウントへのアクセスができなくなる場合があります。安全な場所に保管してください。',
+      showExportSection: 'バックアップを作成',
+      restoreWarning:
+        'このバックアップファイルは、同じパスキーと同じユーザー名でログインできない場合の復元に使用できます。',
+      exportButton: 'バックアップを作成',
+      backupData: 'バックアップデータ:',
+      noCurrentKeyInfo: '現在のアカウント情報が見つかりません。ログイン状態を確認してください。',
+    },
+    import: {
+      title: 'バックアップから復元',
+      description: '以前に作成したバックアップファイルまたはデータを使用してログインします。',
+      fileSelect: '📁バックアップファイルを選択',
+      dataInput: 'バックアップデータを入力',
+      dataPlaceholder: 'バックアップデータをここに貼り付けてください',
+      loginButton: 'バックアップデータでログイン',
+    },
+  },
+  navigation: {
+    key: 'バックアップ',
+  },
+  consent: {
+    title: 'このサイトからのリクエスト',
+    connectDescription:
+      'このサイトはあなたのユーザーIDと接続先サーバーの設定を読み取れるようになります。',
+    eventKind: '内容の種類',
+    method: 'リクエストの種類',
+    methodLabel: {
+      getPublicKey: 'ユーザーIDの取得',
+      getRelays: '接続先サーバーの読み取り',
+      signEvent: '投稿の承認',
+      nip44Encrypt: 'メッセージを暗号化',
+      nip44Decrypt: 'メッセージを読む（復号）',
+      nip04Encrypt: 'メッセージを暗号化（旧方式）',
+      nip04Decrypt: 'メッセージを読む（旧方式）',
+    },
+    peerPubkey: '相手のユーザーID',
+    showRaw: '技術的な詳細を表示',
+    kindLabel: {
+      metadata: 'プロフィール',
+      textNote: '投稿',
+      legacyDm: 'ダイレクトメッセージ（旧方式）',
+      rumor: '非公開メッセージ（内部データ）',
+      seal: '非公開メッセージ（内部データ）',
+      giftWrap: '非公開メッセージ（内部データ）',
+    },
+  },
+};

--- a/examples/svelte-app/src/i18n/translations/types.ts
+++ b/examples/svelte-app/src/i18n/translations/types.ts
@@ -5,6 +5,14 @@
 // 言語タイプの定義
 export type Language = 'ja' | 'en';
 
+// 用語表示モード。simple は Nostr の専門用語を一般ユーザー向けの表現に置き換える。
+export type TermMode = 'simple' | 'standard';
+
+// シンプルモード用の部分オーバーレイ型。未定義のキーは標準文言にフォールバックする。
+export type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
+};
+
 // 翻訳データの型定義
 export interface TranslationData {
   common: {
@@ -128,6 +136,13 @@ export interface TranslationData {
       selectLanguage: string;
       japaneseLabel: string;
       englishLabel: string;
+      changed: string;
+    };
+    termMode: {
+      title: string;
+      selectMode: string;
+      simpleLabel: string;
+      standardLabel: string;
       changed: string;
     };
     theme: {
@@ -272,5 +287,6 @@ export interface TranslationData {
 // 言語ストアの型定義
 export interface I18nStore {
   currentLanguage: Language;
+  termMode: TermMode;
   t: TranslationData;
 }


### PR DESCRIPTION
## 概要 / Overview

**JA:** サンプルアプリ（`examples/svelte-app`）に「用語シンプルモード」を追加します。Nostr 独自の専門用語（公開鍵・秘密鍵・nsec/npub・リレー・署名・NIP-44/04 など）を一般ユーザー向けの平易な表現に置き換え、**デフォルトで有効**にします。設定画面の新しいトグルで従来の標準表記に戻せます。

**EN:** Adds a "simple terminology mode" to the sample app (`examples/svelte-app`). It replaces Nostr-specific jargon (public/secret key, nsec/npub, relay, sign event, NIP-44/04, etc.) with plain wording for general users, and is **enabled by default**. A new toggle in Settings switches back to the standard terms.

## 用語の置き換え / Terminology mapping

| 標準 / Standard | シンプル (JA) | Simple (EN) |
|---|---|---|
| 公開鍵 / Public key | ユーザーID | User ID |
| 秘密鍵・nsec / Secret key・nsec | リカバリーキー | Recovery key |
| リレー / Relay | 接続先サーバー | Servers |
| イベント署名 / Sign event | 投稿の承認 | Approve post |
| イベント種別 / Event kind | 内容の種類 | Type of content |
| NIP-44 / NIP-04 | 標準方式 / 旧方式 | standard / legacy |
| 鍵管理・鍵情報 / Key management・KeyInfo | バックアップ | Backup |
| シークレットキャッシュ / Secret cache | 再認証の間隔 | Re-authentication interval |
| ローカルストレージ / Local storage | この端末に保存されたデータ | Data on this device |

**JA:** npub / nsec の文字列データ自体は他アプリへの持ち出し用に表示を維持しています。
**EN:** The npub / nsec strings themselves are still shown, since they are needed to carry the account to other apps.

## 実装 / Implementation

**JA:** `DeepPartial` オーバーレイ + deep merge 方式です。`simple-ja.ts` / `simple-en.ts` に置き換え対象キーだけを定義し、未定義キーは標準文言へ自動フォールバックします。選択は `localStorage`（`nosskey_term_mode`）に永続化し、未保存時は `simple` が既定です。

**EN:** Implemented as a `DeepPartial` overlay merged over the standard translations. `simple-ja.ts` / `simple-en.ts` define only the overridden keys; any key not overridden falls back to the original wording. The choice persists in `localStorage` (`nosskey_term_mode`), defaulting to `simple`.

### 変更ファイル / Changed files
- 新規 / New: `i18n/translations/simple-ja.ts`, `simple-en.ts`, `components/settings/TermModeSettings.svelte`, `i18n/i18n-store.spec.ts`
- 変更 / Changed: `i18n/translations/types.ts`, `translations.ts`, `i18n-store.ts`, `ja.ts` / `en.ts`（トグル文言のみ / toggle labels only）, `components/screens/SettingsScreen.svelte`

## 検証 / Verification

**JA:** `format:check` / `build` / `test:coverage`（220 passed）/ `check -w svelte-app`（0 errors）すべてグリーン。PC・モバイル両 viewport の実画で日英とも用語反映・レイアウト崩れなしを確認。

**EN:** `format:check` / `build` / `test:coverage` (220 passed) / `check -w svelte-app` (0 errors) all green. Verified on both PC and mobile viewports that terms render correctly in JA/EN with no layout breakage.
