### PR TITLE
fix(deps): bump nanoid and postcss to resolve npm audit failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    open-pull-requests-limit: 5
     groups:
       github-actions:
         update-types: ["minor", "patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,38 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Dependabot version updates
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# npm workspaces はルートの package-lock.json が単一の依存グラフを持つため、
+# directory は "/" のみで packages/* と examples/* の両方を対象にできる。
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    # minor / patch はまとめて 1 PR にし、PR 数の増加を抑える。
+    # major は個別 PR となり、破壊的変更を単独でレビューできる。
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      development-dependencies:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "fix"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "fix"
+      include: "scope"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,11 +24,14 @@ jobs:
         with:
           node-version: '22'
 
-      # 本番依存は配布物に含まれるため、深刻度を問わず失敗させる
+      # SDK の本番依存は深刻度を問わず失敗させる
       - name: Audit production dependencies
         run: npm audit --omit=dev
 
-      # 開発依存はビルドツール由来のトランジティブが大半のため high 以上のみ失敗させる
+      # 開発依存を含む全体。svelte のように devDependencies でありながら
+      # バンドルへ展開されて配信されるものがあるため、閾値は moderate までとし、
+      # ビルドツール由来の low なトランジティブのみを許容する。
       # (--audit-level は終了コードのみを制御し、レポート自体は全件出力される)
-      - name: Audit all dependencies (high and above)
-        run: npm audit --audit-level=high
+      - name: Audit all dependencies (moderate and above)
+        if: always()
+        run: npm audit --audit-level=moderate

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,6 +13,8 @@ jobs:
   audit:
     name: npm audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,5 +24,11 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Audit dependencies
-        run: npm audit
+      # 本番依存は配布物に含まれるため、深刻度を問わず失敗させる
+      - name: Audit production dependencies
+        run: npm audit --omit=dev
+
+      # 開発依存はビルドツール由来のトランジティブが大半のため high 以上のみ失敗させる
+      # (--audit-level は終了コードのみを制御し、レポート自体は全件出力される)
+      - name: Audit all dependencies (high and above)
+        run: npm audit --audit-level=high

--- a/package-lock.json
+++ b/package-lock.json
@@ -2676,9 +2676,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2786,9 +2786,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2806,7 +2806,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## 概要 / Summary

Audit ワークフローが high severity 2 件で失敗していた問題を解消し、再発防止策を追加した。

Fixes the failing Audit workflow (2 high-severity `npm audit` findings) and adds recurrence-prevention measures.

## 変更内容 / Changes

**依存関係の更新 / Dependency bump** (`package-lock.json`)
- nanoid 3.3.12 → 3.3.18 ([GHSA-28wg-ghj8-5hjv](https://github.com/advisories/GHSA-28wg-ghj8-5hjv), [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8))
- postcss 8.5.15 → 8.5.26 ([GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp), [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849))
- いずれも tsup / vite 経由の dev トランジティブ依存。semver 範囲内のパッチ更新のみで `package.json` の変更は不要。
- Both are dev-only transitive deps pulled in via tsup/vite; patch-level bumps within their declared semver ranges, no `package.json` changes needed.

**再発防止 / Recurrence prevention** (`.github/dependabot.yml`, `.github/workflows/audit.yml`)
- `dependabot.yml` の `package-ecosystem` が空文字のままで version updates が一度も動作していなかったため、`npm` と `github-actions` の 2 エコシステムを設定。minor/patch は production/development ごとにグループ化して PR 数を抑制。
- `dependabot.yml` had `package-ecosystem: ""` (unfilled template) — Dependabot version updates had never actually run. Now configured for `npm` and `github-actions`, with minor/patch grouped by production/development to limit PR volume.
- `audit.yml` を本番依存（`--omit=dev`、深刻度問わず失敗）と全体（`--audit-level=moderate`）の 2 ステップに分割。全体側は `moderate` 以上のみ失敗とし、ビルドツール由来の low なトランジティブは許容する一方、devDependencies でもバンドルへ展開されて配信される svelte 等（`examples/svelte-app`）を見逃さないよう `high` ではなく `moderate` を採用。1 段目が失敗しても dev 側のレポートが得られるよう 2 段目に `if: always()` を付与。
- `audit.yml` now splits into two steps: production deps (`--omit=dev`, fails on any severity) and the full tree (`--audit-level=moderate`). `moderate` (not `high`) was chosen because devDependencies like `svelte` in `examples/svelte-app` get bundled into the shipped app despite being dev-only, so a `high`-only threshold would miss moderate-severity issues in code that actually ships. Step 2 uses `if: always()` so the dev-tree report still runs even if step 1 fails.

## 検証 / Verification

- `npm audit` → 0 vulnerabilities
- `npm run format:check` / `npm run build` / `npm run test:coverage`（811 tests）/ `npm run check -w svelte-app` → すべて成功 / all passing
- 修正前の lockfile を隔離環境で再現し、新ポリシー（`--audit-level=moderate`）が今回の high 2 件を検出することを確認 / Reproduced the pre-fix lockfile in an isolated environment and confirmed the new `--audit-level=moderate` policy still catches the original 2 high-severity findings
- PR 上の CI（npm audit / SDK Test,Lint,Build / Sample App Check,Build / dependabot.yml バリデーション）はすべて green

## 対応していない項目 / Out of scope

- `package.json` の `overrides`（esbuild / ws）は manifest に直接依存として現れないため Dependabot の対象外で死角のまま。別途見直しが必要。
- Dependabot の security updates（トランジティブ依存への直接 PR）はリポジトリ設定側の機能で、`dependabot.yml` からは有効化できない。Settings > Code security での確認が必要。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Czrhd6gJ7qYiFeBm3VG5L8